### PR TITLE
fix(futebol): elimina look-ahead das premissas do Motor de Score (Task 0)

### DIFF
--- a/dbt_futebol/models/intermediate/_int_futebol__models.yml
+++ b/dbt_futebol/models/intermediate/_int_futebol__models.yml
@@ -114,6 +114,57 @@ models:
               - outcome_side
               - line_value
 
+  - name: int_futebol_team_form_pit
+    description: >
+      Correção da Task 0 (look-ahead) — forma e tabela POINT-IN-TIME por (fixture_id, team_id):
+      tudo calculado só com jogos FINALIZADOS da mesma competição/season e kickoff ANTERIOR ao do
+      jogo-alvo. Substitui as duas fontes contaminadas dos 5 modelos de premissas: (A)
+      fact_team_season_stats, que tem 1 snapshot por (time, liga, season) e em 2024/2025 é a
+      temporada FECHADA aplicada à rodada 1 (played_total=38, ~51% de cada média sendo futuro,
+      100% dos jogos com o próprio resultado dentro da média); e (B2) o standings_latest
+      (MAX(snapshot_date) sem âncora no kickoff), cujo histórico só começa em 11/06/2026.
+      Reconstrói do fact_fixtures as mesmas colunas consumidas (gols pró/contra casa/fora/total,
+      clean sheet, failed to score, played/wins/draws) mais a tabela do campeonato no instante do
+      jogo (rank/points/ppg/n_wins_last5/n_teams). O rank sai DENTRO do grupo (group_name das
+      standings = estrutura do sorteio, conhecida antes dos jogos): pontos corridos = rank global
+      1-20 (ou 1-36 na fase de liga da Champions); Libertadores/Sudamericana/Copa do Mundo = rank
+      por grupo, igual à API; Copa do Brasil não tem standings -> rank NULL, como já era.
+      Validado contra a tabela real da API (Brasileirão 2026): 56/63 pontos e 55/63 ranks exatos,
+      erro médio de 0,27 posição — as diferenças são o snapshot diário estar defasado do kickoff.
+      Em jogos FUTUROS o resultado é ~idêntico ao antigo (diferença média de 0,003 gol/jogo), ou
+      seja, a correção muda o backtest e não mexe em produção.
+    columns:
+      - name: fixture_id
+        tests: [not_null]
+      - name: team_id
+        tests: [not_null]
+      - name: played_total
+        description: "Jogos do time na competição/season ANTES do kickoff. 0 na estreia -> médias NULL -> premissa FALSE. Exposto p/ a recalibragem poder decidir um piso de amostra."
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: rank
+        description: "Posição na tabela (dentro do grupo) no instante do jogo. NULL sem standings (Copa do Brasil) ou antes da estreia."
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                inclusive: true
+      - name: ppg
+        description: "Pontos por jogo até o kickoff. NULL com played_total=0."
+      - name: n_wins_last5
+        description: "Vitórias nos 5 jogos anteriores ao kickoff. Substitui o parse de standings.form."
+        tests: [not_null]
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - fixture_id
+              - team_id
+
   - name: int_futebol_player_importance
     description: >
       S7 — proxy de IMPORTÂNCIA de jogador (minutos x titularidade) p/ pesar desfalques no
@@ -148,10 +199,17 @@ models:
     description: >
       S7 — desfalques por (fixture, time, jogador) com TIPO (Missing Fixture/Questionable) +
       flag is_important. Artefato do aceite ("lista por time com tipo fora/dúvida e flag
-      titular sim/não"). Snapshot mais recente por fixture; 1 linha por (fixture, team, player)
-      preferindo Missing Fixture a Questionable (guard de double-count poll x season-log);
-      join ao proxy por (player_id, competition_id = league_id) — por player+competição (lida
-      com transferências). is_important COALESCE FALSE (degradação graciosa). Consumido por
+      titular sim/não"). ⚠️ Correção da Task 0: (D) só entram snapshots COLETADOS ANTES DO APITO
+      (extracted_at < kickoff_utc) — o log de /injuries da API é retroativo e 99,6% das ~174 mil
+      linhas foram coletadas depois do jogo, inclusive de quem se machucou DURANTE a partida;
+      essa assimetria (dado no backtest, ausente em produção) era o vazamento. Usa extracted_at
+      e não snapshot_date porque o poll pré-jogo roda de hora em hora e no dia do jogo há coleta
+      antes E depois do apito. Efeito: a premissa vai a FALSE em quase todo jogo passado e fica
+      intacta p/ jogos futuros. (E) is_important virou POINT-IN-TIME (minutos/titularidades
+      acumulados ANTES do kickoff, via window function sobre fact_fixture_player_stats), no lugar
+      do pool de todas as seasons; is_important_pooled fica exposto p/ comparação. Dentro da
+      janela pré-jogo, 1 linha por (fixture, team, player) preferindo Missing Fixture a
+      Questionable (guard de double-count poll x season-log). Consumido por
       int_futebol_premissas_1x2 (só Missing Fixture AND is_important dispara). Só Brasileirão.
     columns:
       - name: fixture_id

--- a/dbt_futebol/models/intermediate/int_futebol_desfalques.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_desfalques.sql
@@ -1,19 +1,34 @@
 {{ config(
     materialized='view',
-    description='S7 do Motor de Score — desfalques por (fixture, time, jogador) com TIPO + flag de IMPORTÂNCIA. Artefato do aceite da S7 ("lista de desfalques por time, cada um com tipo fora/dúvida e flag titular sim/não"). Snapshot MAIS RECENTE por fixture (MAX(snapshot_date)) de fact_injuries_snapshot, colapsado a 1 linha por (fixture, team, player) preferindo Missing Fixture a Questionable — resolve a divergência de (type, reason) entre o poll por fixture e o season-log (guard de double-count: + teste de uniqueness). Juntado ao proxy int_futebol_player_importance por (player_id, competition_id = league_id) — join por player+competição (NÃO team_id) lida com transferências entre clubes BR. is_important COALESCE FALSE (degradação graciosa: jogador sem histórico). Consumido por int_futebol_premissas_1x2 (só Missing Fixture AND is_important dispara desfalque). ⚠️ Coverage: só Brasileirão (injuries=TRUE); Copa não gera linhas.'
+    description='S7 do Motor de Score — desfalques por (fixture, time, jogador) com TIPO + flag de IMPORTÂNCIA. Artefato do aceite da S7 ("lista de desfalques por time, cada um com tipo fora/dúvida e flag titular sim/não"). ⚠️ Correção da Task 0 (itens D e E): (D) só entram snapshots COLETADOS ANTES DO APITO (extracted_at < kickoff_utc). O log de lesões da API é RETROATIVO — 99,6% das ~174 mil linhas foram coletadas depois do jogo, inclusive de quem se machucou DURANTE a partida. Sem a âncora, no backtest a premissa enxerga um dado que em produção não existe (a assimetria É o vazamento). Usa extracted_at (timestamp da coleta) e não snapshot_date porque o poll pré-jogo roda de hora em hora: no dia do jogo há coleta antes E depois do apito. Efeito esperado e correto: a premissa vai a FALSE em quase todo jogo passado e fica intacta p/ jogos futuros (todo snapshot de um jogo que ainda não aconteceu é, por construção, pré-jogo). (E) is_important passou a ser POINT-IN-TIME: minutos/titularidades acumulados do jogador ANTES do kickoff, no lugar do pool de todas as seasons. is_important_pooled fica exposto p/ comparação. Dentro da janela pré-jogo, colapsa a 1 linha por (fixture, team, player) preferindo Missing Fixture a Questionable — resolve a divergência de (type, reason) entre o poll por fixture e o season-log (guard de double-count: + teste de uniqueness). Consumido por int_futebol_premissas_1x2 (só Missing Fixture AND is_important dispara desfalque). ⚠️ Coverage: só Brasileirão (injuries=TRUE); Copa não gera linhas.'
 ) }}
 
-WITH inj_latest AS (
+WITH fixtures AS (
+    SELECT fixture_id, kickoff_utc
+    FROM {{ ref('fact_fixtures') }}
+),
+
+-- (D) Janela PRÉ-JOGO: descarta o log retroativo. Sem isto, o backtest lê lesões registradas
+-- depois do apito — inclusive as que aconteceram durante o próprio jogo.
+inj_pregame AS (
     SELECT
-        fixture_id,
-        team_id,
-        player_id,
-        player_name,
-        injury_type,
-        injury_reason,
-        league_id
-    FROM {{ ref('fact_injuries_snapshot') }}
-    -- snapshot mais recente por fixture (o histórico acumula no fato; o desfalque "vigente" é o último).
+        i.fixture_id,
+        i.team_id,
+        i.player_id,
+        i.player_name,
+        i.injury_type,
+        i.injury_reason,
+        i.league_id,
+        i.snapshot_date
+    FROM {{ ref('fact_injuries_snapshot') }} i
+    JOIN fixtures f USING (fixture_id)
+    WHERE i.extracted_at < f.kickoff_utc
+),
+
+inj_latest AS (
+    SELECT * EXCEPT (snapshot_date)
+    FROM inj_pregame
+    -- snapshot mais recente ANTES do apito (o histórico acumula no fato; vale o último pré-jogo).
     QUALIFY snapshot_date = MAX(snapshot_date) OVER (PARTITION BY fixture_id)
 ),
 
@@ -28,15 +43,51 @@ inj_dedup AS (
     ) = 1
 ),
 
-importance AS (
+-- (E) Importância POINT-IN-TIME. Log cumulativo de minutos/titularidades do jogador ATÉ cada
+-- jogo dele; a leitura pega o estado do último jogo ANTERIOR ao kickoff do jogo-alvo. Window
+-- function, sem cross join — o pool de todas as seasons era o resíduo de look-ahead do item E.
+player_log AS (
     SELECT
-        player_id,
-        competition_id,
-        is_important,
-        start_share,
-        total_minutes,
-        avg_rating,
-        games
+        ps.player_id,
+        ps.competition_id,
+        f.kickoff_utc,
+        SUM(ps.minutes)                             OVER w AS cum_minutes,
+        SUM(IF(ps.is_substitute = FALSE, 1, 0))     OVER w AS cum_starts,
+        COUNT(*)                                    OVER w AS cum_games,
+        AVG(ps.rating)                              OVER w AS cum_rating
+    FROM {{ ref('fact_fixture_player_stats') }} ps
+    JOIN fixtures f USING (fixture_id)
+    WINDOW w AS (
+        PARTITION BY ps.player_id, ps.competition_id
+        ORDER BY f.kickoff_utc
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    )
+),
+
+importance_pit AS (
+    SELECT
+        d.fixture_id,
+        d.team_id,
+        d.player_id,
+        pl.cum_minutes,
+        pl.cum_starts,
+        pl.cum_games,
+        pl.cum_rating
+    FROM inj_dedup d
+    JOIN fixtures f ON f.fixture_id = d.fixture_id
+    LEFT JOIN player_log pl
+        ON  pl.player_id      = d.player_id
+        AND pl.competition_id = d.league_id
+        AND pl.kickoff_utc    < f.kickoff_utc
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY d.fixture_id, d.team_id, d.player_id
+        ORDER BY pl.kickoff_utc DESC
+    ) = 1
+),
+
+-- Proxy pooled (todas as seasons), mantido só p/ comparação/front — NÃO alimenta a premissa.
+importance_pooled AS (
+    SELECT player_id, competition_id, is_important
     FROM {{ ref('int_futebol_player_importance') }}
 )
 
@@ -47,13 +98,24 @@ SELECT
     i.player_name,
     i.injury_type,                       -- 'Missing Fixture' (fora) | 'Questionable' (dúvida)
     i.injury_reason,
-    COALESCE(imp.is_important, FALSE)  AS is_important,
-    imp.start_share,
-    imp.total_minutes,
-    imp.avg_rating,
-    COALESCE(imp.games, 0)             AS importance_games,
+
+    -- titular regular ATÉ o jogo (mesmos thresholds do proxy: >=450 min e >=50% de titularidade)
+    COALESCE(
+        p.cum_minutes >= 450 AND SAFE_DIVIDE(p.cum_starts, p.cum_games) >= 0.5,
+        FALSE
+    )                                  AS is_important,
+    COALESCE(pool.is_important, FALSE) AS is_important_pooled,
+
+    SAFE_DIVIDE(p.cum_starts, p.cum_games) AS start_share,
+    p.cum_minutes                      AS total_minutes,
+    p.cum_rating                       AS avg_rating,
+    COALESCE(p.cum_games, 0)           AS importance_games,
     CURRENT_TIMESTAMP() AS dbt_loaded_at
 FROM inj_dedup i
-LEFT JOIN importance imp
-    ON  imp.player_id = i.player_id
-    AND imp.competition_id = i.league_id
+LEFT JOIN importance_pit p
+    ON  p.fixture_id = i.fixture_id
+    AND p.team_id    = i.team_id
+    AND p.player_id  = i.player_id
+LEFT JOIN importance_pooled pool
+    ON  pool.player_id      = i.player_id
+    AND pool.competition_id = i.league_id

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='S1 do Motor de Score — premissas de contexto do mercado RESULTADO (1X2). 3 linhas por fixture (outcome Home/Draw/Away). S = lado apostado, O = adversário. Cada premissa é um booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.1 do épico MOTOR_SCORE_CONFIABILIDADE.md). Penalidades específicas: pick_empate (-10), desfalque_proprio (-15). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/injuries). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities.'
+    description='S1 do Motor de Score — premissas de contexto do mercado RESULTADO (1X2). 3 linhas por fixture (outcome Home/Draw/Away). S = lado apostado, O = adversário. ⚠️ Task 0 (look-ahead): forca_mismatch/mando/superioridade_tabela/forma leem int_futebol_team_form_pit (point-in-time por fixture), NÃO mais fact_team_season_stats + standings_latest — que em 24/25 entregavam a temporada fechada e a tabela final a jogos da rodada 1. Cada premissa é um booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.1 do épico MOTOR_SCORE_CONFIABILIDADE.md). Penalidades específicas: pick_empate (-10), desfalque_proprio (-15). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/injuries). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities.'
 ) }}
 
 WITH fixtures AS (
@@ -25,26 +25,19 @@ outcomes AS (
     FROM fixtures
 ),
 
-tss AS (
+-- Correção da Task 0 (look-ahead): forma E tabela POINT-IN-TIME por (fixture, time), só com
+-- jogos anteriores ao kickoff. Uma única fonte no lugar das duas contaminadas —
+-- fact_team_season_stats (1 snapshot por season: em 24/25 é a temporada FECHADA aplicada à
+-- rodada 1) e standings_latest (MAX(snapshot_date) sem âncora no jogo = tabela final).
+pit AS (
     SELECT
-        team_id, season, competition_id,
+        fixture_id, team_id,
         goals_for_avg_home, goals_for_avg_away,
         goals_against_avg_home, goals_against_avg_away,
         wins_home, draws_home, played_home,
-        wins_away, draws_away, played_away
-    FROM {{ ref('fact_team_season_stats') }}
-),
-
--- 1 linha por (liga, season, time): snapshot mais recente; na Copa evita a linha duplicada
--- "Ranking of third-placed teams" preferindo o grupo principal.
-standings_latest AS (
-    SELECT league_id, season, team_id, rank, points, played_total, form
-    FROM {{ ref('fact_standings_snapshot') }}
-    QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY league_id, season, team_id
-        ORDER BY snapshot_date DESC,
-                 CASE WHEN group_name LIKE '%third-placed%' THEN 1 ELSE 0 END
-    ) = 1
+        wins_away, draws_away, played_away,
+        rank, ppg, n_wins_last5
+    FROM {{ ref('int_futebol_team_form_pit') }}
 ),
 
 -- Spine (fixture-alvo, time) p/ ancorar o xG ao kickoff do jogo (point-in-time).
@@ -131,24 +124,21 @@ metrics AS (
         COALESCE(si.missing_important_count, 0) AS s_missing,
         COALESCE(oi.missing_important_count, 0) AS o_missing,
 
-        -- tabela (superioridade_tabela)
-        ss.rank                                   AS s_rank,
-        os.rank                                   AS o_rank,
-        ss.points / NULLIF(ss.played_total, 0)    AS s_ppg,
-        os.points / NULLIF(os.played_total, 0)    AS o_ppg,
+        -- tabela do campeonato NO INSTANTE DO JOGO (superioridade_tabela)
+        s.rank    AS s_rank,
+        od.rank   AS o_rank,
+        s.ppg     AS s_ppg,
+        od.ppg    AS o_ppg,
 
-        -- forma: vitórias nos últimos 5 (conta 'W' nos últimos 5 chars do form de S)
-        ( LENGTH(RIGHT(COALESCE(ss.form, ''), 5))
-        - LENGTH(REPLACE(RIGHT(COALESCE(ss.form, ''), 5), 'W', '')) ) AS n_wins_last5,
+        -- forma: vitórias nos 5 jogos ANTERIORES ao kickoff (antes: 'W' no form do último snapshot)
+        COALESCE(s.n_wins_last5, 0) AS n_wins_last5,
 
         -- h2h
         COALESCE(hh.h2h_total, 0) AS h2h_total,
         COALESCE(hh.s_wins, 0)    AS s_wins
     FROM outcomes o
-    LEFT JOIN tss s   ON s.team_id  = o.s_team_id AND s.season  = o.season AND s.competition_id  = o.competition_id
-    LEFT JOIN tss od  ON od.team_id = o.o_team_id AND od.season = o.season AND od.competition_id = o.competition_id
-    LEFT JOIN standings_latest ss ON ss.team_id = o.s_team_id AND ss.season = o.season AND ss.league_id = o.competition_id
-    LEFT JOIN standings_latest os ON os.team_id = o.o_team_id AND os.season = o.season AND os.league_id = o.competition_id
+    LEFT JOIN pit s   ON s.fixture_id  = o.fixture_id AND s.team_id  = o.s_team_id
+    LEFT JOIN pit od  ON od.fixture_id = o.fixture_id AND od.team_id = o.o_team_id
     LEFT JOIN xg sx   ON sx.fixture_id = o.fixture_id AND sx.team_id = o.s_team_id
     LEFT JOIN xg ox   ON ox.fixture_id = o.fixture_id AND ox.team_id = o.o_team_id
     LEFT JOIN desf si  ON si.fixture_id = o.fixture_id AND si.team_id = o.s_team_id

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='S3 do Motor de Score — premissas de contexto do mercado HANDICAP ASIATICO (market_id 4). 2 linhas por (fixture, line_value): outcome_side Home e Away. Convenção dos dados (API-Football, confirmada 2026-06-24): line_value é o handicap na ÓTICA DO MANDANTE e é o MESMO p/ os dois lados — "Home -1.5" e "Away -1.5" são o PAR complementar (de-vig soma ~1.03, pin_n_outcomes=2). Logo o handicap NA ÓTICA DO LADO = IF(side=Home, line_value, -line_value): side_handicap<0 => FAVORITO (dá handicap), >0 => AZARÃO (recebe), =0 => pick (nenhuma premissa dispara). Favorito: 5 premissas (Σ40, §12.3); Azarão: 3 (Σ30). Penalidade específica: handicap_alto (-12, |line_value|>=2.5). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. Gate/edge/Score saem no mart fact_value_opportunities (gate de completude Pinnacle = par >=2, igual O/U).
+    description='S3 do Motor de Score — premissas de contexto do mercado HANDICAP ASIATICO (market_id 4). ⚠️ Task 0 (look-ahead): supremacia/tende_golear/adversario_fragil_fora/mando_forte/sem_rodizio/defesa_fora_solida leem int_futebol_team_form_pit (point-in-time por fixture) — o lado FAVORITO era 100% contaminado. raramente_perde_por_2 e favorito_irregular já eram limpos (margin_stats com kickoff_utc <) e não mudaram. 2 linhas por (fixture, line_value): outcome_side Home e Away. Convenção dos dados (API-Football, confirmada 2026-06-24): line_value é o handicap na ÓTICA DO MANDANTE e é o MESMO p/ os dois lados — "Home -1.5" e "Away -1.5" são o PAR complementar (de-vig soma ~1.03, pin_n_outcomes=2). Logo o handicap NA ÓTICA DO LADO = IF(side=Home, line_value, -line_value): side_handicap<0 => FAVORITO (dá handicap), >0 => AZARÃO (recebe), =0 => pick (nenhuma premissa dispara). Favorito: 5 premissas (Σ40, §12.3); Azarão: 3 (Σ30). Penalidade específica: handicap_alto (-12, |line_value|>=2.5). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. Gate/edge/Score saem no mart fact_value_opportunities (gate de completude Pinnacle = par >=2, igual O/U).
     ⚠️ Reconciliação §12.3: o bloco "Azarão" do playbook mistura rótulos S/O (ex.: "favorito_irregular | S venceu por 2+..."); aqui as premissas seguem o NOME/INTENÇÃO: raramente_perde_por_2 e defesa_fora_solida medem o AZARÃO (S); favorito_irregular mede o FAVORITO (O). Ao calibrar, alinhar o .md a esta leitura.'
 ) }}
 
@@ -44,31 +44,17 @@ outcomes AS (
     CROSS JOIN UNNEST(['Home', 'Away']) AS side
 ),
 
-tss AS (
+-- Correção da Task 0 (look-ahead): forma E tabela POINT-IN-TIME por (fixture, time), só com
+-- jogos anteriores ao kickoff. Substitui fact_team_season_stats (temporada fechada em 24/25) e
+-- o standings_latest (tabela final). n_teams vem junto, por (liga, season).
+pit AS (
     SELECT
-        team_id, season, competition_id,
+        fixture_id, team_id,
         goals_for_avg_home, goals_for_avg_away,
         goals_against_avg_home, goals_against_avg_away,
-        wins_home, draws_home, played_home
-    FROM {{ ref('fact_team_season_stats') }}
-),
-
--- 1 linha por (liga, season, time): snapshot mais recente; evita a linha duplicada
--- "third-placed" da Copa preferindo o grupo principal (mesmo padrão do 1X2).
-standings_latest AS (
-    SELECT league_id, season, team_id, rank, points, played_total
-    FROM {{ ref('fact_standings_snapshot') }}
-    QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY league_id, season, team_id
-        ORDER BY snapshot_date DESC,
-                 CASE WHEN group_name LIKE '%third-placed%' THEN 1 ELSE 0 END
-    ) = 1
-),
--- Nº de times por (liga, season) p/ o proxy de motivação (sem_rodizio).
-league_size AS (
-    SELECT league_id, season, COUNT(*) AS n_teams
-    FROM standings_latest
-    GROUP BY league_id, season
+        wins_home, draws_home, played_home,
+        rank, ppg, n_teams
+    FROM {{ ref('int_futebol_team_form_pit') }}
 ),
 
 -- Margem (gols pró − contra) por time em cada jogo FINALIZADO; vira a base de
@@ -120,22 +106,19 @@ metrics AS (
         -- aproveitamento de S como mandante (mando_forte)
         (s.wins_home * 3 + s.draws_home) / NULLIF(s.played_home * 3, 0) * 100 AS pct_pts_home,
 
-        -- tabela (supremacia)
-        ss.rank                                AS s_rank,
-        os.rank                                AS o_rank,
-        ss.points / NULLIF(ss.played_total, 0) AS s_ppg,
-        os.points / NULLIF(os.played_total, 0) AS o_ppg,
-        ls.n_teams                             AS n_teams,
+        -- tabela do campeonato NO INSTANTE DO JOGO (supremacia)
+        s.rank    AS s_rank,
+        od.rank   AS o_rank,
+        s.ppg     AS s_ppg,
+        od.ppg    AS o_ppg,
+        s.n_teams AS n_teams,
 
         -- margens (raramente_perde_por_2 = S; favorito_irregular = O)
         sm.n_games AS s_n_games, sm.n_lost2 AS s_lost2,
         om.n_games AS o_n_games, om.n_won2  AS o_won2
     FROM outcomes o
-    LEFT JOIN tss s   ON s.team_id  = o.s_team_id AND s.season  = o.season AND s.competition_id  = o.competition_id
-    LEFT JOIN tss od  ON od.team_id = o.o_team_id AND od.season = o.season AND od.competition_id = o.competition_id
-    LEFT JOIN standings_latest ss ON ss.team_id = o.s_team_id AND ss.season = o.season AND ss.league_id = o.competition_id
-    LEFT JOIN standings_latest os ON os.team_id = o.o_team_id AND os.season = o.season AND os.league_id = o.competition_id
-    LEFT JOIN league_size ls      ON ls.league_id = o.competition_id AND ls.season = o.season
+    LEFT JOIN pit s   ON s.fixture_id  = o.fixture_id AND s.team_id  = o.s_team_id
+    LEFT JOIN pit od  ON od.fixture_id = o.fixture_id AND od.team_id = o.o_team_id
     LEFT JOIN margin_stats sm ON sm.fixture_id = o.fixture_id AND sm.team_id = o.s_team_id
     LEFT JOIN margin_stats om ON om.fixture_id = o.fixture_id AND om.team_id = o.o_team_id
 ),
@@ -151,9 +134,9 @@ flags AS (
         m.is_favorito AND COALESCE(m.o_ga_venue >= 1.6, FALSE)                  AS adversario_fragil_fora,
         m.is_favorito AND m.s_is_home AND COALESCE(m.pct_pts_home >= 60, FALSE) AS mando_forte,
         -- sem_rodizio = proxy COARSE de motivação (jogo importante, sem rodízio): só ligas de
-        -- pontos corridos (Brasileirão, Série B, La Liga e Premier League — 20 times, mesma dinâmica G6/Z3 de
-        -- Europa/rebaixamento, então rank<=6 / rank>=n-3 vale sem mudança; revisar na recalibração por liga) e S em
-        -- zona de disputa (G6 ou Z4). Copa -> FALSE (rank é por grupo, proxy não vale).
+        -- pontos corridos (Brasileirão, Série B, La Liga, Premier League e Serie A ITA — 20 times, mesma dinâmica
+        -- G6/Z3 de Europa/rebaixamento, então rank<=6 / rank>=n-3 vale sem mudança; revisar na recalibração por
+        -- liga) e S em zona de disputa (G6 ou Z4). Copa -> FALSE (rank é por grupo, proxy não vale).
         -- Copa do Brasil -> FALSE também (mata-mata sem standings: s_rank/n_teams vêm NULL do
         -- LEFT JOIN e o COALESCE já derruba; fica fora do IN por decisão, não por acidente).
         -- Libertadores/Sudamericana -> FALSE também, mas por outro motivo: elas TÊM standings
@@ -164,7 +147,7 @@ flags AS (
         -- Champions League -> FALSE pelo mesmo motivo: fase de liga (36 times, 8 jogos) vira
         -- mata-mata em fevereiro e a tabela congela; G6/Z3 não modela a dinâmica top-8/9-24.
         -- TODO: refinar com rodada/congestionamento de calendário.
-        m.is_favorito AND m.competition IN ('brasileirao', 'serie_b', 'la_liga', 'premier_league')
+        m.is_favorito AND m.competition IN ('brasileirao', 'serie_b', 'la_liga', 'premier_league', 'serie_a_ita')
             AND COALESCE(m.s_rank <= 6 OR m.s_rank >= m.n_teams - 3, FALSE)     AS sem_rodizio,
         -- Azarão (Σ30)
         m.is_azarao AND COALESCE(m.s_n_games >= 5 AND m.s_lost2 / m.s_n_games < 0.30, FALSE) AS raramente_perde_por_2,

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_btts.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_btts.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='S4 do Motor de Score — premissas de contexto do mercado AMBOS MARCAM / BTTS (market_id 8). 2 linhas por fixture: Yes e No. Sim: dois ataques ativos e defesas vazáveis (4 premissas, Σ34). Não (espelho): uma defesa forte ou um ataque que trava (3 premissas, Σ28). Σ por lado < 55 -> sem clamp. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.4). Convenções herdadas do S2: clean sheet%/failed-to-score% sobre o TOTAL da temporada (SAFE_DIVIDE p/ played_total=0); gols feitos médios por VENUE (mandante em casa, visitante fora). historico_btts/seco = últimos 5 jogos FINALIZADOS de cada time na MESMA competição, anteriores ao jogo (>=3 de 5 ~ 60%). Sem penalidade específica (só as globais, aplicadas no mart). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities (BTTS via de-vig de CONSENSO, pois a Pinnacle não precifica BTTS — valor_fonte=consenso).'
+    description='S4 do Motor de Score — premissas de contexto do mercado AMBOS MARCAM / BTTS (market_id 8). ⚠️ Task 0 (look-ahead): ambos_marcam/defesa_forte/ataque_trava/ataque_dos_dois/defesas_vazaveis leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats. historico_btts/historico_seco já eram limpos (last5 com kickoff <). 2 linhas por fixture: Yes e No. Sim: dois ataques ativos e defesas vazáveis (4 premissas, Σ34). Não (espelho): uma defesa forte ou um ataque que trava (3 premissas, Σ28). Σ por lado < 55 -> sem clamp. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.4). Convenções herdadas do S2: clean sheet%/failed-to-score% sobre o TOTAL da temporada (SAFE_DIVIDE p/ played_total=0); gols feitos médios por VENUE (mandante em casa, visitante fora). historico_btts/seco = últimos 5 jogos FINALIZADOS de cada time na MESMA competição, anteriores ao jogo (>=3 de 5 ~ 60%). Sem penalidade específica (só as globais, aplicadas no mart). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities (BTTS via de-vig de CONSENSO, pois a Pinnacle não precifica BTTS — valor_fonte=consenso).'
 ) }}
 
 WITH fixtures AS (
@@ -20,12 +20,15 @@ outcomes AS (
     CROSS JOIN UNNEST(['Yes', 'No']) AS side
 ),
 
-tss AS (
+-- Correção da Task 0 (look-ahead): agregados POINT-IN-TIME por (fixture, time), só com jogos
+-- anteriores ao kickoff. Substitui fact_team_season_stats, que tem 1 snapshot por season (em
+-- 24/25 = temporada fechada, com o próprio jogo dentro das médias).
+pit AS (
     SELECT
-        team_id, season, competition_id,
+        fixture_id, team_id,
         goals_for_avg_home, goals_for_avg_away,
         clean_sheet_total, failed_to_score_total, played_total
-    FROM {{ ref('fact_team_season_stats') }}
+    FROM {{ ref('int_futebol_team_form_pit') }}
 ),
 
 -- Histórico BTTS: ambos marcaram (ou não) nos últimos 5 jogos FINALIZADOS de cada time, na
@@ -82,8 +85,8 @@ metrics AS (
         (SELECT COUNT(*) FROM UNNEST(hl.last5_btts) b WHERE NOT b) AS home_no_btts_cnt,
         (SELECT COUNT(*) FROM UNNEST(al.last5_btts) b WHERE NOT b) AS away_no_btts_cnt
     FROM outcomes o
-    LEFT JOIN tss h    ON h.team_id  = o.home_team_id AND h.season = o.season AND h.competition_id = o.competition_id
-    LEFT JOIN tss a    ON a.team_id  = o.away_team_id AND a.season = o.season AND a.competition_id = o.competition_id
+    LEFT JOIN pit h    ON h.fixture_id = o.fixture_id AND h.team_id = o.home_team_id
+    LEFT JOIN pit a    ON a.fixture_id = o.fixture_id AND a.team_id = o.away_team_id
     LEFT JOIN last5 hl ON hl.fixture_id = o.fixture_id AND hl.team_id = o.home_team_id
     LEFT JOIN last5 al ON al.fixture_id = o.fixture_id AND al.team_id = o.away_team_id
 ),

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_dc.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_dc.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='S5 do Motor de Score — premissas de contexto do mercado DUPLA CHANCE (market_id 12). 2 linhas por fixture: 1X (mandante ou empate, S=Home) e X2 (empate ou visitante, S=Away). DC é aposta de proteção: vale quando o mercado superprecifica a zebra do lado DESCOBERTO (O). 4 premissas (Σ34, sem clamp — bem abaixo de 55), espelha §12.5. lado_coberto_forte REUSA forca_mismatch/superioridade_tabela do int_futebol_premissas_1x2 (do lado S); adversario_limitado reusa o h2h_favoravel do 1X2. equilibrio_defensivo e invicto_recente derivam de fact_team_season_stats (gols sofridos no total) e dos jogos FINALIZADOS da MESMA season/competição anteriores ao jogo (goleados = cedeu 3+, e derrotas nos últimos 5) — o filtro de season evita sangrar a temporada passada pela pausa de off-season. O 12 (sem empate) NÃO é produzido (não casa com o padrão S/O da §12.5). Penalidade específica (odd_muito_baixa <1,20) e o gate próprio (melhor_odd >=1,25, sem odd_juice) são aplicados no mart fact_value_opportunities. Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front.'
+    description='S5 do Motor de Score — premissas de contexto do mercado DUPLA CHANCE (market_id 12). ⚠️ Task 0 (look-ahead): equilibrio_defensivo/adversario_limitado leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats; lado_coberto_forte herda a correção via int_futebol_premissas_1x2 (era a premissa MAIS contaminada, com as duas fontes sujas). invicto_recente já era limpa. 2 linhas por fixture: 1X (mandante ou empate, S=Home) e X2 (empate ou visitante, S=Away). DC é aposta de proteção: vale quando o mercado superprecifica a zebra do lado DESCOBERTO (O). 4 premissas (Σ34, sem clamp — bem abaixo de 55), espelha §12.5. lado_coberto_forte REUSA forca_mismatch/superioridade_tabela do int_futebol_premissas_1x2 (do lado S); adversario_limitado reusa o h2h_favoravel do 1X2. equilibrio_defensivo e invicto_recente derivam de fact_team_season_stats (gols sofridos no total) e dos jogos FINALIZADOS da MESMA season/competição anteriores ao jogo (goleados = cedeu 3+, e derrotas nos últimos 5) — o filtro de season evita sangrar a temporada passada pela pausa de off-season. O 12 (sem empate) NÃO é produzido (não casa com o padrão S/O da §12.5). Penalidade específica (odd_muito_baixa <1,20) e o gate próprio (melhor_odd >=1,25, sem odd_juice) são aplicados no mart fact_value_opportunities. Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front.'
 ) }}
 
 WITH fixtures AS (
@@ -30,12 +30,14 @@ reuse_1x2 AS (
     FROM {{ ref('int_futebol_premissas_1x2') }}
 ),
 
-tss AS (
+-- Correção da Task 0 (look-ahead): agregados POINT-IN-TIME por (fixture, time), só com jogos
+-- anteriores ao kickoff, no lugar de fact_team_season_stats (1 snapshot por season).
+pit AS (
     SELECT
-        team_id, season, competition_id,
+        fixture_id, team_id,
         goals_against_avg_total,
         wins_total, draws_total, played_total
-    FROM {{ ref('fact_team_season_stats') }}
+    FROM {{ ref('int_futebol_team_form_pit') }}
 ),
 
 -- Jogos finalizados (mesma competição, MESMA season, anteriores) -> goleados (cedeu 3+) e
@@ -98,8 +100,8 @@ metrics AS (
         COALESCE(x.superioridade_tabela, FALSE) AS x_superioridade_tabela,
         COALESCE(x.h2h_favoravel, FALSE)        AS x_h2h_favoravel
     FROM outcomes o
-    LEFT JOIN tss s        ON s.team_id  = o.s_team_id AND s.season  = o.season AND s.competition_id  = o.competition_id
-    LEFT JOIN tss od       ON od.team_id = o.o_team_id AND od.season = o.season AND od.competition_id = o.competition_id
+    LEFT JOIN pit s        ON s.fixture_id  = o.fixture_id AND s.team_id  = o.s_team_id
+    LEFT JOIN pit od       ON od.fixture_id = o.fixture_id AND od.team_id = o.o_team_id
     LEFT JOIN team_hist st ON st.fixture_id = o.fixture_id AND st.team_id = o.s_team_id
     LEFT JOIN team_hist ot ON ot.fixture_id = o.fixture_id AND ot.team_id = o.o_team_id
     LEFT JOIN reuse_1x2 x  ON x.fixture_id  = o.fixture_id AND x.x1_outcome = o.s_1x2_outcome

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ou.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ou.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='S2 do Motor de Score — premissas de contexto do mercado GOLS Over/Under (market_id 5). 2 linhas por (fixture, line_value): Over e Under, por linha L. Universo de linhas = canônicas {1.5,2.5,3.5} de toda fixture UNION as linhas presentes nas odds (market_id=5) — assim valida no Brasileirão mesmo sem odds (pausa FIFA) e ainda deixa a penalidade linha_extrema disparar em linhas extremas do mercado. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.2; Over Σ56 / Under Σ52, com clamp ao teto 55 — Over é o único lado que encosta no teto). Penalidade específica: linha_extrema (-10, L<=0,5 ou L>=4,5). Movimento de linha (linha_subindo/descendo) = CONSENSO do mercado (média das PROBABILIDADES IMPLÍCITAS 1/odd de TODAS as casas t24h->t15m; odd crua super-ponderaria o leg de odd alta), DISTINTO da corroboração linha_sharp_confirma (só Pinnacle) p/ não contar o mesmo sinal 2x (§10.8). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/ritmo). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities.'
+    description='S2 do Motor de Score — premissas de contexto do mercado GOLS Over/Under (market_id 5). ⚠️ Task 0 (look-ahead): ataque_combinado/defesas_firmes/defesas_vazaveis/clean_sheets_altos/ataques_fracos/ambos_vazam leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats; xg_combinado_alto/xg_baixo_combinado/ritmo_alto passaram a usar o spine ancorado no kickoff (item C) em vez da média da season inteira — era o caso que fazia o MESMO xG medir −2,4 no 1X2 (point-in-time) e +0,5 aqui. historico_over/under e linha_subindo/descendo já eram limpos. 2 linhas por (fixture, line_value): Over e Under, por linha L. Universo de linhas = canônicas {1.5,2.5,3.5} de toda fixture UNION as linhas presentes nas odds (market_id=5) — assim valida no Brasileirão mesmo sem odds (pausa FIFA) e ainda deixa a penalidade linha_extrema disparar em linhas extremas do mercado. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.2; Over Σ56 / Under Σ52, com clamp ao teto 55 — Over é o único lado que encosta no teto). Penalidade específica: linha_extrema (-10, L<=0,5 ou L>=4,5). Movimento de linha (linha_subindo/descendo) = CONSENSO do mercado (média das PROBABILIDADES IMPLÍCITAS 1/odd de TODAS as casas t24h->t15m; odd crua super-ponderaria o leg de odd alta), DISTINTO da corroboração linha_sharp_confirma (só Pinnacle) p/ não contar o mesmo sinal 2x (§10.8). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/ritmo). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities.'
 ) }}
 
 WITH fixtures AS (
@@ -38,36 +38,71 @@ outcomes AS (
     CROSS JOIN UNNEST(['Over', 'Under']) AS side
 ),
 
-tss AS (
+-- Correção da Task 0 (look-ahead): agregados POINT-IN-TIME por (fixture, time), só com jogos
+-- anteriores ao kickoff, no lugar de fact_team_season_stats (1 snapshot por season = temporada
+-- fechada em 24/25, com o próprio jogo e os seguintes dentro das médias).
+pit AS (
     SELECT
-        team_id, season, competition_id,
+        fixture_id, team_id,
         goals_for_avg_home, goals_for_avg_away,
         goals_against_avg_home, goals_against_avg_away,
         clean_sheet_total, failed_to_score_total, played_total
-    FROM {{ ref('fact_team_season_stats') }}
+    FROM {{ ref('int_futebol_team_form_pit') }}
 ),
 
--- xG médio de ATAQUE por time-season (sem self-join: O/U só precisa do xG_for de cada um;
--- Brasileirão preenchido, Copa ~vazio -> NULL -> premissa de xG não dispara).
+-- Spine (fixture-alvo, time) p/ ancorar xG e ritmo ao kickoff — MESMO padrão que o _1x2 já
+-- usava p/ o xG. Correção da Task 0 (item C): antes eram médias da season INTEIRA, o que fazia
+-- o mesmo xG medir negativo no 1X2 (point-in-time) e positivo no Gols (contaminado).
+fixture_team_spine AS (
+    SELECT fixture_id, season, competition_id, kickoff_utc, home_team_id AS team_id FROM fixtures
+    UNION ALL
+    SELECT fixture_id, season, competition_id, kickoff_utc, away_team_id FROM fixtures
+),
+
+-- xG médio de ATAQUE do time ATÉ o jogo (Brasileirão preenchido, Copa ~vazio -> NULL ->
+-- premissa de xG não dispara).
 xg AS (
-    SELECT team_id, season, competition_id, AVG(expected_goals) AS xg_for_avg
-    FROM {{ ref('fact_fixture_stats') }}
-    GROUP BY team_id, season, competition_id
+    SELECT sp.fixture_id, sp.team_id, AVG(st.expected_goals) AS xg_for_avg
+    FROM fixture_team_spine sp
+    JOIN {{ ref('fact_fixture_stats') }} st
+        ON  st.team_id        = sp.team_id
+        AND st.season         = sp.season
+        AND st.competition_id = sp.competition_id
+        AND st.date_utc       < DATE(sp.kickoff_utc)
+    GROUP BY sp.fixture_id, sp.team_id
 ),
 
--- Ritmo: finalizações+escanteios por time-jogo -> média por time-season; mediana da liga
--- sobre as MÉDIAS por time (grão coerente com a comparação das duas médias). Brasileirão only.
+-- Ritmo: finalizações+escanteios por time-jogo -> média do time ATÉ o jogo.
 pace_team AS (
-    SELECT team_id, season, competition_id,
-           AVG(total_shots + corner_kicks) AS pace_avg
-    FROM {{ ref('fact_fixture_stats') }}
-    GROUP BY team_id, season, competition_id
+    SELECT sp.fixture_id, sp.team_id, sp.competition_id, sp.season,
+           AVG(st.total_shots + st.corner_kicks) AS pace_avg
+    FROM fixture_team_spine sp
+    JOIN {{ ref('fact_fixture_stats') }} st
+        ON  st.team_id        = sp.team_id
+        AND st.season         = sp.season
+        AND st.competition_id = sp.competition_id
+        AND st.date_utc       < DATE(sp.kickoff_utc)
+    GROUP BY sp.fixture_id, sp.team_id, sp.competition_id, sp.season
 ),
+-- Mediana da liga sobre as médias por time NO INSTANTE DO JOGO: 1 mediana por (liga, season,
+-- fixture), e não mais uma única mediana da season fechada.
 league_pace_median AS (
-    SELECT competition_id, season,
+    SELECT fixture_id,
            APPROX_QUANTILES(pace_avg, 2)[OFFSET(1)] AS pace_median
-    FROM pace_team
-    GROUP BY competition_id, season
+    FROM (
+        SELECT sp.fixture_id, lt.team_id,
+               AVG(st.total_shots + st.corner_kicks) AS pace_avg
+        FROM (SELECT DISTINCT fixture_id, competition_id, season, kickoff_utc FROM fixture_team_spine) sp
+        JOIN (SELECT DISTINCT competition_id, season, team_id FROM fixture_team_spine) lt
+            ON lt.competition_id = sp.competition_id AND lt.season = sp.season
+        JOIN {{ ref('fact_fixture_stats') }} st
+            ON  st.team_id        = lt.team_id
+            AND st.season         = sp.season
+            AND st.competition_id = sp.competition_id
+            AND st.date_utc       < DATE(sp.kickoff_utc)
+        GROUP BY sp.fixture_id, lt.team_id
+    )
+    GROUP BY fixture_id
 ),
 
 -- Histórico Over/Under: gols totais dos últimos 5 jogos FINALIZADOS de cada time, na MESMA
@@ -149,13 +184,13 @@ metrics AS (
         -- implícita média SUBIU (t15m > t24h) = odd caiu (dinheiro entrando neste lado)
         COALESCE(lm.prob_t15m > lm.prob_t24h, FALSE)         AS linha_caiu
     FROM outcomes o
-    LEFT JOIN tss h  ON h.team_id  = o.home_team_id AND h.season  = o.season AND h.competition_id  = o.competition_id
-    LEFT JOIN tss a  ON a.team_id  = o.away_team_id AND a.season  = o.season AND a.competition_id  = o.competition_id
-    LEFT JOIN xg hx  ON hx.team_id = o.home_team_id AND hx.season = o.season AND hx.competition_id = o.competition_id
-    LEFT JOIN xg ax  ON ax.team_id = o.away_team_id AND ax.season = o.season AND ax.competition_id = o.competition_id
-    LEFT JOIN pace_team hp ON hp.team_id = o.home_team_id AND hp.season = o.season AND hp.competition_id = o.competition_id
-    LEFT JOIN pace_team ap ON ap.team_id = o.away_team_id AND ap.season = o.season AND ap.competition_id = o.competition_id
-    LEFT JOIN league_pace_median lpm ON lpm.competition_id = o.competition_id AND lpm.season = o.season
+    LEFT JOIN pit h  ON h.fixture_id  = o.fixture_id AND h.team_id  = o.home_team_id
+    LEFT JOIN pit a  ON a.fixture_id  = o.fixture_id AND a.team_id  = o.away_team_id
+    LEFT JOIN xg hx  ON hx.fixture_id = o.fixture_id AND hx.team_id = o.home_team_id
+    LEFT JOIN xg ax  ON ax.fixture_id = o.fixture_id AND ax.team_id = o.away_team_id
+    LEFT JOIN pace_team hp ON hp.fixture_id = o.fixture_id AND hp.team_id = o.home_team_id
+    LEFT JOIN pace_team ap ON ap.fixture_id = o.fixture_id AND ap.team_id = o.away_team_id
+    LEFT JOIN league_pace_median lpm ON lpm.fixture_id = o.fixture_id
     LEFT JOIN last5 hl ON hl.fixture_id = o.fixture_id AND hl.team_id = o.home_team_id
     LEFT JOIN last5 al ON al.fixture_id = o.fixture_id AND al.team_id = o.away_team_id
     LEFT JOIN line_move lm ON lm.fixture_id = o.fixture_id AND lm.line_value = o.line_value AND lm.outcome = o.outcome

--- a/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
@@ -1,0 +1,198 @@
+{{ config(
+    materialized='table',
+    cluster_by=['fixture_id', 'team_id'],
+    description='Correção da Task 0 (look-ahead) — agregados de forma POINT-IN-TIME por (fixture_id, team_id): tudo é calculado SÓ com jogos FINALIZADOS da MESMA competição/season e com kickoff ANTERIOR ao do jogo-alvo. Substitui as duas fontes contaminadas dos 5 modelos de premissas: (A) fact_team_season_stats, que tem 1 único snapshot por (time, liga, season) — p/ 2024/2025 é a temporada FECHADA (played_total=38 aplicado à rodada 1, ~51% de cada média sendo futuro e 100% dos jogos com o próprio resultado dentro da média); e (B2) o standings_latest (MAX(snapshot_date) sem âncora no kickoff), cujo histórico só começa em 11/06/2026 e que p/ 24/25 é a tabela final. Reconstrói do fact_fixtures o mesmo conjunto de colunas consumido pelos modelos (gols pró/contra casa/fora/total, clean sheet, failed to score, played/wins/draws) MAIS a tabela do campeonato no instante do jogo (rank/points/ppg/n_wins_last5). O rank sai DENTRO do grupo (group_name das standings = estrutura do chaveamento, conhecida antes dos jogos — não é medição): liga de pontos corridos = 1 grupo, logo rank global 1-20 (Brasileirão/Série B/La Liga/PL/Serie A ITA) ou 1-36 (Champions, fase de liga); Libertadores/Sudamericana/Copa do Mundo = rank por grupo (1-4 / 1-12), igual à API; Copa do Brasil não tem standings -> sem grupo -> rank NULL, como já era. Degradação graciosa por construção: no início de temporada played_total=0 -> médias NULL -> premissa FALSE (honesto: na rodada 1 não existe passado). played_* fica exposto p/ que a recalibragem possa decidir um piso de amostra.'
+) }}
+
+WITH fixtures AS (
+    SELECT
+        fixture_id, competition, competition_id, season,
+        home_team_id, away_team_id, kickoff_utc,
+        status_short, goals_home, goals_away
+    FROM {{ ref('fact_fixtures') }}
+),
+
+-- Grão de saída: os dois lados de cada jogo (inclusive jogos futuros).
+targets AS (
+    SELECT fixture_id, competition, competition_id, season, kickoff_utc,
+           home_team_id AS team_id
+    FROM fixtures
+    UNION ALL
+    SELECT fixture_id, competition, competition_id, season, kickoff_utc,
+           away_team_id
+    FROM fixtures
+),
+
+-- Jogos FINALIZADOS viram 1 linha por (time, jogo), com o eixo casa/fora. É a única fonte de
+-- performance daqui p/ baixo — mesmo idioma das CTEs last5/margin_stats/team_hist que já existem.
+team_log AS (
+    SELECT competition_id, season, kickoff_utc, home_team_id AS team_id,
+           TRUE AS is_home, goals_home AS gf, goals_away AS ga
+    FROM fixtures
+    WHERE status_short = 'FT' AND goals_home IS NOT NULL AND goals_away IS NOT NULL
+    UNION ALL
+    SELECT competition_id, season, kickoff_utc, away_team_id,
+           FALSE, goals_away, goals_home
+    FROM fixtures
+    WHERE status_short = 'FT' AND goals_home IS NOT NULL AND goals_away IS NOT NULL
+),
+
+-- Universo de times por (liga, season) — tirado de fixtures, não de standings, p/ a Copa do
+-- Brasil (sem tabela) também ter n_teams.
+league_teams AS (
+    SELECT DISTINCT competition_id, season, team_id
+    FROM targets
+),
+league_size AS (
+    SELECT competition_id, season, COUNT(*) AS n_teams
+    FROM league_teams
+    GROUP BY competition_id, season
+),
+
+-- Grupo de cada time. É estrutura de chaveamento (o sorteio), conhecida antes dos jogos —
+-- entra só p/ o rank PIT ser calculado no mesmo recorte que o rank da API. Dedup igual ao
+-- standings_latest que estava nos modelos: prefere o grupo principal ao "third-placed".
+team_group AS (
+    SELECT league_id AS competition_id, season, team_id, group_name
+    FROM {{ ref('fact_standings_snapshot') }}
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY league_id, season, team_id
+        ORDER BY CASE WHEN group_name LIKE '%third-placed%' THEN 1 ELSE 0 END,
+                 snapshot_date DESC
+    ) = 1
+),
+
+-- Cada fixture é uma ÂNCORA DE TEMPO. Cruzada com TODOS os times da liga porque o rank exige a
+-- tabela inteira naquele instante, não só os dois times do jogo (o filtro p/ os dois vem no fim).
+anchors AS (
+    SELECT fixture_id, competition_id, season, kickoff_utc FROM fixtures
+),
+
+pit AS (
+    SELECT
+        a.fixture_id,
+        lt.team_id,
+        a.competition_id,
+        a.season,
+
+        -- jogos / resultados
+        COUNTIF(l.is_home)                          AS played_home,
+        COUNTIF(NOT l.is_home)                      AS played_away,
+        COUNT(l.team_id)                            AS played_total,
+        COUNTIF(l.is_home       AND l.gf > l.ga)    AS wins_home,
+        COUNTIF(l.is_home       AND l.gf = l.ga)    AS draws_home,
+        COUNTIF(NOT l.is_home   AND l.gf > l.ga)    AS wins_away,
+        COUNTIF(NOT l.is_home   AND l.gf = l.ga)    AS draws_away,
+        COUNTIF(l.gf > l.ga)                        AS wins_total,
+        COUNTIF(l.gf = l.ga)                        AS draws_total,
+
+        -- gols marcados / sofridos (médias por venue e no total)
+        SAFE_DIVIDE(SUM(IF(l.is_home,     l.gf, 0)), COUNTIF(l.is_home))     AS goals_for_avg_home,
+        SAFE_DIVIDE(SUM(IF(NOT l.is_home, l.gf, 0)), COUNTIF(NOT l.is_home)) AS goals_for_avg_away,
+        SAFE_DIVIDE(SUM(l.gf),                       COUNT(l.team_id))       AS goals_for_avg_total,
+        SAFE_DIVIDE(SUM(IF(l.is_home,     l.ga, 0)), COUNTIF(l.is_home))     AS goals_against_avg_home,
+        SAFE_DIVIDE(SUM(IF(NOT l.is_home, l.ga, 0)), COUNTIF(NOT l.is_home)) AS goals_against_avg_away,
+        SAFE_DIVIDE(SUM(l.ga),                       COUNT(l.team_id))       AS goals_against_avg_total,
+
+        -- defesa / ataque agregados
+        COUNTIF(l.ga = 0)                           AS clean_sheet_total,
+        COUNTIF(l.gf = 0)                           AS failed_to_score_total,
+
+        -- insumos da tabela do campeonato
+        COUNTIF(l.gf > l.ga) * 3 + COUNTIF(l.gf = l.ga)  AS points,
+        COALESCE(SUM(l.gf), 0)                           AS goals_for_total,
+        COALESCE(SUM(l.gf) - SUM(l.ga), 0)               AS goal_diff,
+
+        -- forma: os últimos 5 resultados ANTES do jogo (substitui o parse de standings.form)
+        ARRAY_AGG(
+            CASE WHEN l.gf > l.ga THEN 'W'
+                 WHEN l.gf = l.ga THEN 'D'
+                 WHEN l.gf < l.ga THEN 'L' END
+            IGNORE NULLS ORDER BY l.kickoff_utc DESC LIMIT 5
+        ) AS last5_desc
+    FROM anchors a
+    JOIN league_teams lt
+        ON  lt.competition_id = a.competition_id
+        AND lt.season         = a.season
+    LEFT JOIN team_log l
+        ON  l.team_id        = lt.team_id
+        AND l.competition_id = a.competition_id
+        AND l.season         = a.season
+        AND l.kickoff_utc    < a.kickoff_utc
+    GROUP BY a.fixture_id, lt.team_id, a.competition_id, a.season
+),
+
+-- Tabela do campeonato no instante do jogo. Critério de desempate = pontos > vitórias > saldo >
+-- gols pró (o do Brasileirão), + team_id p/ ser determinístico. ROW_NUMBER e não RANK porque o
+-- rank da API é estrito (não repete posição), e o modelo compara diferenças de rank.
+-- rank NULL quando o time ainda não jogou na temporada: antes da rodada 1 a tabela não existe e
+-- todo mundo empataria em 0 -> `s_rank <= 6` do sem_rodizio dispararia p/ a liga inteira.
+ranked AS (
+    SELECT
+        p.*,
+        tg.group_name,
+        IF(tg.group_name IS NULL OR p.played_total = 0, NULL,
+           ROW_NUMBER() OVER (
+               PARTITION BY p.fixture_id, tg.group_name
+               ORDER BY p.points DESC, p.wins_total DESC, p.goal_diff DESC,
+                        p.goals_for_total DESC, p.team_id
+           )
+        ) AS rank
+    FROM pit p
+    LEFT JOIN team_group tg
+        ON  tg.competition_id = p.competition_id
+        AND tg.season         = p.season
+        AND tg.team_id        = p.team_id
+)
+
+SELECT
+    t.fixture_id,
+    t.team_id,
+    t.competition,
+    t.competition_id,
+    t.season,
+    t.kickoff_utc,
+
+    -- jogos / resultados (todos PIT)
+    r.played_home,
+    r.played_away,
+    r.played_total,
+    r.wins_home,
+    r.draws_home,
+    r.wins_away,
+    r.draws_away,
+    r.wins_total,
+    r.draws_total,
+
+    -- gols
+    r.goals_for_avg_home,
+    r.goals_for_avg_away,
+    r.goals_for_avg_total,
+    r.goals_against_avg_home,
+    r.goals_against_avg_away,
+    r.goals_against_avg_total,
+    r.clean_sheet_total,
+    r.failed_to_score_total,
+
+    -- tabela do campeonato no instante do jogo
+    r.rank,
+    r.points,
+    r.goal_diff,
+    SAFE_DIVIDE(r.points, r.played_total) AS ppg,
+    ls.n_teams,
+    r.group_name,
+
+    -- forma (últimos 5 antes do jogo). form_last5 sai do mais ANTIGO p/ o mais RECENTE, igual à
+    -- convenção do campo form da API (que os modelos liam com RIGHT(form, 5)).
+    (SELECT COUNT(*) FROM UNNEST(r.last5_desc) x WHERE x = 'W') AS n_wins_last5,
+    ARRAY_LENGTH(COALESCE(r.last5_desc, []))                    AS n_games_last5,
+    ARRAY_TO_STRING(ARRAY_REVERSE(COALESCE(r.last5_desc, [])), '') AS form_last5,
+
+    CURRENT_TIMESTAMP() AS dbt_loaded_at
+FROM targets t
+JOIN ranked r
+    ON  r.fixture_id = t.fixture_id
+    AND r.team_id    = t.team_id
+LEFT JOIN league_size ls
+    ON  ls.competition_id = t.competition_id
+    AND ls.season         = t.season

--- a/dbt_futebol/models/marts/fact_fixtures.sql
+++ b/dbt_futebol/models/marts/fact_fixtures.sql
@@ -17,6 +17,7 @@ SELECT
         WHEN 140 THEN 'la_liga'
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
+        WHEN 135 THEN 'serie_a_ita'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS competition_id,

--- a/dbt_futebol/models/marts/fact_injuries_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_injuries_snapshot.sql
@@ -20,6 +20,7 @@ SELECT
         WHEN 140 THEN 'la_liga'
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
+        WHEN 135 THEN 'serie_a_ita'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS league_id,

--- a/dbt_futebol/models/marts/fact_odds_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_odds_snapshot.sql
@@ -20,6 +20,7 @@ SELECT
         WHEN 140 THEN 'la_liga'
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
+        WHEN 135 THEN 'serie_a_ita'
         ELSE 'unknown'
     END                                              AS competition,
     league_id,

--- a/dbt_futebol/models/marts/fact_predictions_api.sql
+++ b/dbt_futebol/models/marts/fact_predictions_api.sql
@@ -20,6 +20,7 @@ SELECT
         WHEN 140 THEN 'la_liga'
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
+        WHEN 135 THEN 'serie_a_ita'
         ELSE 'unknown'
     END                                              AS competition,
     league_id,

--- a/dbt_futebol/models/marts/fact_standings_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_standings_snapshot.sql
@@ -20,6 +20,7 @@ SELECT
         WHEN 140 THEN 'la_liga'
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
+        WHEN 135 THEN 'serie_a_ita'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS league_id,

--- a/dbt_futebol/models/marts/fact_team_season_stats.sql
+++ b/dbt_futebol/models/marts/fact_team_season_stats.sql
@@ -22,6 +22,7 @@ SELECT
         WHEN 140 THEN 'la_liga'
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
+        WHEN 135 THEN 'serie_a_ita'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS competition_id,

--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -678,7 +678,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
       - name: competition_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana)"
       - name: season
@@ -829,7 +829,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 13 = Libertadores, 11 = Sudamericana; cluster key — 73 nunca ocorre, mata-mata sem standings)"
         tests:
@@ -934,7 +934,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão)"
         tests:
@@ -1031,7 +1031,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana)"
         tests:
@@ -1152,7 +1152,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana)"
         tests:

--- a/dbt_futebol/tests/assert_desfalques_pregame_only.sql
+++ b/dbt_futebol/tests/assert_desfalques_pregame_only.sql
@@ -1,0 +1,29 @@
+-- Guard de regressão da Task 0 (item D).
+-- Todo desfalque que chega na premissa tem de vir de um snapshot COLETADO ANTES DO APITO.
+-- O log de /injuries da API é retroativo (99,6% das linhas são pós-jogo, inclusive de quem se
+-- machucou durante a partida): sem esta âncora o backtest lê um dado que produção não tem.
+-- Falha = alguém removeu o filtro extracted_at < kickoff_utc.
+
+WITH desfalques AS (
+    SELECT DISTINCT fixture_id, team_id, player_id
+    FROM {{ ref('int_futebol_desfalques') }}
+),
+
+-- Menor instante de coleta disponível p/ aquele (fixture, time, jogador).
+coleta AS (
+    SELECT
+        i.fixture_id,
+        i.team_id,
+        i.player_id,
+        MIN(i.extracted_at) AS primeira_coleta,
+        ANY_VALUE(f.kickoff_utc) AS kickoff_utc
+    FROM {{ ref('fact_injuries_snapshot') }} i
+    JOIN {{ ref('fact_fixtures') }} f USING (fixture_id)
+    GROUP BY i.fixture_id, i.team_id, i.player_id
+)
+
+SELECT d.*, c.primeira_coleta, c.kickoff_utc
+FROM desfalques d
+JOIN coleta c
+    USING (fixture_id, team_id, player_id)
+WHERE c.primeira_coleta >= c.kickoff_utc

--- a/dbt_futebol/tests/assert_pit_first_game_has_no_history.sql
+++ b/dbt_futebol/tests/assert_pit_first_game_has_no_history.sql
@@ -1,0 +1,28 @@
+-- Guard de regressão da Task 0 (look-ahead).
+-- No PRIMEIRO jogo de um time numa (competição, temporada) não existe passado: played_total tem
+-- de ser 0 e rank/médias têm de ser NULL. Era exatamente aqui que o modelo antigo entregava a
+-- temporada FECHADA (played_total=38, tabela final) a um jogo da rodada 1.
+-- Falha = alguma fonte voltou a ser lida sem âncora no kickoff.
+
+WITH primeiro_jogo AS (
+    SELECT
+        fixture_id,
+        team_id,
+        competition,
+        season,
+        kickoff_utc,
+        played_total,
+        rank,
+        goals_for_avg_home
+    FROM {{ ref('int_futebol_team_form_pit') }}
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY team_id, competition_id, season
+        ORDER BY kickoff_utc
+    ) = 1
+)
+
+SELECT *
+FROM primeiro_jogo
+WHERE played_total != 0
+   OR rank IS NOT NULL
+   OR goals_for_avg_home IS NOT NULL

--- a/docs/MOTOR_SCORE_CONFIABILIDADE.md
+++ b/docs/MOTOR_SCORE_CONFIABILIDADE.md
@@ -428,3 +428,65 @@ Combina 2 das 3 saídas (ex.: "S ou empate"). **Valor quando** o mercado **super
 **Pilar A vs Pilar B:** este motor é o **Pilar A (valor/regras)** — usa de-vig da Pinnacle + premissas + `/predictions` da API como "modelo de referência". O benchmark recomenda como evolução um **Pilar B (modelo próprio)**: núcleo **Dixon-Coles** (Poisson + correção de placar baixo + decaimento temporal), λ a partir de **xG** ataque/defesa + mando + ajuste de escalação, com **ratings (pi-ratings/Elo)** como prior. **Hoje não existe** (os `src/utils/futebol-value.ts`/`futebol-tendencias.ts` citados no playbook são referências aspiracionais — não estão no repo). Quando existir, vira corroboração adicional (ou substitui `modelo_api_concorda`).
 
 **Gaps apontados (úteis de saber):** rating próprio ⬜ (tijolo barato e forte — fortaleceria `superioridade_tabela`/`supremacia`, hoje crus via rank/pontos); **peso de jogador** (minutos×qualidade) ⬜ = exatamente o proxy de importância de **S7**; xG fora do Brasileirão ⬜ (Copa fraca — degradação graciosa); mando por liga recalibrado pós-2020 🟡.
+
+---
+
+## 14. Correção do look-ahead (Task 0) — 2026-08-03
+
+A auditoria da **Task 0** (ClickUp `wdx6zev64w`) encontrou que **27 das 39 premissas liam dado posterior
+ao jogo**. As correções abaixo estão implementadas e testadas; **ainda não deployadas** (exige rebuild da
+imagem `dbt-futebol`, ver `.claude/skills/deploy-dbt-changes`).
+
+### O que mudou
+
+| Item | Fonte contaminada | Correção |
+|---|---|---|
+| A + B2 | `fact_team_season_stats` (1 snapshot/season = temporada FECHADA em 24/25) e `standings_latest` (`MAX(snapshot_date)` = tabela final) | Novo `int_futebol_team_form_pit`, grão (fixture_id, team_id), reconstruído de `fact_fixtures` só com jogos anteriores ao kickoff. Traz também rank/points/ppg/n_wins_last5/n_teams |
+| C | xG e pace do O/U em média da season inteira | `fixture_team_spine` + `date_utc < DATE(kickoff)` — o mesmo padrão que o `_1x2` já usava |
+| D | `int_futebol_desfalques` com `MAX(snapshot_date)` | `extracted_at < kickoff_utc`. **99,6% das ~174 mil linhas de `/injuries` foram coletadas depois do apito** |
+| E | `int_futebol_player_importance` com pool de todas as seasons | `is_important` virou point-in-time (window cumulativa) dentro de `int_futebol_desfalques`; `is_important_pooled` fica exposto |
+
+**Guards de regressão:** `assert_pit_first_game_has_no_history` (na estreia, `played_total`=0 e rank NULL)
+e `assert_desfalques_pregame_only` (todo desfalque vem de coleta pré-apito).
+
+### Validação
+
+- `int_futebol_team_form_pit` bate com a tabela real da API (Brasileirão 2026): **56/63 pontos e 55/63 ranks
+  exatos**, erro médio de 0,27 posição. As diferenças são o snapshot diário estar defasado do kickoff — o PIT
+  é mais preciso.
+- **Produção não muda**: em jogos futuros o PIT é ~idêntico ao antigo (diferença média de **0,003 gol/jogo**).
+  Faz sentido: para um jogo que ainda não aconteceu, "tudo antes do kickoff" = "temporada até agora".
+- **Prova cruzada**: as 11 premissas que a auditoria classificou como limpas mudaram **exatamente 0%**; todas
+  as 27 contaminadas mudaram.
+
+### Re-run dos Testes 1 e 3 (o que sobrou)
+
+Teste 1 (acerto vs. a média da mesma linha), maiores quedas: `tende_golear` +32,8 → +8,1 · `defesa_forte`
++19,4 → +3,3 · `mando` +19,3 → +5,8 · `clean_sheets_altos` +20,0 → +5,6 · `superioridade_tabela` +23,5 →
++12,1. Toda premissa limpa: delta 0,0.
+
+Teste 3 (ROI da porta "2+ premissas", 168 jogos com odds, 16/06 a 02/08/2026):
+
+| Porta | ROI antes | ROI depois |
+|---|---|---|
+| 2+ premissas | **+9,2%** (reproduz o "+9,7%") | **−7,6%** |
+| 3+ premissas | +17,1% | −6,0% |
+| edge>0 + 2 premissas | +18,6% | −15,4% |
+
+Antes, o ROI subia monotonicamente com o nº de premissas — assinatura de vazamento. Depois, fica plano em
+−6% a −9%: **a porta de contexto não ordena nada**.
+
+**Achado adicional que muda a leitura:** com piso de 5 jogos disputados, **a base contaminada já dava
+negativo** (−3,9%). Os +9,7% vinham inteiramente das linhas de amostra curta — Copa do Mundo (39% do
+universo, média de **2,4 jogos**), Sudamericana (0,8) e Copa do Brasil (1,9), onde o snapshot de temporada
+cobre um punhado de jogos e o próprio jogo pesa ~1/3 da "média". Brasileirão e Série B (17–18 jogos) nunca
+sustentaram o resultado.
+
+⚠️ **Amostra**: 168 jogos / ~1,5 mês (a odd só existe desde julho/2026) e apostas correlacionadas dentro do
+mesmo jogo. A direção é inequívoca; os números negativos **não** devem ser lidos como estimativa precisa.
+
+### Aberto para decisão
+
+`played_total` foi exposto **sem** piso de amostra embutido: com 1–3 jogos, `superioridade_tabela` acende
+mais (37,6%) do que com 11+ (32,2%) — um time que venceu a estreia tem PPG 3,0 contra 0,0. Definir o piso é
+decisão de calibragem, não de correção de vazamento, e ficou para a recalibragem.

--- a/docs/MOTOR_SCORE_CONFIABILIDADE.md
+++ b/docs/MOTOR_SCORE_CONFIABILIDADE.md
@@ -309,6 +309,33 @@ Preencher a coluna **Status/Notas** in-place quando cada uma for implementada �
 
 **Penalidade específica:** `linha_extrema` (−10, quando L ≤ 0,5 ou L ≥ 4,5 — odd vira juice/longshot).
 
+#### 12.2.1 — Baseline de calibração por liga (medido 2026-08-03)
+
+Cinco das treze regras acima usam **thresholds absolutos** (`35%`, `40%`, `35%`, e os offsets
+`+0,5` / `±0,3`) calibrados no **Brasileirão**. Num ambiente de gols deslocado, todas as premissas
+de um mesmo lado disparam juntas e inflam o `PTS_PREMISSAS` de um outcome que **o mercado já
+precifica** — dupla contagem, não edge. As premissas que já são relativas à liga (`ritmo_alto`, via
+`league_pace_median`) não sofrem disso.
+
+Ambiente real, 760 jogos FT por liga-temporada (`/fixtures`, seasons 2024 e 2025):
+
+| liga | gols/jogo | Δ vs baseline | Over 2.5 | Δ | clean sheet | viés esperado |
+|---|---|---|---|---|---|---|
+| Premier League (39) | 2,84 | **+0,36** | 55,8% | **+9,1pp** | 43,3% | superpontua **Over** |
+| La Liga (140) | 2,66 | +0,17 | 49,3% | +2,6pp | 44,6% | leve, pró-Over |
+| Serie A ITA (135) | 2,49 | +0,01 | 47,0% | +0,3pp | 51,6% | — (na baseline) |
+| **Brasileirão (71)** | **2,48** | — | **46,7%** | — | 49,7% | *baseline* |
+| Série B (72) | 2,20 | **−0,28** | 38,6% | **−8,2pp** | 53,3% | superpontua **Under** |
+
+Observação contraintuitiva registrada no rollout da Serie A ITA: a fama de "liga de poucos gols"
+é folclore do catenaccio — a Serie A moderna é a liga **mais próxima da baseline** de todo o
+portfólio. O desvio real está em Premier League e Série B, ambas em produção.
+
+**Item aberto (Fase 5):** tornar os cinco thresholds relativos à mediana da própria liga-temporada,
+replicando o padrão do `league_pace_median` que já existe em `int_futebol_premissas_ou`. Isso
+autocalibra qualquer liga futura e dispensa tabela de constantes por liga. Validar com backtest
+RPS/CLV antes de aplicar — muda o comportamento de ligas já em produção.
+
 ### 12.3 — Handicap asiático, meia-linha (`market_id` 4)
 `H` = handicap na ótica do mandante. **Valor quando** a supremacia real difere do que a linha pede (favorito dando handicap; azarão recebendo).
 


### PR DESCRIPTION
Resolve a **Task 0** da revisão da metodologia ([ClickUp `wdx6zev64w`](https://app.clickup.com/t/wdx6zev64w)): 27 das 39 premissas dos 5 mercados liam dado posterior ao jogo.

## As duas fontes contaminadas

- **`fact_team_season_stats`** tem um único snapshot por (time, liga, season). Para 2024/2025 é a temporada **fechada** (`played_total`=38) aplicada a jogos da rodada 1 — ~51% de cada média era futuro e 100% dos jogos tinham o próprio resultado dentro da média.
- **`standings_latest`** pegava `MAX(snapshot_date)` sem âncora no kickoff, ou seja, a tabela final.

## O que muda

| Item | Correção |
|---|---|
| A + B2 | Novo **`int_futebol_team_form_pit`** (grão fixture×time) reconstrói do `fact_fixtures` só com jogos anteriores ao kickoff — agregados de time **e** tabela do campeonato no instante do jogo |
| C | xG e ritmo do O/U ancorados no kickoff, replicando o padrão que o `_1x2` já usava |
| D | `int_futebol_desfalques` filtra `extracted_at < kickoff_utc` — **99,6% das ~174 mil linhas de `/injuries` foram coletadas depois do apito** |
| E | `is_important` virou point-in-time (window cumulativa) |

**Nenhum peso ou threshold foi alterado.** Muda só qual dado entra.

## Validação

- `dbt build` verde (PASS=63; o único WARN é pré-existente), mais dois guards de regressão novos.
- O PIT bate com a tabela real da API (Brasileirão 2026): **56/63 pontos e 55/63 ranks exatos**.
- **Produção não muda**: em jogos futuros a diferença média é de **0,003 gol/jogo** — para um jogo que não aconteceu, "tudo antes do kickoff" é "a temporada até agora".
- Prova cruzada: as **11 premissas classificadas como limpas mudaram exatamente 0%**; as 27 contaminadas mudaram todas.

## Consequência (§14 do `MOTOR_SCORE_CONFIABILIDADE.md`)

A porta de "2+ premissas" sai de **+9,2% de ROI para −7,6%**. Antes o ROI subia monotonicamente com o número de premissas (assinatura de vazamento); depois fica plano entre −6% e −9%.

Achado adicional: com piso de 5 jogos disputados, **a base contaminada já dava −3,9%** — os +9,7% vinham das linhas de amostra curta (Copa do Mundo é 39% do universo, com média de 2,4 jogos).

## Notas

- O primeiro commit é o rollout da **Serie A ITA**, que estava pronto e não commitado na working tree — separado para a história ficar limpa.
- Requer o PR par em `data-engineering` que adiciona `int_futebol_team_form_pit` ao `--select` dos workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)