### PR TITLE
Task [0.1]: Teste 2 completo, Teste 4 com controle temporal e varredura de edge

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -67,7 +67,8 @@ fair probabilities.
 The fair probability a value claim must beat. It has three possible benchmarks, in
 descending order of trust: **sharp** (de-vigged Pinnacle, for 1X2/OU/AH), **derivada**
 (computed from Pinnacle's 1X2 de-vig, the only source for Dupla Chance) and
-**consenso**. Only the first two are anchored on a sharp price.
+**consenso**. Only the first two are anchored on a sharp price; note the data stamps
+derivada as `pinnacle` too, so the three-way split exists only where analysis makes it.
 
 **Sharp**:
 Pinnacle, the reference bookmaker. "Linha sharp" is its price; its movement toward our
@@ -136,8 +137,7 @@ Pilar A is this rules engine. Pilar B is the future proper statistical model
 
 ### Measurement and calibration
 
-The vocabulary of the methodology review. Mixing these up is expensive: each Teste
-answers a different question, and only one of them can justify a weight.
+Each Teste answers a different question, and only one of them can justify a weight.
 
 **Point-in-time (PIT)**:
 An aggregate over a team's fixtures rebuilt from only the matches that kicked off
@@ -155,8 +155,8 @@ Answers "does it predict the line?". Needs no odds, so it runs on the full histo
 
 **Teste 2**:
 A premissa's hit rate where it fired, minus the fair probability the price implied on
-those same lines. Answers "does it beat the price?" — the only Teste that can justify
-a weight. Needs odds, so it runs only on the odds era.
+those same lines. Answers "does it beat the price?" — the only Teste that may justify a
+weight, and it runs only on the odds era.
 
 **Teste 3**:
 The ROI of a gate (e.g. "2+ premissas acesas") at flat stakes on the best odd.
@@ -173,12 +173,11 @@ Confiabilidade — whose weights are hand-set.
 _Avoid_: score (reserved for the Score de Confiabilidade)
 
 **Peso de catálogo / peso medido**:
-The point weight a premissa carries in production is a peso de catálogo — chosen by
-hand, never derived. A peso medido comes from that premissa's Teste 2 gain on the base
-limpa. No peso de catálogo may be rewritten from a peso medido without an
-out-of-sample control (see ADR 0001).
+A peso de catálogo is the point weight a premissa carries in production, chosen by hand
+and never derived; a peso medido comes from that premissa's Teste 2 gain. Rewriting the
+first from the second requires an out-of-sample control (ADR 0001).
 
 **Amostra curta**:
 A fixture whose teams have played too few matches for a season aggregate to mean
-anything — structural in knockout competitions. Established cause of fabricated
-signal, not a nuisance to be filtered quietly.
+anything — structural in knockout competitions, and an established cause of fabricated
+signal.

--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -64,8 +64,10 @@ Removing the bookmaker margin (overround) from a market's full set of odds to ob
 fair probabilities.
 
 **Prob justa de fechamento**:
-The fair probability obtained by de-vigging Pinnacle's closing odds — the benchmark
-any value claim must beat.
+The fair probability a value claim must beat. It has three possible benchmarks, in
+descending order of trust: **sharp** (de-vigged Pinnacle, for 1X2/OU/AH), **derivada**
+(computed from Pinnacle's 1X2 de-vig, the only source for Dupla Chance) and
+**consenso**. Only the first two are anchored on a sharp price.
 
 **Sharp**:
 Pinnacle, the reference bookmaker. "Linha sharp" is its price; its movement toward our
@@ -131,3 +133,52 @@ Head-to-head history between the two teams.
 **Pilar A / Pilar B**:
 Pilar A is this rules engine. Pilar B is the future proper statistical model
 (Dixon-Coles + xG) — out of scope today; when it exists it becomes corroboration.
+
+### Measurement and calibration
+
+The vocabulary of the methodology review. Mixing these up is expensive: each Teste
+answers a different question, and only one of them can justify a weight.
+
+**Point-in-time (PIT)**:
+An aggregate over a team's fixtures rebuilt from only the matches that kicked off
+before the fixture being rated. The default for anything the Score reads.
+_Avoid_: histórico, média da temporada (both are silent about where the cut is)
+
+**Base limpa / base contaminada**:
+The premissa data as recomputed point-in-time, versus the same data before that
+correction. The contaminated state is kept only to audit the difference — no
+conclusion may rest on it.
+
+**Teste 1**:
+A premissa's hit rate where it fired, minus the average hit rate of comparable lines.
+Answers "does it predict the line?". Needs no odds, so it runs on the full history.
+
+**Teste 2**:
+A premissa's hit rate where it fired, minus the fair probability the price implied on
+those same lines. Answers "does it beat the price?" — the only Teste that can justify
+a weight. Needs odds, so it runs only on the odds era.
+
+**Teste 3**:
+The ROI of a gate (e.g. "2+ premissas acesas") at flat stakes on the best odd.
+Answers "does a counting rule select bets?".
+
+**Teste 4**:
+The ROI by band of nota ponderada. Answers "does the score *order* bets?" — the
+product question, which counting never asked.
+
+**Nota ponderada**:
+A 0–100 rating built from premissas weighted by their measured Teste 2 gain and
+normalised per mercado. It exists only in analysis, and is not the Score de
+Confiabilidade — whose weights are hand-set.
+_Avoid_: score (reserved for the Score de Confiabilidade)
+
+**Peso de catálogo / peso medido**:
+The point weight a premissa carries in production is a peso de catálogo — chosen by
+hand, never derived. A peso medido comes from that premissa's Teste 2 gain on the base
+limpa. No peso de catálogo may be rewritten from a peso medido without an
+out-of-sample control (see ADR 0001).
+
+**Amostra curta**:
+A fixture whose teams have played too few matches for a season aggregate to mean
+anything — structural in knockout competitions. Established cause of fabricated
+signal, not a nuisance to be filtered quietly.

--- a/dbt_futebol/analyses/task01_edge.sql
+++ b/dbt_futebol/analyses/task01_edge.sql
@@ -1,0 +1,143 @@
+{#
+    Task [0.1] — VARREDURA DE EDGE.  Ticket #7 (Pedido 3 da task), spec #3.
+
+    A pergunta do Pedido 3: barrar linha cujo preço está muito pior que o justo muda o
+    ROI, ou é neutro? Se for neutro, o filtro proposto na A3 é proteção de reputação e
+    não de performance.
+
+    O número que justificava aquele filtro foi medido na BASE CONTAMINADA (a regra
+    testada era "2 premissas mais limite de preço"), então morreu junto com o resto.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    Por que decil e não dois pontos: a tabela do Teste 3 já mostra que preço COMO PORTA
+    piora — exigir edge positivo dá −12,3% contra −10,2% de apostar tudo. O Pedido 3
+    pergunta pela cauda OPOSTA. As duas podem ser verdade ao mesmo tempo: a relação
+    entre preço e retorno não precisa ser monótona, e dois pontos soltos não mostram o
+    formato dela.
+
+    Este ticket não consome peso nenhum, então é independente dos Testes 2 e 4.
+    ────────────────────────────────────────────────────────────────────────────────
+    Duas quebras acompanham cada corte, pelo que os tickets anteriores acharam:
+
+    · PISO DE AMOSTRA — no Teste 2 o piso inverteu os três maiores sinais. Se ele também
+      mexer aqui, "preço não seleciona" pode ser efeito de composição e não de preço.
+    · BENCHMARK — o edge é calculado contra a prob justa, e a fonte dela muda por
+      mercado. No Handicap o ROI das linhas sharp é −6,5 e o das consenso é −26,7. Um
+      corte de edge aplicado ao conjunto todo é, em parte, um corte de benchmark
+      disfarçado.
+
+    → RESULTADOS: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_edge
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_edge.sql
+#}
+
+WITH {{ task01_base() }},
+
+{#- EXCLUSÃO OBRIGATÓRIA aqui: as linhas de conjunto incompleto têm prob_justa = 1,0 por
+    construção, logo edge = odd − 1. Elas não são medições de valor, são um artefato do
+    de-vig de consenso, e ficam INTEIRAS no topo da distribuição de edge — deixá-las
+    dentro tornaria a varredura de edge uma varredura do artefato. São 172 linhas com 2
+    vitórias em 172 e ROI −35,5%.
+
+    O bloco D abaixo mede o tamanho do que foi tirado, para que a exclusão seja auditável
+    e não silenciosa. -#}
+apostas_validas AS (
+    SELECT * FROM apostas WHERE NOT conjunto_incompleto
+),
+
+com_decil AS (
+    SELECT
+        a.*,
+        NTILE(10) OVER (ORDER BY a.edge) AS decil
+    FROM apostas_validas AS a
+),
+
+{#- Decis do edge sobre o universo inteiro. A coluna de piso 5 mede DENTRO das mesmas
+    fronteiras de decil — reparticionar o conjunto filtrado daria decis diferentes e as
+    duas colunas deixariam de ser comparáveis. -#}
+decis AS (
+    SELECT
+        'A. decil de edge'                                          AS bloco,
+        CONCAT('decil ', LPAD(CAST(decil AS STRING), 2, '0'))        AS corte,
+        ROUND(MIN(edge) * 100, 1)                                   AS edge_min,
+        ROUND(MAX(edge) * 100, 1)                                   AS edge_max,
+        COUNT(*)                                                    AS n_p0,
+        ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS roi_p0,
+        COUNTIF(min_jogos >= 5)                                     AS n_p5,
+        ROUND(SAFE_DIVIDE(SUM(IF(ganhou AND min_jogos >= 5, best_odd, 0)),
+                          COUNTIF(min_jogos >= 5)) * 100 - 100, 1)  AS roi_p5
+    FROM com_decil
+    GROUP BY decil
+),
+
+{#- Cortes nomeados. O primeiro é o universo sem filtro (referência), e os seguintes vão
+    afrouxando o piso de edge até a regra de hoje. -#}
+cortes AS (
+    {%- set limites = [
+        ('a. sem filtro (referencia)',      -999.0),
+        ('b. edge > -30%',                    -0.30),
+        ('c. edge > -20%',                    -0.20),
+        ('d. edge > -10%',                    -0.10),
+        ('e. edge >  -5%',                    -0.05),
+        ('f. edge >   0%  (regra de hoje)',    0.00)
+    ] -%}
+    {%- for rotulo, lim in limites %}
+    {%- if not loop.first %}
+    UNION ALL
+    {%- endif %}
+    SELECT
+        'B. corte de edge' AS bloco,
+        '{{ rotulo }}'     AS corte,
+        ROUND(MIN(edge) * 100, 1)                                   AS edge_min,
+        ROUND(MAX(edge) * 100, 1)                                   AS edge_max,
+        COUNT(*)                                                    AS n_p0,
+        ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS roi_p0,
+        COUNTIF(min_jogos >= 5)                                     AS n_p5,
+        ROUND(SAFE_DIVIDE(SUM(IF(ganhou AND min_jogos >= 5, best_odd, 0)),
+                          COUNTIF(min_jogos >= 5)) * 100 - 100, 1)  AS roi_p5
+    FROM apostas_validas
+    WHERE edge > {{ lim }}
+    {%- endfor %}
+),
+
+{#- O mesmo corte, quebrado por benchmark: separa "o preço seleciona" de "a Pinnacle
+    escolhe quais jogos precificar". -#}
+por_benchmark AS (
+    SELECT
+        'C. benchmark'                                              AS bloco,
+        CONCAT(benchmark, faixa)                                    AS corte,
+        ROUND(MIN(edge) * 100, 1)                                   AS edge_min,
+        ROUND(MAX(edge) * 100, 1)                                   AS edge_max,
+        COUNT(*)                                                    AS n_p0,
+        ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS roi_p0,
+        COUNTIF(min_jogos >= 5)                                     AS n_p5,
+        ROUND(SAFE_DIVIDE(SUM(IF(ganhou AND min_jogos >= 5, best_odd, 0)),
+                          COUNTIF(min_jogos >= 5)) * 100 - 100, 1)  AS roi_p5
+    FROM (
+        SELECT *, IF(edge > 0, ' · edge > 0', ' · tudo') AS faixa
+        FROM apostas_validas
+    )
+    GROUP BY benchmark, faixa
+),
+
+{#- Auditoria da exclusão: o que foi tirado dos blocos A-C, para a exclusão não ser
+    silenciosa. Espera-se ROI muito ruim e edge absurdo — é a assinatura do artefato. -#}
+descartado AS (
+    SELECT 'D. excluido do bloco A-C' AS bloco,
+           'conjunto de saidas incompleto' AS corte,
+           ROUND(MIN(edge) * 100, 1) AS edge_min, ROUND(MAX(edge) * 100, 1) AS edge_max,
+           COUNT(*) AS n_p0,
+           ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS roi_p0,
+           COUNTIF(min_jogos >= 5) AS n_p5,
+           ROUND(SAFE_DIVIDE(SUM(IF(ganhou AND min_jogos >= 5, best_odd, 0)),
+                             COUNTIF(min_jogos >= 5)) * 100 - 100, 1) AS roi_p5
+    FROM apostas WHERE conjunto_incompleto
+)
+
+SELECT * FROM decis
+UNION ALL SELECT * FROM cortes
+UNION ALL SELECT * FROM por_benchmark
+UNION ALL SELECT * FROM descartado
+ORDER BY bloco, corte

--- a/dbt_futebol/analyses/task01_estabilidade.sql
+++ b/dbt_futebol/analyses/task01_estabilidade.sql
@@ -1,0 +1,88 @@
+{#
+    Task [0.1] — separa as DUAS hipóteses que a reconciliação não consegue distinguir
+    sozinha.  Ticket #4, spec #3.
+
+    Quando `task01_reconciliacao.sql` acusa delta, há duas explicações possíveis:
+
+      (1) a máquina generalizada quebrou a lógica;
+      (2) as tabelas de origem não são estáveis entre rebuilds.
+
+    Esta análise ataca a (2) diretamente, e o faz com CONTROLE — não por eliminação.
+
+    COMO: o dataset `futebol_task0` guarda o estado das premissas congelado em
+    2026-08-03, salvo durante a Task [0] para auditoria. Ele é referenciado por caminho
+    literal, e não por `ref()`, porque está deliberadamente fora do DAG do dbt: é um
+    snapshot morto, ninguém o reconstrói.
+
+    A comparação só é legítima para as premissas que a Task [0] NÃO alterou. As outras
+    nove mudaram de propósito (passaram a ler `int_futebol_team_form_pit` e o spine
+    ancorado no kickoff), então qualquer diferença nelas é a correção, não instabilidade.
+    Elas vão na saída assim mesmo, marcadas — servem de referência para o tamanho da
+    correção, e a ausência delas esconderia que a comparação é parcial.
+
+    A LEITURA: entre as quatro "já eram limpas", duas leem `fact_odds_snapshot`
+    (`linha_subindo`/`linha_descendo`) e duas leem histórico de jogos
+    (`historico_over`/`historico_under`). Se só as duas primeiras se mexerem, a
+    instabilidade tem endereço e causa, e não é hipótese.
+
+    → RESULTADOS DAS EXECUÇÕES: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_estabilidade
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_estabilidade.sql
+#}
+
+{%- set premissas_ou = [
+    ('linha_subindo',      'A. ja era limpa — LE ODDS'),
+    ('linha_descendo',     'A. ja era limpa — LE ODDS'),
+    ('historico_over',     'B. ja era limpa — le historico (CONTROLE)'),
+    ('historico_under',    'B. ja era limpa — le historico (CONTROLE)'),
+    ('ataque_combinado',   'C. corrigida na Task 0 (diferenca esperada)'),
+    ('defesas_firmes',     'C. corrigida na Task 0 (diferenca esperada)'),
+    ('defesas_vazaveis',   'C. corrigida na Task 0 (diferenca esperada)'),
+    ('clean_sheets_altos', 'C. corrigida na Task 0 (diferenca esperada)'),
+    ('ataques_fracos',     'C. corrigida na Task 0 (diferenca esperada)'),
+    ('ambos_vazam',        'C. corrigida na Task 0 (diferenca esperada)'),
+    ('xg_combinado_alto',  'C. corrigida na Task 0 (diferenca esperada)'),
+    ('xg_baixo_combinado', 'C. corrigida na Task 0 (diferenca esperada)'),
+    ('ritmo_alto',         'C. corrigida na Task 0 (diferenca esperada)')
+] -%}
+
+WITH par AS (
+    SELECT
+        u.classe,
+        u.premissa,
+        u.antes,
+        u.depois
+    FROM `smartbetting-dados.futebol_task0.int_futebol_premissas_ou_before` AS o
+    JOIN {{ ref('int_futebol_premissas_ou') }} AS h
+      USING (fixture_id, outcome, line_value)
+    CROSS JOIN UNNEST([
+        {%- for col, classe in premissas_ou %}
+        STRUCT('{{ classe }}' AS classe, '{{ col }}' AS premissa,
+               o.{{ col }} AS antes, h.{{ col }} AS depois){{ "," if not loop.last }}
+        {%- endfor %}
+    ]) AS u
+)
+
+SELECT
+    classe,
+    premissa,
+    COUNT(*)                    AS linhas_comparadas,
+    COUNTIF(antes != depois)    AS flips,
+    ROUND(SAFE_DIVIDE(COUNTIF(antes != depois), COUNT(*)) * 100, 3) AS pct_flips,
+    -- A conclusão só é válida se as duas linhas de CONTROLE derem exatamente zero. Se
+    -- o controle se mexer, a explicação não é "lê odds" — é alguma outra coisa, e esta
+    -- análise não a encontrou.
+    CASE
+        WHEN classe LIKE 'B.%' AND COUNTIF(antes != depois) > 0
+            THEN 'CONTROLE QUEBROU — a leitura abaixo nao se sustenta'
+        WHEN classe LIKE 'A.%' AND COUNTIF(antes != depois) > 0
+            THEN 'instabilidade confirmada'
+        WHEN classe LIKE 'A.%'
+            THEN 'estavel nesta janela'
+        ELSE '—'
+    END AS leitura
+FROM par
+GROUP BY classe, premissa
+ORDER BY classe, flips DESC

--- a/dbt_futebol/analyses/task01_premissa_forte.sql
+++ b/dbt_futebol/analyses/task01_premissa_forte.sql
@@ -1,0 +1,146 @@
+{#
+    Task [0.1] — A VARIANTE DE PREMISSA FORTE, in-sample contra out-of-sample.
+    Ticket #9, spec #3.
+
+    ════════════════════════════════════════════════════════════════════════════════
+    POR QUE ESTA ANÁLISE EXISTE SEPARADA
+
+    O `task01_teste4_piso.sql` mostrou que exigir ao menos uma premissa "forte" produz
+    o PRIMEIRO ROI positivo de toda a investigação: +10,0% no piso 0, +7,5% no piso 5,
+    +8,3% no piso 10, sobre 1.200 a 1.300 apostas.
+
+    Esse número não pode ser reportado como está. "Forte" é definido pelo ganho do
+    Teste 2 medido NOS MESMOS DADOS em que o ROI é medido. Selecionar apostas por um
+    critério ajustado à amostra e depois avaliar na mesma amostra é exatamente o
+    procedimento que produziu os +9,7% que a Task [0] matou — trocado de vazamento
+    temporal por vazamento de seleção, mas o mesmo erro.
+
+    Esta análise faz a única pergunta que dá sentido àquele número:
+
+        Se "forte" for decidido SÓ com a 1a metade da janela, o filtro ainda paga
+        na 2a metade?
+
+    Se sim, é o achado mais importante da task. Se não, é o artefato se repetindo com
+    roupa nova — e é melhor descobrir aqui do que num comentário publicado.
+    ════════════════════════════════════════════════════════════════════════════════
+    Quatro linhas por piso, e a comparação que importa é a 3a contra a 4a:
+
+      1. todas as apostas, 2a metade                  <- referência
+      2. forte definido em TODA a janela, ROI em toda <- in-sample (o numero de cima)
+      3. forte definido em TODA a janela, ROI na 2a   <- ainda contaminado (H2 ⊂ tudo)
+      4. forte definido só na 1a metade, ROI na 2a    <- OUT-OF-SAMPLE de verdade
+
+    → RESULTADOS: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_premissa_forte
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_premissa_forte.sql
+#}
+
+{%- set pisos = [0, 5, 10] -%}
+{%- set limiar = 5 -%}
+
+WITH {{ task01_base() }},
+
+validas AS (
+    SELECT * FROM apostas WHERE NOT conjunto_incompleto
+),
+
+metades AS (
+    SELECT fixture_id, NTILE(2) OVER (ORDER BY kickoff_utc, fixture_id) AS metade
+    FROM (SELECT DISTINCT fixture_id, kickoff_utc FROM validas)
+),
+
+linhas AS (
+    SELECT a.*, m.metade, pl.premissa, pl.acesa
+    FROM validas AS a
+    JOIN metades AS m USING (fixture_id)
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+),
+
+{#- Ganho do Teste 2 por (piso, janela de ajuste). `janela` = 'tudo' ou 'h1'. -#}
+ganhos AS (
+    {%- set combos = [] -%}
+    {%- for piso in pisos -%}
+        {%- for jf in [('tudo', 'TRUE'), ('h1', 'metade = 1')] -%}
+            {%- set _ = combos.append((piso, jf[0], jf[1])) -%}
+        {%- endfor -%}
+    {%- endfor -%}
+    {%- for piso, janela, filtro in combos %}
+    {%- if not loop.first %}
+    UNION ALL
+    {%- endif %}
+    SELECT
+        {{ piso }} AS piso, '{{ janela }}' AS janela, market_id, premissa,
+        (AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+       - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100 AS ganho,
+        COUNTIF(acesa)                                      AS n_ajuste
+    FROM linhas
+    WHERE min_jogos >= {{ piso }}
+      AND {{ filtro }}
+      AND benchmark = CASE market_id WHEN 12 THEN 'derivada'
+                                     WHEN 8  THEN 'consenso'
+                                     ELSE         'sharp' END
+    GROUP BY market_id, premissa
+    {%- endfor %}
+),
+
+{#- Uma aposta "tem forte" se alguma premissa acesa nela tem ganho >= limiar, segundo a
+    janela de ajuste em questão. -#}
+apostas_forte AS (
+    SELECT
+        l.fixture_id, l.market_id, l.outcome_side, l.line_value, l.metade, l.min_jogos,
+        g.piso, g.janela,
+        LOGICAL_OR(l.acesa AND g.ganho >= {{ limiar }})       AS tem_forte,
+        IF(ANY_VALUE(l.ganhou), ANY_VALUE(l.best_odd), 0) - 1 AS lucro
+    FROM linhas AS l
+    JOIN ganhos AS g
+      ON g.market_id = l.market_id AND g.premissa = l.premissa
+    WHERE l.min_jogos >= g.piso
+    GROUP BY l.fixture_id, l.market_id, l.outcome_side, l.line_value,
+             l.metade, l.min_jogos, g.piso, g.janela
+),
+
+cenarios AS (
+    SELECT piso, '1. todas as apostas, 2a metade' AS cenario, lucro, fixture_id
+    FROM apostas_forte WHERE janela = 'tudo' AND metade = 2
+
+    UNION ALL
+    SELECT piso, '2. forte de TODA a janela, ROI em toda (IN-SAMPLE)', lucro, fixture_id
+    FROM apostas_forte WHERE janela = 'tudo' AND tem_forte
+
+    UNION ALL
+    SELECT piso, '3. forte de TODA a janela, ROI na 2a metade', lucro, fixture_id
+    FROM apostas_forte WHERE janela = 'tudo' AND tem_forte AND metade = 2
+
+    UNION ALL
+    SELECT piso, '4. forte so da 1a metade, ROI na 2a (OUT-OF-SAMPLE)', lucro, fixture_id
+    FROM apostas_forte WHERE janela = 'h1' AND tem_forte AND metade = 2
+),
+
+media AS (
+    SELECT piso, cenario, AVG(lucro) AS m FROM cenarios GROUP BY piso, cenario
+),
+resid AS (
+    SELECT c.piso, c.cenario, c.fixture_id, SUM(c.lucro - m.m) AS r
+    FROM cenarios AS c JOIN media AS m USING (piso, cenario)
+    GROUP BY 1, 2, 3
+)
+
+SELECT
+    CONCAT('piso ', LPAD(CAST(c.piso AS STRING), 2, '0')) AS corte,
+    c.cenario,
+    COUNT(*)                                              AS n_apostas,
+    COUNT(DISTINCT c.fixture_id)                          AS n_jogos,
+    ROUND(AVG(c.lucro) * 100, 1)                          AS roi,
+    -- erro-padrão agrupado por fixture
+    ROUND(SAFE_DIVIDE(SQRT(ANY_VALUE(e.soma_quad)), COUNT(*)) * 100, 1) AS ep_cluster
+FROM cenarios AS c
+JOIN (SELECT piso, cenario, SUM(POW(r, 2)) AS soma_quad FROM resid GROUP BY 1, 2) AS e
+  USING (piso, cenario)
+GROUP BY c.piso, c.cenario
+ORDER BY corte, cenario

--- a/dbt_futebol/analyses/task01_reconciliacao.sql
+++ b/dbt_futebol/analyses/task01_reconciliacao.sql
@@ -1,0 +1,211 @@
+{#
+    Task [0.1] — SEAM 1: reconciliação por resposta conhecida.  Ticket #4, spec #3.
+
+    Roda a máquina GENERALIZADA (`task01_base`) restrita ao escopo que já foi publicado
+    e mostra esperado vs obtido. Verde significa duas coisas, e as duas são necessárias
+    antes de qualquer análise a jusante:
+
+      1. generalizar para os 5 mercados não quebrou a lógica de gate nem de liquidação;
+      2. as tabelas de premissa e odds são ESTÁVEIS entre rebuilds — nunca verificado,
+         e toda conclusão histórica depende disso.
+
+    Divergência não é necessariamente bug: pode ser instabilidade de tabela. As duas
+    hipóteses são separáveis pelo `n` que vai ao lado de cada linha — valor diferente
+    com amostra igual é lógica; amostra diferente é universo.
+
+    Corte congelado em 2026-08-02, que é a janela dos números publicados (16/06 a 02/08).
+
+    ────────────────────────────────────────────────────────────────────────────────
+    RESULTADO DA PRIMEIRA EXECUÇÃO (2026-08-04) — a máquina está certa, a base não é
+    estável:
+
+      · 22 das 25 linhas com delta EXATAMENTE 0,0, incluindo as 6 do Teste 2 e 4 dos 5
+        mercados (Dupla Chance inclusive bate o n=154 publicado).
+      · Só o mercado de GOLS derivou: −6,9 contra −7,3 publicado. A deriva agregada dos
+        cortes 2+/3+ é inteiramente explicada por ele (Gols é 2.182 das 4.066 apostas).
+      · Confirmado que não é regressão da generalização: a query ad-hoc original, rodada
+        hoje sem alterar um byte, também devolve −7,4 onde ontem devolveu −7,6.
+
+    CAUSA: o Gols é o ÚNICO dos 5 mercados com premissa derivada de odd. `linha_subindo`
+    e `linha_descendo` leem `fact_odds_snapshot` direto (média das probabilidades
+    implícitas de todas as casas, t24h -> t15m), e o modelo ainda monta o universo de
+    linhas a partir das odds presentes. Toda vez que a tabela de odds muda, essas duas
+    premissas podem virar, `n_prem` muda e o ROI dos cortes por contagem muda junto.
+    1X2, Handicap, BTTS e Dupla Chance não leem odd em premissa nenhuma — e são
+    exatamente os quatro que reproduziram byte a byte.
+
+    MEDIDO, contra o snapshot congelado `futebol_task0` (as duas premissas de linha "já
+    eram limpas" na Task 0, logo o `_before` guarda o valor de ontem):
+
+        linha_descendo                       20 flips / 50.608 linhas
+        linha_subindo                        16 flips / 50.608 linhas
+        historico_over    (controle limpo)    0 flips
+        historico_under   (controle limpo)    0 flips
+
+    O controle fecha o argumento: `historico_over/under` estão na MESMA classe de
+    premissa não afetada pela correção da Task 0, mas leem histórico em vez de odd — e
+    não mexeram uma linha.
+
+    CONSEQUÊNCIA p/ os tickets a jusante:
+
+      1. Número de Gols só é comparável entre execuções se a data de build for
+         registrada junto. Todo relatório desta task precisa carimbar o `dbt_loaded_at`
+         das tabelas de origem.
+      2. 0,07% das linhas viraram e isso moveu o ROI do mercado em 0,4pp — porque a
+         porta é um LIMIAR: uma linha que vai de n_prem=1 p/ 2 entra inteira no
+         universo. Vale checar no Teste 4 se a nota ponderada, sendo contínua, é menos
+         sensível a esse ruído que a porta de contagem. Se for, é um argumento a favor
+         dela que ninguém levantou ainda — e que não depende do resultado de ROI.
+    ────────────────────────────────────────────────────────────────────────────────
+
+    Rodar com:
+      dbt compile --select path:analyses/task01_reconciliacao.sql
+      e executar o SQL de target/compiled/... no BigQuery
+#}
+
+WITH {{ task01_base(cutoff='2026-08-02') }},
+
+-- Teste 3: ROI de cada porta, stake fixa na melhor odd.
+teste3 AS (
+    SELECT 'Teste 3' AS bloco, 'a. universo sem porta' AS metrica,
+           COUNT(*) AS n, -10.2 AS esperado,
+           ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS obtido
+    FROM bets
+
+    UNION ALL
+    SELECT 'Teste 3', 'b. 2+ premissas',
+           COUNT(*), -7.6,
+           ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
+    FROM bets WHERE n_prem >= 2
+
+    UNION ALL
+    SELECT 'Teste 3', 'c. 3+ premissas',
+           COUNT(*), -6.0,
+           ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
+    FROM bets WHERE n_prem >= 3
+
+    UNION ALL
+    SELECT 'Teste 3', 'd. regra de hoje (edge > 0)',
+           COUNT(*), -12.3,
+           ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
+    FROM bets WHERE edge > 0
+
+    UNION ALL
+    SELECT 'Teste 3', 'e. edge > 0 e 2+ premissas',
+           COUNT(*), -15.4,
+           ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
+    FROM bets WHERE edge > 0 AND n_prem >= 2
+),
+
+-- Teste 3 por mercado, na porta "2+ premissas". Localiza a deriva: se só um mercado
+-- se mover, a instabilidade tem endereço.
+teste3_mercado AS (
+    SELECT
+        'Teste 3 por mercado (2+)' AS bloco,
+        CASE b.market_id
+            WHEN 1  THEN 'a. 1X2'
+            WHEN 5  THEN 'b. Gols'
+            WHEN 4  THEN 'c. Handicap'
+            WHEN 8  THEN 'd. BTTS'
+            WHEN 12 THEN 'e. Dupla Chance'
+        END AS metrica,
+        COUNT(*) AS n,
+        ANY_VALUE(m.esperado) AS esperado,
+        ROUND((SUM(IF(b.ganhou, b.best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS obtido
+    FROM bets AS b
+    JOIN UNNEST([
+        STRUCT(1  AS market_id, -2.5 AS esperado),
+        STRUCT(5  AS market_id, -7.3 AS esperado),
+        STRUCT(4  AS market_id, -9.9 AS esperado),
+        STRUCT(8  AS market_id, -1.1 AS esperado),
+        STRUCT(12 AS market_id,  1.4 AS esperado)
+    ]) AS m
+      ON m.market_id = b.market_id
+    WHERE b.n_prem >= 2
+    GROUP BY b.market_id
+),
+
+-- Teste 2 do mercado de Gols, contra benchmark sharp (o mesmo filtro da rodada
+-- anterior, que exigia valor_fonte='pinnacle'). Métrica: acerto médio menos prob justa
+-- média, nas linhas em que a premissa acendeu.
+teste2_gols AS (
+    SELECT
+        'Teste 2 (Gols)' AS bloco,
+        pl.premissa      AS metrica,
+        COUNTIF(pl.acesa) AS n,
+        e.esperado,
+        ROUND((AVG(IF(pl.acesa, CAST(b.ganhou AS INT64), NULL))
+             - AVG(IF(pl.acesa, b.prob_justa_fechamento, NULL))) * 100, 1) AS obtido
+    FROM bets AS b
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = b.market_id
+      AND pl.fixture_id                 = b.fixture_id
+      AND pl.outcome_side               = b.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(b.line_value, -999)
+    JOIN UNNEST([
+        STRUCT('clean_sheets_altos' AS premissa,  16.9 AS esperado),
+        STRUCT('defesas_firmes'     AS premissa,   3.4 AS esperado),
+        STRUCT('xg_combinado_alto'  AS premissa,  -2.6 AS esperado),
+        STRUCT('ataque_combinado'   AS premissa,  -3.6 AS esperado),
+        STRUCT('defesas_vazaveis'   AS premissa,  -5.2 AS esperado),
+        STRUCT('ambos_vazam'        AS premissa,  -3.7 AS esperado)
+    ]) AS e
+      ON e.premissa = pl.premissa
+    WHERE b.market_id = 5
+      AND b.benchmark = 'sharp'
+    GROUP BY 1, 2, 4
+),
+
+cobertura AS (
+    SELECT 'Cobertura' AS bloco, 'a. jogos com odd' AS metrica,
+           COUNT(*) AS n, 168.0 AS esperado,
+           CAST(COUNT(DISTINCT fixture_id) AS FLOAT64) AS obtido
+    FROM bets
+
+    -- Se isto não for zero, a degradação graciosa falhou em algum lugar: contar
+    -- premissas por SUM(CAST(bool AS INT64)) (a query original) propaga NULL e derruba
+    -- a linha inteira de toda porta, enquanto COUNTIF não. Aí o número publicado não é
+    -- reproduzível por construção, e não por erro meu.
+    UNION ALL
+    SELECT 'Cobertura', 'b. linhas com premissa NULL',
+           COUNT(*), 0.0,
+           CAST(SUM(n_prem_null) AS FLOAT64)
+    FROM bets
+),
+
+-- Informativo: onde procurar, se algo acima divergir. Sem valor publicado p/ comparar.
+-- Agrupa POR benchmark, não ANY_VALUE(benchmark): os mercados 4 e 5 são MISTOS (a
+-- Pinnacle cobre a maior parte, mas não todos os jogos), e um rótulo arbitrário por
+-- mercado esconderia exatamente a distinção que a task existe para tornar visível.
+por_mercado AS (
+    SELECT
+        'Cobertura por benchmark' AS bloco,
+        CONCAT('market ', CAST(market_id AS STRING), ' — ', benchmark) AS metrica,
+        COUNT(*) AS n,
+        CAST(NULL AS FLOAT64) AS esperado,
+        ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS obtido
+    FROM bets
+    GROUP BY market_id, benchmark
+)
+
+SELECT
+    bloco,
+    metrica,
+    n,
+    esperado,
+    obtido,
+    ROUND(obtido - esperado, 1) AS delta,
+    CASE
+        WHEN esperado IS NULL                        THEN '—'
+        WHEN ABS(obtido - esperado) < 0.05           THEN 'OK'
+        WHEN ABS(obtido - esperado) <= 0.3           THEN 'ATENCAO'
+        ELSE                                              'DIVERGE'
+    END AS status
+FROM (
+    SELECT * FROM teste3
+    UNION ALL SELECT * FROM teste3_mercado
+    UNION ALL SELECT * FROM teste2_gols
+    UNION ALL SELECT * FROM cobertura
+    UNION ALL SELECT * FROM por_mercado
+)
+ORDER BY bloco, metrica

--- a/dbt_futebol/analyses/task01_reconciliacao.sql
+++ b/dbt_futebol/analyses/task01_reconciliacao.sql
@@ -58,6 +58,14 @@
          dela que ninguém levantou ainda — e que não depende do resultado de ROI.
     ────────────────────────────────────────────────────────────────────────────────
 
+    ACHADO DA GUARDA DE DESCARTE (mesma execução): além do gap já conhecido da saída
+    '12' da Dupla Chance (168 linhas, 1 por jogo), o mercado 6 — Goals Over/Under First
+    Half — tinha 3.642 linhas de odd sumindo em silêncio na janela congelada. O Motor
+    não pontua gols do 1º tempo, então excluí-lo está certo; o problema era estar sendo
+    excluído POR ACIDENTE, pelo INNER JOIN com as premissas, e não por escopo declarado.
+    O macro passou a filtrar `market_id IN (1,4,5,8,12)` explicitamente. Todos os 25
+    números acima ficaram byte a byte iguais depois da mudança — era mesmo só acidente.
+
     Rodar com:
       dbt compile --select path:analyses/task01_reconciliacao.sql
       e executar o SQL de target/compiled/... no BigQuery
@@ -173,6 +181,33 @@ cobertura AS (
     FROM bets
 ),
 
+-- Guarda de descarte silencioso. O JOIN de `bets` com as premissas é INNER, então
+-- qualquer linha de odd sem premissa correspondente some sem aviso. Já sabemos de uma
+-- (a saída '12' da Dupla Chance, que o modelo de premissas não emite); esta guarda
+-- existe para que não haja uma segunda que ninguém viu. Esperado 0 em toda linha.
+descarte AS (
+    SELECT
+        'Descarte silencioso' AS bloco,
+        CONCAT('market ', CAST(o.market_id AS STRING), ' — ', o.outcome_side,
+               IF(o.market_id = 12 AND o.outcome_side = '12',
+                  '  (gap CONHECIDO, reportado)', '')) AS metrica,
+        COUNT(*) AS n,
+        0.0 AS esperado,
+        CAST(COUNTIF(b.fixture_id IS NULL) AS FLOAT64) AS obtido
+    FROM odds AS o
+    JOIN fx AS f
+      ON f.fixture_id = o.fixture_id
+    LEFT JOIN bets AS b
+      ON  b.market_id                  = o.market_id
+      AND b.fixture_id                 = o.fixture_id
+      AND b.outcome_side               = o.outcome_side
+      AND COALESCE(b.line_value, -999) = COALESCE(o.line_value, -999)
+    WHERE (o.market_id NOT IN (4, 5)
+           OR MOD(CAST(ABS(o.line_value) * 2 AS INT64), 2) = 1)
+    GROUP BY o.market_id, o.outcome_side
+    HAVING COUNTIF(b.fixture_id IS NULL) > 0
+),
+
 -- Informativo: onde procurar, se algo acima divergir. Sem valor publicado p/ comparar.
 -- Agrupa POR benchmark, não ANY_VALUE(benchmark): os mercados 4 e 5 são MISTOS (a
 -- Pinnacle cobre a maior parte, mas não todos os jogos), e um rótulo arbitrário por
@@ -206,6 +241,7 @@ FROM (
     UNION ALL SELECT * FROM teste3_mercado
     UNION ALL SELECT * FROM teste2_gols
     UNION ALL SELECT * FROM cobertura
+    UNION ALL SELECT * FROM descarte
     UNION ALL SELECT * FROM por_mercado
 )
 ORDER BY bloco, metrica

--- a/dbt_futebol/analyses/task01_reconciliacao.sql
+++ b/dbt_futebol/analyses/task01_reconciliacao.sql
@@ -7,7 +7,8 @@
 
       1. generalizar para os 5 mercados não quebrou a lógica de gate nem de liquidação;
       2. as tabelas de premissa e odds são ESTÁVEIS entre rebuilds — nunca verificado,
-         e toda conclusão histórica depende disso.
+         e toda conclusão histórica depende disso. Quando (2) falha, quem separa as
+         hipóteses é `task01_estabilidade.sql`, não esta análise.
 
     Divergência não é necessariamente bug: pode ser instabilidade de tabela. As duas
     hipóteses são separáveis pelo `n` que vai ao lado de cada linha — valor diferente
@@ -15,141 +16,104 @@
 
     Corte congelado em 2026-08-02, que é a janela dos números publicados (16/06 a 02/08).
 
-    ────────────────────────────────────────────────────────────────────────────────
-    RESULTADO DA PRIMEIRA EXECUÇÃO (2026-08-04) — a máquina está certa, a base não é
-    estável:
+    → RESULTADOS DAS EXECUÇÕES: `docs/TASK01_RESULTADOS.md`. Não moram aqui de
+      propósito: este arquivo deve mudar quando a LÓGICA muda, não quando os números
+      mudam.
 
-      · 22 das 25 linhas com delta EXATAMENTE 0,0, incluindo as 6 do Teste 2 e 4 dos 5
-        mercados (Dupla Chance inclusive bate o n=154 publicado).
-      · Só o mercado de GOLS derivou: −6,9 contra −7,3 publicado. A deriva agregada dos
-        cortes 2+/3+ é inteiramente explicada por ele (Gols é 2.182 das 4.066 apostas).
-      · Confirmado que não é regressão da generalização: a query ad-hoc original, rodada
-        hoje sem alterar um byte, também devolve −7,4 onde ontem devolveu −7,6.
-
-    CAUSA: o Gols é o ÚNICO dos 5 mercados com premissa derivada de odd. `linha_subindo`
-    e `linha_descendo` leem `fact_odds_snapshot` direto (média das probabilidades
-    implícitas de todas as casas, t24h -> t15m), e o modelo ainda monta o universo de
-    linhas a partir das odds presentes. Toda vez que a tabela de odds muda, essas duas
-    premissas podem virar, `n_prem` muda e o ROI dos cortes por contagem muda junto.
-    1X2, Handicap, BTTS e Dupla Chance não leem odd em premissa nenhuma — e são
-    exatamente os quatro que reproduziram byte a byte.
-
-    MEDIDO, contra o snapshot congelado `futebol_task0` (as duas premissas de linha "já
-    eram limpas" na Task 0, logo o `_before` guarda o valor de ontem):
-
-        linha_descendo                       20 flips / 50.608 linhas
-        linha_subindo                        16 flips / 50.608 linhas
-        historico_over    (controle limpo)    0 flips
-        historico_under   (controle limpo)    0 flips
-
-    O controle fecha o argumento: `historico_over/under` estão na MESMA classe de
-    premissa não afetada pela correção da Task 0, mas leem histórico em vez de odd — e
-    não mexeram uma linha.
-
-    CONSEQUÊNCIA p/ os tickets a jusante:
-
-      1. Número de Gols só é comparável entre execuções se a data de build for
-         registrada junto. Todo relatório desta task precisa carimbar o `dbt_loaded_at`
-         das tabelas de origem.
-      2. 0,07% das linhas viraram e isso moveu o ROI do mercado em 0,4pp — porque a
-         porta é um LIMIAR: uma linha que vai de n_prem=1 p/ 2 entra inteira no
-         universo. Vale checar no Teste 4 se a nota ponderada, sendo contínua, é menos
-         sensível a esse ruído que a porta de contagem. Se for, é um argumento a favor
-         dela que ninguém levantou ainda — e que não depende do resultado de ROI.
-    ────────────────────────────────────────────────────────────────────────────────
-
-    ACHADO DA GUARDA DE DESCARTE (mesma execução): além do gap já conhecido da saída
-    '12' da Dupla Chance (168 linhas, 1 por jogo), o mercado 6 — Goals Over/Under First
-    Half — tinha 3.642 linhas de odd sumindo em silêncio na janela congelada. O Motor
-    não pontua gols do 1º tempo, então excluí-lo está certo; o problema era estar sendo
-    excluído POR ACIDENTE, pelo INNER JOIN com as premissas, e não por escopo declarado.
-    O macro passou a filtrar `market_id IN (1,4,5,8,12)` explicitamente. Todos os 25
-    números acima ficaram byte a byte iguais depois da mudança — era mesmo só acidente.
+    POR QUE ISTO NÃO É UM `tests/assert_*.sql`, apesar de ter cara de asserção: fixa uma
+    data congelada e valores literais publicados, então apodrece por construção — em
+    semanas passaria a falhar pelo motivo certo na hora errada. E o pipeline agendado
+    roda `dbt run`, não `dbt build`, então não executaria ali de qualquer forma. O custo
+    dessa escolha é real e assumido: nada re-executa isto sozinho, é rodar à mão.
 
     Rodar com:
-      dbt compile --select path:analyses/task01_reconciliacao.sql
-      e executar o SQL de target/compiled/... no BigQuery
+      dbt compile --select task01_reconciliacao
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_reconciliacao.sql
 #}
 
 WITH {{ task01_base(cutoff='2026-08-02') }},
 
--- Teste 3: ROI de cada porta, stake fixa na melhor odd.
+{#- PROCEDÊNCIA das constantes `esperado` deste bloco: tabela "Do Teste 3, a linha que
+    muda a leitura é a do universo sem porta" na descrição da task [0.1] (ClickUp
+    wdx6zevfgf), reproduzida na issue #3. -#}
 teste3 AS (
     SELECT 'Teste 3' AS bloco, 'a. universo sem porta' AS metrica,
            COUNT(*) AS n, -10.2 AS esperado,
            ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS obtido
-    FROM bets
+    FROM apostas
 
     UNION ALL
     SELECT 'Teste 3', 'b. 2+ premissas',
            COUNT(*), -7.6,
            ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
-    FROM bets WHERE n_prem >= 2
+    FROM apostas WHERE n_prem >= 2
 
     UNION ALL
     SELECT 'Teste 3', 'c. 3+ premissas',
            COUNT(*), -6.0,
            ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
-    FROM bets WHERE n_prem >= 3
+    FROM apostas WHERE n_prem >= 3
 
     UNION ALL
     SELECT 'Teste 3', 'd. regra de hoje (edge > 0)',
            COUNT(*), -12.3,
            ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
-    FROM bets WHERE edge > 0
+    FROM apostas WHERE edge > 0
 
     UNION ALL
     SELECT 'Teste 3', 'e. edge > 0 e 2+ premissas',
            COUNT(*), -15.4,
            ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1)
-    FROM bets WHERE edge > 0 AND n_prem >= 2
+    FROM apostas WHERE edge > 0 AND n_prem >= 2
 ),
 
--- Teste 3 por mercado, na porta "2+ premissas". Localiza a deriva: se só um mercado
--- se mover, a instabilidade tem endereço.
+{#- PROCEDÊNCIA: comentário de entrega da Task [0] no ClickUp wdx6zev64w — "Por mercado,
+    todos viram: 1X2 +33,7 -> −2,5 · BTTS +25,9 -> −1,1 · Handicap +10,7 -> −9,9 · Gols
+    +5,7 -> −7,3 · Dupla Chance +1,4% em 154 apostas". São os valores DEPOIS (base limpa),
+    na porta 2+ premissas. Não constam da issue #4; entram porque localizam a deriva —
+    se só um mercado se mover, a instabilidade tem endereço. -#}
 teste3_mercado AS (
     SELECT
         'Teste 3 por mercado (2+)' AS bloco,
-        CASE b.market_id
-            WHEN 1  THEN 'a. 1X2'
-            WHEN 5  THEN 'b. Gols'
-            WHEN 4  THEN 'c. Handicap'
-            WHEN 8  THEN 'd. BTTS'
-            WHEN 12 THEN 'e. Dupla Chance'
-        END AS metrica,
+        m.rotulo AS metrica,
         COUNT(*) AS n,
         ANY_VALUE(m.esperado) AS esperado,
-        ROUND((SUM(IF(b.ganhou, b.best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS obtido
-    FROM bets AS b
+        ROUND((SUM(IF(a.ganhou, a.best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS obtido
+    FROM apostas AS a
     JOIN UNNEST([
-        STRUCT(1  AS market_id, -2.5 AS esperado),
-        STRUCT(5  AS market_id, -7.3 AS esperado),
-        STRUCT(4  AS market_id, -9.9 AS esperado),
-        STRUCT(8  AS market_id, -1.1 AS esperado),
-        STRUCT(12 AS market_id,  1.4 AS esperado)
+        STRUCT(1  AS market_id, 'a. 1X2'          AS rotulo, -2.5 AS esperado),
+        STRUCT(5  AS market_id, 'b. Gols'         AS rotulo, -7.3 AS esperado),
+        STRUCT(4  AS market_id, 'c. Handicap'     AS rotulo, -9.9 AS esperado),
+        STRUCT(8  AS market_id, 'd. BTTS'         AS rotulo, -1.1 AS esperado),
+        STRUCT(12 AS market_id, 'e. Dupla Chance' AS rotulo,  1.4 AS esperado)
     ]) AS m
-      ON m.market_id = b.market_id
-    WHERE b.n_prem >= 2
-    GROUP BY b.market_id
+      ON m.market_id = a.market_id
+    WHERE a.n_prem >= 2
+    GROUP BY m.rotulo
 ),
 
--- Teste 2 do mercado de Gols, contra benchmark sharp (o mesmo filtro da rodada
--- anterior, que exigia valor_fonte='pinnacle'). Métrica: acerto médio menos prob justa
--- média, nas linhas em que a premissa acendeu.
+{#- Teste 2 do mercado de Gols, contra benchmark sharp (o mesmo filtro da rodada
+    anterior, que exigia valor_fonte='pinnacle'). Métrica: acerto médio menos prob justa
+    média, nas linhas em que a premissa acendeu.
+
+    PROCEDÊNCIA: mesmo comentário de entrega da Task [0] — "Só clean_sheets_altos
+    (+16,9) e defesas_firmes (+3,4) seguem positivos … xg_combinado_alto vai de +3,1
+    para −2,6 · ataque_combinado +15,9 -> −3,6 · defesas_vazaveis +9,5 -> −5,2 ·
+    ambos_vazam +4,4 -> −3,7". -#}
 teste2_gols AS (
     SELECT
         'Teste 2 (Gols)' AS bloco,
         pl.premissa      AS metrica,
         COUNTIF(pl.acesa) AS n,
         e.esperado,
-        ROUND((AVG(IF(pl.acesa, CAST(b.ganhou AS INT64), NULL))
-             - AVG(IF(pl.acesa, b.prob_justa_fechamento, NULL))) * 100, 1) AS obtido
-    FROM bets AS b
+        ROUND((AVG(IF(pl.acesa, CAST(a.ganhou AS INT64), NULL))
+             - AVG(IF(pl.acesa, a.prob_justa_fechamento, NULL))) * 100, 1) AS obtido
+    FROM apostas AS a
     JOIN prem_long AS pl
-      ON  pl.market_id                  = b.market_id
-      AND pl.fixture_id                 = b.fixture_id
-      AND pl.outcome_side               = b.outcome_side
-      AND COALESCE(pl.line_value, -999) = COALESCE(b.line_value, -999)
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
     JOIN UNNEST([
         STRUCT('clean_sheets_altos' AS premissa,  16.9 AS esperado),
         STRUCT('defesas_firmes'     AS premissa,   3.4 AS esperado),
@@ -159,16 +123,17 @@ teste2_gols AS (
         STRUCT('ambos_vazam'        AS premissa,  -3.7 AS esperado)
     ]) AS e
       ON e.premissa = pl.premissa
-    WHERE b.market_id = 5
-      AND b.benchmark = 'sharp'
+    WHERE a.market_id = 5
+      AND a.benchmark = 'sharp'
     GROUP BY 1, 2, 4
 ),
 
 cobertura AS (
-    SELECT 'Cobertura' AS bloco, 'a. jogos com odd' AS metrica,
+    SELECT 'Cobertura' AS bloco,
+           'a. jogos que sobreviveram a todos os recortes' AS metrica,
            COUNT(*) AS n, 168.0 AS esperado,
            CAST(COUNT(DISTINCT fixture_id) AS FLOAT64) AS obtido
-    FROM bets
+    FROM apostas
 
     -- Se isto não for zero, a degradação graciosa falhou em algum lugar: contar
     -- premissas por SUM(CAST(bool AS INT64)) (a query original) propaga NULL e derruba
@@ -178,48 +143,72 @@ cobertura AS (
     SELECT 'Cobertura', 'b. linhas com premissa NULL',
            COUNT(*), 0.0,
            CAST(SUM(n_prem_null) AS FLOAT64)
-    FROM bets
+    FROM apostas
 ),
 
--- Guarda de descarte silencioso. O JOIN de `bets` com as premissas é INNER, então
--- qualquer linha de odd sem premissa correspondente some sem aviso. Já sabemos de uma
--- (a saída '12' da Dupla Chance, que o modelo de premissas não emite); esta guarda
--- existe para que não haja uma segunda que ninguém viu. Esperado 0 em toda linha.
-descarte AS (
+{#- GUARDA DE DESCARTE SILENCIOSO.
+
+    Lê `odds`, que o macro deixa exposto SEM recorte nenhum — de propósito. A primeira
+    versão desta guarda lia a fonte já filtrada por escopo, e portanto era cega
+    exatamente à classe de perda que ela mesma tinha acabado de encontrar (as 3.642
+    linhas do mercado 6). Guarda que só enxerga depois do filtro não guarda o filtro.
+
+    Todo descarte é classificado por motivo. Os declarados são informativos; o que
+    sobra tem de ser ZERO, e essa linha é emitida sempre, mesmo valendo zero — ausência
+    de linha não pode ser confundida com ausência de checagem. -#}
+descartes AS (
     SELECT
-        'Descarte silencioso' AS bloco,
-        CONCAT('market ', CAST(o.market_id AS STRING), ' — ', o.outcome_side,
-               IF(o.market_id = 12 AND o.outcome_side = '12',
-                  '  (gap CONHECIDO, reportado)', '')) AS metrica,
-        COUNT(*) AS n,
-        0.0 AS esperado,
-        CAST(COUNTIF(b.fixture_id IS NULL) AS FLOAT64) AS obtido
+        CASE
+            WHEN o.market_id NOT IN ({{ task01_markets().keys() | join(', ') }})
+                THEN 'a. fora do escopo do Motor (declarado)'
+            WHEN o.best_odd IS NULL OR o.edge IS NULL
+                THEN 'b. sem preco justo, edge NULL (declarado)'
+            WHEN NOT {{ task01_meia_linha('o.') }}
+                THEN 'c. linha inteira, push possivel (declarado)'
+            WHEN o.market_id = 12 AND o.outcome_side = '12'
+                THEN 'd. gap conhecido: DC nao emite premissa p/ 12'
+            ELSE
+                 'e. INESPERADO'
+        END AS motivo
     FROM odds AS o
-    JOIN fx AS f
-      ON f.fixture_id = o.fixture_id
-    LEFT JOIN bets AS b
-      ON  b.market_id                  = o.market_id
-      AND b.fixture_id                 = o.fixture_id
-      AND b.outcome_side               = o.outcome_side
-      AND COALESCE(b.line_value, -999) = COALESCE(o.line_value, -999)
-    WHERE (o.market_id NOT IN (4, 5)
-           OR MOD(CAST(ABS(o.line_value) * 2 AS INT64), 2) = 1)
-    GROUP BY o.market_id, o.outcome_side
-    HAVING COUNTIF(b.fixture_id IS NULL) > 0
+    JOIN jogos_encerrados AS j
+      ON j.fixture_id = o.fixture_id
+    LEFT JOIN apostas AS ap
+      ON  ap.market_id                  = o.market_id
+      AND ap.fixture_id                 = o.fixture_id
+      AND ap.outcome_side               = o.outcome_side
+      AND COALESCE(ap.line_value, -999) = COALESCE(o.line_value, -999)
+    WHERE ap.fixture_id IS NULL
 ),
 
--- Informativo: onde procurar, se algo acima divergir. Sem valor publicado p/ comparar.
--- Agrupa POR benchmark, não ANY_VALUE(benchmark): os mercados 4 e 5 são MISTOS (a
--- Pinnacle cobre a maior parte, mas não todos os jogos), e um rótulo arbitrário por
--- mercado esconderia exatamente a distinção que a task existe para tornar visível.
-por_mercado AS (
+descarte_assercao AS (
+    SELECT 'Descarte' AS bloco,
+           'z. INESPERADOS (tem de ser 0)' AS metrica,
+           COUNT(*) AS n,
+           0.0 AS esperado,
+           CAST(COUNTIF(motivo = 'e. INESPERADO') AS FLOAT64) AS obtido
+    FROM descartes
+),
+
+descarte_detalhe AS (
+    SELECT 'Descarte' AS bloco, motivo AS metrica,
+           COUNT(*) AS n, CAST(NULL AS FLOAT64) AS esperado,
+           CAST(COUNT(*) AS FLOAT64) AS obtido
+    FROM descartes GROUP BY motivo
+),
+
+{#- Informativo: onde procurar, se algo acima divergir. Agrupa POR benchmark, não
+    ANY_VALUE(benchmark): os mercados 4 e 5 são MISTOS (a Pinnacle cobre a maior parte,
+    mas não todos os jogos), e um rótulo arbitrário por mercado esconderia exatamente a
+    distinção que esta task existe para tornar visível. -#}
+por_benchmark AS (
     SELECT
         'Cobertura por benchmark' AS bloco,
         CONCAT('market ', CAST(market_id AS STRING), ' — ', benchmark) AS metrica,
         COUNT(*) AS n,
         CAST(NULL AS FLOAT64) AS esperado,
         ROUND((SUM(IF(ganhou, best_odd, 0)) / COUNT(*) - 1) * 100, 1) AS obtido
-    FROM bets
+    FROM apostas
     GROUP BY market_id, benchmark
 )
 
@@ -230,18 +219,22 @@ SELECT
     esperado,
     obtido,
     ROUND(obtido - esperado, 1) AS delta,
+    -- 0,05 é tolerância de ARREDONDAMENTO e nada mais: os valores publicados têm 1 casa
+    -- decimal, então reprodução exata dá delta 0,0. Não há faixa intermediária de
+    -- propósito — uma banda larga o bastante p/ acomodar "quase igual" teria engolido a
+    -- deriva de 0,4pp do Gols, que é o achado do ticket.
     CASE
-        WHEN esperado IS NULL                        THEN '—'
-        WHEN ABS(obtido - esperado) < 0.05           THEN 'OK'
-        WHEN ABS(obtido - esperado) <= 0.3           THEN 'ATENCAO'
-        ELSE                                              'DIVERGE'
+        WHEN esperado IS NULL              THEN '—'
+        WHEN ABS(obtido - esperado) < 0.05 THEN 'OK'
+        ELSE                                    'DIVERGE'
     END AS status
 FROM (
     SELECT * FROM teste3
     UNION ALL SELECT * FROM teste3_mercado
     UNION ALL SELECT * FROM teste2_gols
     UNION ALL SELECT * FROM cobertura
-    UNION ALL SELECT * FROM descarte
-    UNION ALL SELECT * FROM por_mercado
+    UNION ALL SELECT * FROM descarte_assercao
+    UNION ALL SELECT * FROM descarte_detalhe
+    UNION ALL SELECT * FROM por_benchmark
 )
 ORDER BY bloco, metrica

--- a/dbt_futebol/analyses/task01_teste1.sql
+++ b/dbt_futebol/analyses/task01_teste1.sql
@@ -1,0 +1,138 @@
+{#
+    Task [0.1] — TESTE 1 completo na base limpa.  Ticket #6, spec #3.
+
+    O Teste 1 mede se a premissa PREVÊ O RESULTADO DA LINHA:
+
+        diferença = média(acerto | premissa acesa) − média(taxa base da MESMA linha)
+
+    onde "taxa base da mesma linha" é o acerto médio de todas as linhas do mesmo
+    (mercado, lado, valor da linha) — o Over 2.5 de uma premissa é comparado ao Over 2.5
+    em geral, não ao universo inteiro.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    POR QUE ELE EXISTE AQUI, e por que NÃO é a fonte primária de peso:
+
+    Prever a linha não é gerar valor. Uma premissa pode acertar muito e não pagar nada,
+    porque o mercado também sabe — foi essa distinção que primeiro salvou e depois
+    derrubou o `xg_combinado_alto`. Quem define peso é o Teste 2.
+
+    O Teste 1 entra como CONTROLE OUT-OF-SAMPLE exigido pelo ADR 0001: ele não precisa
+    de odd, então roda em todo jogo encerrado — um universo de milhares de partidas,
+    DISJUNTO das ~170 em que o ROI do Teste 4 é medido. Pesos vindos daqui são ajustados
+    em dados que não são os dados avaliados, e é isso que faz deles um controle.
+    ────────────────────────────────────────────────────────────────────────────────
+    O universo é construído do `prem_long` + `jogos_encerrados` do macro, com a MESMA
+    liquidação e o MESMO filtro de meia-linha do Teste 2/3 (macros `task01_liquidacao` e
+    `task01_meia_linha`). Nada é redefinido localmente: se as duas medições liquidassem
+    diferente, a comparação entre elas não significaria nada.
+
+    O piso de amostra entra como coluna pelo mesmo motivo do Teste 2 — lá ele INVERTEU
+    os três maiores sinais. Um peso de controle medido sem piso carregaria o mesmo
+    artefato que o peso primário, e deixaria de ser controle de coisa alguma.
+
+    → RESULTADOS: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_teste1
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_teste1.sql
+#}
+
+WITH {{ task01_base() }},
+
+{#- Universo do Teste 1: toda linha de premissa de jogo encerrado, COM OU SEM ODD. É
+    aqui que ele se separa do Teste 2 — e é essa separação que o torna um controle. -#}
+linhas AS (
+    SELECT
+        pl.market_id,
+        pl.fixture_id,
+        pl.outcome_side,
+        pl.line_value,
+        pl.premissa,
+        pl.acesa,
+        j.season,
+        COALESCE(pit.min_jogos, 0)          AS min_jogos,
+        {{ task01_liquidacao('pl.', 'j.') }} AS ganhou
+    FROM prem_long AS pl
+    JOIN jogos_encerrados AS j
+      ON j.fixture_id = pl.fixture_id
+    LEFT JOIN pit
+      ON pit.fixture_id = pl.fixture_id
+    WHERE {{ task01_meia_linha('pl.') }}
+),
+
+{#- Taxa base por (mercado, lado, linha). Deduplicado ao grão de LINHA antes de agregar:
+    `linhas` tem uma tupla por premissa, e agregar direto ali pesaria cada linha pelo
+    número de premissas do mercado. -#}
+linhas_unicas AS (
+    SELECT DISTINCT market_id, fixture_id, outcome_side, line_value, ganhou
+    FROM linhas
+),
+base_linha AS (
+    SELECT
+        market_id,
+        outcome_side,
+        line_value,
+        AVG(CAST(ganhou AS INT64)) AS taxa_base,
+        COUNT(*)                   AS n_linha
+    FROM linhas_unicas
+    GROUP BY 1, 2, 3
+),
+
+universo AS (
+    SELECT
+        COUNT(DISTINCT fixture_id)                                          AS jogos,
+        COUNT(DISTINCT IF(season = 2024, fixture_id, NULL))                 AS jogos_2024,
+        COUNT(DISTINCT IF(season = 2025, fixture_id, NULL))                 AS jogos_2025,
+        COUNT(DISTINCT IF(season = 2026, fixture_id, NULL))                 AS jogos_2026
+    FROM linhas
+),
+
+agregado AS (
+    SELECT
+        l.market_id,
+        l.premissa,
+        AVG(IF(l.acesa, l.min_jogos, NULL))                     AS jogos_medios,
+        AVG(IF(l.acesa, IF(l.min_jogos < 5, 1.0, 0.0), NULL))   AS frac_curta
+        {%- for piso in [0, 5, 10] %},
+        COUNTIF(l.acesa AND l.min_jogos >= {{ piso }})          AS n_{{ piso }},
+        AVG(IF(l.acesa AND l.min_jogos >= {{ piso }},
+               CAST(l.ganhou AS INT64), NULL))                  AS p_real_{{ piso }},
+        AVG(IF(l.acesa AND l.min_jogos >= {{ piso }},
+               b.taxa_base, NULL))                              AS p_base_{{ piso }}
+        {%- endfor %}
+    FROM linhas AS l
+    JOIN base_linha AS b
+      ON  b.market_id                  = l.market_id
+      AND b.outcome_side               = l.outcome_side
+      AND COALESCE(b.line_value, -999) = COALESCE(l.line_value, -999)
+    GROUP BY l.market_id, l.premissa
+    HAVING COUNTIF(l.acesa) > 0
+)
+
+SELECT
+    u.jogos                                                 AS jogos_no_universo,
+    u.jogos_2024,
+    u.jogos_2025,
+    u.jogos_2026,
+    CASE g.market_id
+        {%- for mid, m in task01_markets().items() %}
+        WHEN {{ mid }} THEN '{{ m.nome }}'
+        {%- endfor %}
+    END                                                     AS mercado,
+    g.premissa,
+    ROUND(SAFE_DIVIDE(g.n_0, g.n_0 + 50), 2)                AS fator_encolhimento,
+    ROUND(g.jogos_medios, 1)                                AS jogos_medios,
+    ROUND(g.frac_curta * 100, 1)                            AS pct_amostra_curta
+    {%- for piso in [0, 5, 10] %},
+    g.n_{{ piso }}                                          AS n_p{{ piso }},
+    ROUND(g.p_base_{{ piso }} * 100, 1)                     AS taxa_base_p{{ piso }},
+    ROUND(g.p_real_{{ piso }} * 100, 1)                     AS acertou_p{{ piso }},
+    ROUND((g.p_real_{{ piso }} - g.p_base_{{ piso }}) * 100, 1) AS diferenca_p{{ piso }},
+    -- Peso de CONTROLE, mesma regra de encolhimento do Teste 2 p/ que as duas fontes
+    -- sejam comparáveis entre si: max(diferença, 0) × n/(n+50).
+    ROUND(GREATEST((g.p_real_{{ piso }} - g.p_base_{{ piso }}) * 100, 0)
+          * SAFE_DIVIDE(g.n_{{ piso }}, g.n_{{ piso }} + 50), 2) AS peso_ctrl_p{{ piso }}
+    {%- endfor %}
+FROM agregado AS g
+CROSS JOIN universo AS u
+ORDER BY mercado, diferenca_p0 DESC

--- a/dbt_futebol/analyses/task01_teste2.sql
+++ b/dbt_futebol/analyses/task01_teste2.sql
@@ -1,0 +1,133 @@
+{#
+    Task [0.1] — TESTE 2 completo nos 5 mercados, base limpa, e derivação do peso
+    medido.  Ticket #5, spec #3.
+
+    O Teste 2 mede se a premissa BATE O PREÇO, e é o único dos quatro que pode
+    justificar um peso. O Teste 1 mede outra coisa (prever a linha) — foi essa distinção
+    que primeiro salvou e depois derrubou o `xg_combinado_alto`.
+
+        diferença = média(acerto | premissa acesa) − média(prob justa | premissa acesa)
+
+    ────────────────────────────────────────────────────────────────────────────────
+    BENCHMARK: a tabela sai por (mercado, premissa, BENCHMARK), e não por (mercado,
+    premissa).
+
+    A Pinnacle não cobre todos os jogos. Handicap e Gols são MISTOS — cerca de metade
+    das linhas tem preço sharp e metade cai no consenso (mediana das casas). A rodada
+    anterior mediu só as sharp; juntar as duas metades numa linha só misturaria dois
+    benchmarks de graus diferentes dentro do mesmo número.
+
+    O PESO é derivado apenas do MELHOR benchmark disponível de cada mercado:
+
+        1X2, Handicap, Gols   sharp      (de-vig direto da Pinnacle)
+        Dupla Chance          derivada   (do de-vig 1X2 da Pinnacle — âncora sharp)
+        BTTS                  consenso   (a Pinnacle estruturalmente não precifica)
+
+    As linhas de consenso do Handicap e do Gols vão na saída assim mesmo, marcadas com
+    `usado_para_peso = false`. Elas não pesam, mas precisam ser vistas: o ROI delas é
+    muito pior que o das sharp (−26,7 contra −6,5 no Handicap), e essa diferença não é
+    do benchmark — é de QUAIS jogos a Pinnacle escolhe precificar. Ignorá-las
+    esconderia isso.
+    ────────────────────────────────────────────────────────────────────────────────
+    PESO (ADR 0001):
+
+        peso = max(diferença, 0) × n / (n + k)          k = 50
+
+    Encolhimento por amostra, não ganho cru. O achado central da Task [0] foi que
+    amostra curta fabrica sinal: os +9,7% que morreram vinham inteiramente de
+    competições de mata-mata com 0,8 a 2,4 jogos disputados. Peso proporcional ao ganho
+    bruto daria as maiores notas justamente às premissas que acenderam poucas vezes.
+    `peso_k0` (sem encolhimento) vai junto como sensibilidade.
+
+    Ganho negativo vira peso ZERO, não peso negativo: com esta amostra, uma diferença de
+    −5 é indistinguível de ruído, e peso negativo fitaria esse ruído.
+    ────────────────────────────────────────────────────────────────────────────────
+    `jogos_medios` e `pct_amostra_curta` existem para amarrar cada premissa ao artefato
+    que matou a medição anterior. Premissa com ganho alto E `pct_amostra_curta` alto é
+    exatamente o padrão que produziu os +9,7%.
+
+    Universo: TODOS os jogos liquidados com odd, sem corte congelado — a janela exata
+    sai nas duas primeiras colunas.
+
+    → RESULTADOS: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_teste2
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_teste2.sql
+#}
+
+WITH {{ task01_base() }},
+
+{#- Uma passada, grão (mercado, premissa, benchmark). Só as linhas em que a premissa
+    ACENDEU entram nas médias — é essa a definição do Teste 2. -#}
+agregado AS (
+    SELECT
+        a.market_id,
+        pl.premissa,
+        a.benchmark,
+        COUNTIF(pl.acesa)                                        AS n,
+        AVG(IF(pl.acesa, a.prob_justa_fechamento, NULL))         AS p_odd,
+        AVG(IF(pl.acesa, CAST(a.ganhou AS INT64), NULL))         AS p_real,
+        AVG(IF(pl.acesa, a.min_jogos, NULL))                     AS jogos_medios,
+        AVG(IF(pl.acesa, IF(a.min_jogos < 5, 1.0, 0.0), NULL))   AS frac_curta
+    FROM apostas AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    GROUP BY a.market_id, pl.premissa, a.benchmark
+    HAVING COUNTIF(pl.acesa) > 0
+),
+
+janela AS (
+    SELECT
+        MIN(DATE(kickoff_utc)) AS janela_ini,
+        MAX(DATE(kickoff_utc)) AS janela_fim,
+        COUNT(DISTINCT fixture_id) AS jogos_no_universo,
+        COUNT(*) AS linhas_no_universo
+    FROM apostas
+)
+
+SELECT
+    j.janela_ini,
+    j.janela_fim,
+    j.jogos_no_universo,
+    CASE g.market_id
+        {%- for mid, m in task01_markets().items() %}
+        WHEN {{ mid }} THEN '{{ m.nome }}'
+        {%- endfor %}
+    END                                                     AS mercado,
+    g.premissa,
+    g.benchmark,
+    -- O melhor benchmark disponível de cada mercado. Só estas linhas geram peso.
+    (g.benchmark = CASE g.market_id
+                       WHEN 12 THEN 'derivada'
+                       WHEN 8  THEN 'consenso'
+                       ELSE         'sharp'
+                   END)                                     AS usado_para_peso,
+    g.n,
+    ROUND(g.p_odd  * 100, 1)                                AS a_odd_dava,
+    ROUND(g.p_real * 100, 1)                                AS aconteceu,
+    ROUND((g.p_real - g.p_odd) * 100, 1)                    AS diferenca,
+    ROUND(g.jogos_medios, 1)                                AS jogos_medios,
+    ROUND(g.frac_curta * 100, 1)                            AS pct_amostra_curta,
+    -- peso = max(diferença, 0) × n/(n+k). k=50 é o encolhimento por amostra; k=0 é a
+    -- sensibilidade que mostra o quanto o encolhimento está segurando.
+    IF(g.benchmark = CASE g.market_id
+                         WHEN 12 THEN 'derivada'
+                         WHEN 8  THEN 'consenso'
+                         ELSE         'sharp'
+                     END,
+       ROUND(GREATEST((g.p_real - g.p_odd) * 100, 0) * SAFE_DIVIDE(g.n, g.n + 50), 2),
+       NULL)                                                AS peso_k50,
+    IF(g.benchmark = CASE g.market_id
+                         WHEN 12 THEN 'derivada'
+                         WHEN 8  THEN 'consenso'
+                         ELSE         'sharp'
+                     END,
+       ROUND(GREATEST((g.p_real - g.p_odd) * 100, 0), 2),
+       NULL)                                                AS peso_k0
+FROM agregado AS g
+CROSS JOIN janela AS j
+ORDER BY mercado, usado_para_peso DESC, diferenca DESC

--- a/dbt_futebol/analyses/task01_teste2.sql
+++ b/dbt_futebol/analyses/task01_teste2.sql
@@ -59,17 +59,29 @@
 WITH {{ task01_base() }},
 
 {#- Uma passada, grão (mercado, premissa, benchmark). Só as linhas em que a premissa
-    ACENDEU entram nas médias — é essa a definição do Teste 2. -#}
+    ACENDEU entram nas médias — é essa a definição do Teste 2.
+
+    O PISO DE AMOSTRA entra como COLUNA, não como execução separada. Motivo: a primeira
+    rodada do Teste 2 mostrou que o encolhimento por amostra e o piso tratam eixos
+    DIFERENTES. `k` trata `n` pequeno (a premissa acendeu poucas vezes); o piso trata
+    jogo sem histórico. `clean_sheets_altos` tem n=105 (grande, o encolhimento mal
+    encosta) e 77% das linhas em jogo com menos de 5 partidas disputadas — que é a
+    assinatura exata do artefato que matou os +9,7%. Sem ver os dois lado a lado não dá
+    para saber se um peso alto é sinal ou é o mata-mata de novo. -#}
 agregado AS (
     SELECT
         a.market_id,
         pl.premissa,
         a.benchmark,
-        COUNTIF(pl.acesa)                                        AS n,
-        AVG(IF(pl.acesa, a.prob_justa_fechamento, NULL))         AS p_odd,
-        AVG(IF(pl.acesa, CAST(a.ganhou AS INT64), NULL))         AS p_real,
         AVG(IF(pl.acesa, a.min_jogos, NULL))                     AS jogos_medios,
         AVG(IF(pl.acesa, IF(a.min_jogos < 5, 1.0, 0.0), NULL))   AS frac_curta
+        {%- for piso in [0, 5, 10] %},
+        COUNTIF(pl.acesa AND a.min_jogos >= {{ piso }})          AS n_{{ piso }},
+        AVG(IF(pl.acesa AND a.min_jogos >= {{ piso }},
+               a.prob_justa_fechamento, NULL))                   AS p_odd_{{ piso }},
+        AVG(IF(pl.acesa AND a.min_jogos >= {{ piso }},
+               CAST(a.ganhou AS INT64), NULL))                   AS p_real_{{ piso }}
+        {%- endfor %}
     FROM apostas AS a
     JOIN prem_long AS pl
       ON  pl.market_id                  = a.market_id
@@ -87,47 +99,58 @@ janela AS (
         COUNT(DISTINCT fixture_id) AS jogos_no_universo,
         COUNT(*) AS linhas_no_universo
     FROM apostas
+),
+
+{#- `preferido` calculado UMA vez, não repetido em cada coluna que depende dele. -#}
+rotulado AS (
+    SELECT
+        g.*,
+        CASE g.market_id
+            {%- for mid, m in task01_markets().items() %}
+            WHEN {{ mid }} THEN '{{ m.nome }}'
+            {%- endfor %}
+        END AS mercado,
+        g.benchmark = CASE g.market_id
+                          WHEN 12 THEN 'derivada'
+                          WHEN 8  THEN 'consenso'
+                          ELSE         'sharp'
+                      END AS preferido
+    FROM agregado AS g
 )
 
 SELECT
     j.janela_ini,
     j.janela_fim,
     j.jogos_no_universo,
-    CASE g.market_id
-        {%- for mid, m in task01_markets().items() %}
-        WHEN {{ mid }} THEN '{{ m.nome }}'
-        {%- endfor %}
-    END                                                     AS mercado,
-    g.premissa,
-    g.benchmark,
-    -- O melhor benchmark disponível de cada mercado. Só estas linhas geram peso.
-    (g.benchmark = CASE g.market_id
-                       WHEN 12 THEN 'derivada'
-                       WHEN 8  THEN 'consenso'
-                       ELSE         'sharp'
-                   END)                                     AS usado_para_peso,
-    g.n,
-    ROUND(g.p_odd  * 100, 1)                                AS a_odd_dava,
-    ROUND(g.p_real * 100, 1)                                AS aconteceu,
-    ROUND((g.p_real - g.p_odd) * 100, 1)                    AS diferenca,
-    ROUND(g.jogos_medios, 1)                                AS jogos_medios,
-    ROUND(g.frac_curta * 100, 1)                            AS pct_amostra_curta,
-    -- peso = max(diferença, 0) × n/(n+k). k=50 é o encolhimento por amostra; k=0 é a
-    -- sensibilidade que mostra o quanto o encolhimento está segurando.
-    IF(g.benchmark = CASE g.market_id
-                         WHEN 12 THEN 'derivada'
-                         WHEN 8  THEN 'consenso'
-                         ELSE         'sharp'
-                     END,
-       ROUND(GREATEST((g.p_real - g.p_odd) * 100, 0) * SAFE_DIVIDE(g.n, g.n + 50), 2),
-       NULL)                                                AS peso_k50,
-    IF(g.benchmark = CASE g.market_id
-                         WHEN 12 THEN 'derivada'
-                         WHEN 8  THEN 'consenso'
-                         ELSE         'sharp'
-                     END,
-       ROUND(GREATEST((g.p_real - g.p_odd) * 100, 0), 2),
-       NULL)                                                AS peso_k0
-FROM agregado AS g
+    r.mercado,
+    r.premissa,
+    r.benchmark,
+    r.preferido                                             AS usado_para_peso,
+    -- Fator de encolhimento aplicado ao peso: n/(n+50). Exposto em vez de um flag
+    -- binário de "n suficiente" porque o corte seria arbitrário e este número já diz
+    -- exatamente quanto da medição sobreviveu. `desfalque_adversario` (n=7) fica em
+    -- 0,12: qualquer sinal que ela tivesse seria 88% descartado por falta de amostra,
+    -- e isso é diferente de "medimos e deu ruim".
+    ROUND(SAFE_DIVIDE(r.n_0, r.n_0 + 50), 2)                AS fator_encolhimento,
+    ROUND(r.jogos_medios, 1)                                AS jogos_medios,
+    ROUND(r.frac_curta * 100, 1)                            AS pct_amostra_curta
+    {%- for piso in [0, 5, 10] %},
+    r.n_{{ piso }}                                          AS n_p{{ piso }},
+    ROUND(r.p_odd_{{ piso }}  * 100, 1)                     AS a_odd_dava_p{{ piso }},
+    ROUND(r.p_real_{{ piso }} * 100, 1)                     AS aconteceu_p{{ piso }},
+    ROUND((r.p_real_{{ piso }} - r.p_odd_{{ piso }}) * 100, 1) AS diferenca_p{{ piso }},
+    -- peso = max(diferença, 0) × n/(n+k), k=50. Ganho negativo vira ZERO, não peso
+    -- negativo: com esta amostra, −5 é indistinguível de ruído.
+    IF(r.preferido,
+       ROUND(GREATEST((r.p_real_{{ piso }} - r.p_odd_{{ piso }}) * 100, 0)
+             * SAFE_DIVIDE(r.n_{{ piso }}, r.n_{{ piso }} + 50), 2),
+       NULL)                                                AS peso_p{{ piso }}
+    {%- endfor %},
+    -- Sensibilidade: peso sem encolhimento nenhum, no piso 0. Mostra o quanto o k=50
+    -- está segurando.
+    IF(r.preferido,
+       ROUND(GREATEST((r.p_real_0 - r.p_odd_0) * 100, 0), 2),
+       NULL)                                                AS peso_p0_k0
+FROM rotulado AS r
 CROSS JOIN janela AS j
-ORDER BY mercado, usado_para_peso DESC, diferenca DESC
+ORDER BY r.mercado, r.preferido DESC, diferenca_p0 DESC

--- a/dbt_futebol/analyses/task01_teste4.sql
+++ b/dbt_futebol/analyses/task01_teste4.sql
@@ -1,0 +1,264 @@
+{#
+    Task [0.1] — TESTE 4: o ROI sobe com a nota?  Ticket #8, spec #3.
+
+    A pergunta de produto. Nenhum teste anterior a fez: o Teste 1 mede premissa
+    individual contra a linha, o Teste 2 contra o preço, o Teste 3 mede CONTAGEM de
+    premissas. Ninguém mediu a NOTA PONDERADA contra o ROI.
+
+    ════════════════════════════════════════════════════════════════════════════════
+    QUATRO FONTES DE PESO — e o par que mede a inflação in-sample
+
+    O ADR 0001 exige que nenhuma conclusão de produto saia do corte in-sample. O
+    controle previsto lá (pesos do Teste 1) revelou-se fraco no ticket #6: os dois
+    testes medem construtos quase ortogonais, então curva plana sob pesos do Teste 1
+    não prova ajuste — prova apenas que prever a linha não paga.
+
+    O controle real é temporal, e está no par B/C:
+
+      A. t2_full  · pesos do Teste 2 sobre TODA a janela, ROI sobre TODA a janela
+                    -> o pedido literal. In-sample.
+      B. t2_h1    · pesos da 1a METADE, ROI sobre a 1a METADE
+                    -> in-sample, par de controle
+      C. t2_h1    · pesos da 1a METADE, ROI sobre a 2a METADE
+                    -> OUT-OF-SAMPLE de verdade
+
+    B e C usam OS MESMOS PESOS e diferem só no conjunto avaliado. A distância entre
+    eles é a inflação in-sample, medida em vez de suposta.
+
+      D. t1       · pesos do Teste 1 (universo de 6.042 jogos), ROI sobre toda a janela
+                    -> mantido pelo ADR; responde "premissa que prevê bem paga?"
+
+    A permutação (curva nula) fica em `task01_teste4_permutacao.sql`.
+    ════════════════════════════════════════════════════════════════════════════════
+    PESOS COM PISO DE 5 JOGOS, sempre. No ticket #5 o piso INVERTEU os três maiores
+    sinais: `clean_sheets_altos` +17,1 -> −1,7, `superioridade_xg` +5,2 -> −8,9,
+    `tende_golear` +3,9 -> −18,5. Peso sem piso faria a nota herdar exatamente o
+    artefato que a Task [0] removeu.
+
+    DUAS COMPOSIÇÕES, lado a lado:
+
+      nota_premissas  Σ dos pesos das premissas acesas.
+      score_pos_a1    o mesmo + corroboração − penalidades. É o objeto que iria pro ar
+                      depois da A1, que remove apenas o componente de VALOR.
+
+    Ambas normalizadas 0–100 POR MERCADO (pelo total de pontos disponíveis naquele
+    mercado), e as faixas são agrupadas DEPOIS da normalização: 5 mercados × 5 faixas
+    deixaria dezenas de apostas por célula, nenhuma distinguível de zero.
+
+    INTERVALO: erro-padrão AGRUPADO POR FIXTURE, na forma analítica (cluster-robust)
+    em vez de bootstrap. É exato para uma média, custa uma passada em vez de centenas,
+    e trata a correlação entre apostas do mesmo jogo — que é o que o bootstrap
+    agrupado existiria para tratar.
+
+    → RESULTADOS: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_teste4
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_teste4.sql
+#}
+
+WITH {{ task01_base() }},
+
+{#- Artefato do de-vig de consenso (prob_justa = 1,0 com um só lado precificado): fora,
+    sempre. Ver ticket #7. -#}
+validas AS (
+    SELECT * FROM apostas WHERE NOT conjunto_incompleto
+),
+
+{#- Metades TEMPORAIS por jogo, não por linha: apostas do mesmo jogo têm de cair juntas,
+    senão o "out-of-sample" vaza pelo próprio fixture. -#}
+metades AS (
+    SELECT
+        fixture_id,
+        NTILE(2) OVER (ORDER BY kickoff_utc, fixture_id) AS metade
+    FROM (SELECT DISTINCT fixture_id, kickoff_utc FROM validas)
+),
+
+apostas_m AS (
+    SELECT v.*, m.metade
+    FROM validas AS v
+    JOIN metades AS m USING (fixture_id)
+),
+
+{#- Linhas do benchmark PREFERIDO de cada mercado — o mesmo critério do Teste 2. Peso
+    medido contra consenso não é comparável em grau com peso medido contra linha sharp. -#}
+para_peso AS (
+    SELECT a.*, pl.premissa, pl.acesa
+    FROM apostas_m AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    WHERE a.benchmark = CASE a.market_id
+                            WHEN 12 THEN 'derivada'
+                            WHEN 8  THEN 'consenso'
+                            ELSE         'sharp'
+                        END
+      AND a.min_jogos >= 5
+),
+
+pesos_t2 AS (
+    SELECT 'A. t2_full' AS fonte, market_id, premissa,
+           GREATEST((AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+                   - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100, 0)
+           * SAFE_DIVIDE(COUNTIF(acesa), COUNTIF(acesa) + 50) AS peso
+    FROM para_peso
+    GROUP BY market_id, premissa
+
+    UNION ALL
+    SELECT 'B. t2_h1', market_id, premissa,
+           GREATEST((AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+                   - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100, 0)
+           * SAFE_DIVIDE(COUNTIF(acesa), COUNTIF(acesa) + 50)
+    FROM para_peso WHERE metade = 1
+    GROUP BY market_id, premissa
+),
+
+{#- Peso de controle do Teste 1: universo de TODO jogo encerrado, sem exigir odd. Mesma
+    regra de encolhimento e mesmo piso, p/ que as fontes sejam comparáveis. -#}
+t1_linhas AS (
+    SELECT
+        pl.market_id, pl.fixture_id, pl.outcome_side, pl.line_value, pl.premissa, pl.acesa,
+        COALESCE(pit.min_jogos, 0)          AS min_jogos,
+        {{ task01_liquidacao('pl.', 'j.') }} AS ganhou
+    FROM prem_long AS pl
+    JOIN jogos_encerrados AS j ON j.fixture_id = pl.fixture_id
+    LEFT JOIN pit ON pit.fixture_id = pl.fixture_id
+    WHERE {{ task01_meia_linha('pl.') }}
+),
+t1_base AS (
+    SELECT market_id, outcome_side, line_value, AVG(CAST(ganhou AS INT64)) AS taxa_base
+    FROM (SELECT DISTINCT market_id, fixture_id, outcome_side, line_value, ganhou FROM t1_linhas)
+    GROUP BY 1, 2, 3
+),
+pesos_t1 AS (
+    SELECT 'D. t1_controle' AS fonte, l.market_id, l.premissa,
+           GREATEST((AVG(IF(l.acesa, CAST(l.ganhou AS INT64), NULL))
+                   - AVG(IF(l.acesa, b.taxa_base, NULL))) * 100, 0)
+           * SAFE_DIVIDE(COUNTIF(l.acesa), COUNTIF(l.acesa) + 50) AS peso
+    FROM t1_linhas AS l
+    JOIN t1_base AS b
+      ON  b.market_id                  = l.market_id
+      AND b.outcome_side               = l.outcome_side
+      AND COALESCE(b.line_value, -999) = COALESCE(l.line_value, -999)
+    WHERE l.min_jogos >= 5
+    GROUP BY l.market_id, l.premissa
+),
+
+pesos AS (
+    SELECT * FROM pesos_t2 UNION ALL SELECT * FROM pesos_t1
+),
+teto AS (
+    SELECT fonte, market_id, SUM(peso) AS pts_max
+    FROM pesos GROUP BY fonte, market_id
+),
+
+{#- Nota por (aposta, fonte de peso). -#}
+notas AS (
+    SELECT
+        a.fixture_id, a.market_id, a.metade, a.ganhou, a.best_odd,
+        a.pts_corroboracao, a.penalidades_globais_pts, a.penalidades_especificas_pts,
+        p.fonte,
+        SUM(IF(pl.acesa, p.peso, 0)) AS nota_pts,
+        ANY_VALUE(t.pts_max)         AS pts_max
+    FROM apostas_m AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    JOIN pesos AS p
+      ON p.market_id = pl.market_id AND p.premissa = pl.premissa
+    JOIN teto AS t
+      ON t.fonte = p.fonte AND t.market_id = a.market_id
+    GROUP BY a.fixture_id, a.market_id, a.metade, a.ganhou, a.best_odd,
+             a.pts_corroboracao, a.penalidades_globais_pts, a.penalidades_especificas_pts,
+             a.outcome_side, a.line_value, p.fonte
+),
+
+{#- Duas composições, e o universo de avaliação de cada fonte. O par B/C usa os MESMOS
+    pesos: B avalia na metade em que eles foram ajustados, C na outra. -#}
+avaliado AS (
+    SELECT
+        CASE WHEN fonte = 'B. t2_h1' AND metade = 2 THEN 'C. t2_h1 -> 2a metade (OUT-OF-SAMPLE)'
+             WHEN fonte = 'B. t2_h1'                THEN 'B. t2_h1 -> 1a metade (in-sample)'
+             ELSE fonte END                                          AS avaliacao,
+        composicao.nome                                              AS composicao,
+        fixture_id,
+        LEAST(GREATEST(SAFE_DIVIDE(composicao.pts, composicao.teto) * 100, 0), 100) AS nota_pct,
+        IF(ganhou, best_odd, 0) - 1                                  AS lucro
+    FROM notas
+    CROSS JOIN UNNEST([
+        STRUCT('1. nota_premissas' AS nome, nota_pts AS pts, pts_max AS teto),
+        STRUCT('2. score_pos_a1'   AS nome,
+               nota_pts + pts_corroboracao
+                        - penalidades_globais_pts - penalidades_especificas_pts AS pts,
+               pts_max + 15 AS teto)
+    ]) AS composicao
+    WHERE pts_max > 0
+),
+
+com_faixa AS (
+    SELECT *,
+           CASE WHEN nota_pct >= 80 THEN 'e. 80-100'
+                WHEN nota_pct >= 60 THEN 'd. 60-80'
+                WHEN nota_pct >= 40 THEN 'c. 40-60'
+                WHEN nota_pct >= 20 THEN 'b. 20-40'
+                ELSE                     'a. 00-20' END AS faixa,
+           AVG(lucro) OVER (PARTITION BY avaliacao, composicao,
+                            CASE WHEN nota_pct >= 80 THEN 5 WHEN nota_pct >= 60 THEN 4
+                                 WHEN nota_pct >= 40 THEN 3 WHEN nota_pct >= 20 THEN 2
+                                 ELSE 1 END)            AS media_faixa
+    FROM avaliado
+),
+
+{#- Erro-padrão agrupado por fixture: soma dos resíduos DENTRO do jogo, ao quadrado,
+    somada entre jogos, sobre n². É a variância cluster-robusta da média. -#}
+por_fixture AS (
+    SELECT avaliacao, composicao, faixa, fixture_id,
+           SUM(lucro - media_faixa) AS resid_jogo
+    FROM com_faixa
+    GROUP BY 1, 2, 3, 4
+),
+erro AS (
+    SELECT avaliacao, composicao, faixa,
+           SUM(POW(resid_jogo, 2)) AS soma_quad,
+           COUNT(*)                AS n_jogos
+    FROM por_fixture GROUP BY 1, 2, 3
+),
+
+faixas AS (
+    SELECT
+        c.avaliacao, c.composicao, c.faixa,
+        COUNT(*)                                   AS n_apostas,
+        e.n_jogos,
+        ROUND(AVG(c.nota_pct), 1)                  AS nota_media,
+        ROUND(AVG(c.lucro) * 100, 1)               AS roi,
+        ROUND(SAFE_DIVIDE(SQRT(e.soma_quad), COUNT(*)) * 100, 1) AS ep_cluster,
+        CAST(NULL AS FLOAT64)                      AS inclinacao
+    FROM com_faixa AS c
+    JOIN erro AS e USING (avaliacao, composicao, faixa)
+    GROUP BY c.avaliacao, c.composicao, c.faixa, e.soma_quad, e.n_jogos
+),
+
+{#- A pergunta "sobe?" sem binning: inclinação do lucro contra a nota (pp de ROI por
+    ponto de nota) e a correlação. Usa todas as apostas, sem perder poder p/ faixa. -#}
+continuo AS (
+    SELECT
+        avaliacao, composicao, 'z. CONTINUO (todas)' AS faixa,
+        COUNT(*)                                       AS n_apostas,
+        COUNT(DISTINCT fixture_id)                     AS n_jogos,
+        ROUND(AVG(nota_pct), 1)                        AS nota_media,
+        ROUND(AVG(lucro) * 100, 1)                     AS roi,
+        CAST(NULL AS FLOAT64)                          AS ep_cluster,
+        -- pp de ROI por ponto de nota. Positivo = o ROI sobe com a nota.
+        ROUND(COVAR_SAMP(lucro, nota_pct)
+              / NULLIF(VAR_SAMP(nota_pct), 0) * 100, 3) AS inclinacao
+    FROM com_faixa
+    GROUP BY avaliacao, composicao
+)
+
+SELECT * FROM faixas
+UNION ALL SELECT * FROM continuo
+ORDER BY composicao, avaliacao, faixa

--- a/dbt_futebol/analyses/task01_teste4_permutacao.sql
+++ b/dbt_futebol/analyses/task01_teste4_permutacao.sql
@@ -1,0 +1,156 @@
+{#
+    Task [0.1] — TESTE 4, curva NULA por permutação.  Ticket #8, spec #3.
+
+    O `task01_teste4.sql` mediu a inclinação do ROI contra a nota: +0,238 pp por ponto
+    de nota com pesos do Teste 2, e +0,223 out-of-sample. A pergunta que falta é a única
+    que dá significado a esses números: **qual inclinação o ACASO produz nesta amostra?**
+
+    Com 169 jogos e apostas correlacionadas dentro de cada jogo, uma inclinação positiva
+    pode ser inteiramente ruído. Sem a distribuição nula, +0,223 é um número sem régua.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    MÉTODO: 200 réplicas. Em cada uma, os pesos são EMBARALHADOS entre as premissas do
+    MESMO mercado — a distribuição de pesos fica idêntica, muda só quem recebe qual.
+
+    Isso isola exatamente a hipótese em teste. Se a nota ordena porque as premissas
+    certas têm os pesos certos, embaralhar destrói o sinal. Se ela ordena por qualquer
+    razão estrutural (mercados com pesos maiores serem melhores, faixas altas terem
+    odds diferentes), o embaralhamento preserva — e a inclinação observada não prova
+    nada sobre as premissas.
+
+    AUTOTESTE: se a mediana das réplicas embaralhadas vier claramente positiva, o
+    defeito está na normalização ou no binning, não no mundo — e o Teste 4 inteiro não
+    está pronto. É critério de aceite do ticket #8.
+    ────────────────────────────────────────────────────────────────────────────────
+
+    → RESULTADOS: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_teste4_permutacao
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_teste4_permutacao.sql
+#}
+
+{%- set n_reps = 200 -%}
+
+WITH {{ task01_base() }},
+
+validas AS (
+    SELECT * FROM apostas WHERE NOT conjunto_incompleto
+),
+
+para_peso AS (
+    SELECT a.market_id, a.ganhou, a.prob_justa_fechamento, pl.premissa, pl.acesa
+    FROM validas AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    WHERE a.benchmark = CASE a.market_id
+                            WHEN 12 THEN 'derivada'
+                            WHEN 8  THEN 'consenso'
+                            ELSE         'sharp'
+                        END
+      AND a.min_jogos >= 5
+),
+
+{#- Pesos reais do Teste 2, piso 5 — os mesmos do `task01_teste4.sql`. -#}
+pesos AS (
+    SELECT market_id, premissa,
+           GREATEST((AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+                   - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100, 0)
+           * SAFE_DIVIDE(COUNTIF(acesa), COUNTIF(acesa) + 50) AS peso
+    FROM para_peso
+    GROUP BY market_id, premissa
+),
+
+{#- Réplica 0 = a atribuição VERDADEIRA; 1..N = embaralhadas. Manter a real dentro da
+    mesma máquina garante que ela e o nulo passem pelo mesmo caminho de código. -#}
+reps AS (
+    SELECT rep FROM UNNEST(GENERATE_ARRAY(0, {{ n_reps }})) AS rep
+),
+
+{#- Duas ordenações do mesmo conjunto de pesos por mercado: a premissa recebe o peso que
+    caiu na sua posição sorteada. Na réplica 0 as duas ordens coincidem. -#}
+ordenado AS (
+    SELECT
+        p.market_id, p.premissa, p.peso,
+        r.rep,
+        ROW_NUMBER() OVER (PARTITION BY p.market_id, r.rep ORDER BY p.premissa) AS pos_real,
+        ROW_NUMBER() OVER (PARTITION BY p.market_id, r.rep
+                           ORDER BY IF(r.rep = 0,
+                                       CAST(FARM_FINGERPRINT(p.premissa) AS FLOAT64),
+                                       CAST(FARM_FINGERPRINT(CONCAT(p.premissa, '#',
+                                            CAST(r.rep AS STRING))) AS FLOAT64))) AS pos_sorteada
+    FROM pesos AS p
+    CROSS JOIN reps AS r
+),
+pesos_rep AS (
+    SELECT
+        a.market_id, a.rep, a.premissa,
+        IF(a.rep = 0, a.peso, b.peso) AS peso
+    FROM ordenado AS a
+    JOIN ordenado AS b
+      ON b.market_id = a.market_id AND b.rep = a.rep AND b.pos_real = a.pos_sorteada
+),
+teto AS (
+    SELECT market_id, rep, SUM(peso) AS pts_max FROM pesos_rep GROUP BY market_id, rep
+),
+
+notas AS (
+    SELECT
+        a.fixture_id, pr.rep,
+        LEAST(GREATEST(SAFE_DIVIDE(SUM(IF(pl.acesa, pr.peso, 0)),
+                                   ANY_VALUE(t.pts_max)) * 100, 0), 100) AS nota_pct,
+        IF(ANY_VALUE(a.ganhou), ANY_VALUE(a.best_odd), 0) - 1            AS lucro
+    FROM validas AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    JOIN pesos_rep AS pr
+      ON pr.market_id = pl.market_id AND pr.premissa = pl.premissa
+    JOIN teto AS t
+      ON t.market_id = a.market_id AND t.rep = pr.rep
+    GROUP BY a.fixture_id, a.market_id, a.outcome_side, a.line_value, pr.rep
+),
+
+inclinacoes AS (
+    SELECT
+        rep,
+        COVAR_SAMP(lucro, nota_pct) / NULLIF(VAR_SAMP(nota_pct), 0) * 100 AS inclinacao,
+        -- Separação entre a faixa alta e a baixa, em pp de ROI. É a leitura de produto:
+        -- "apostar só nas notas altas rende quanto a mais que apostar só nas baixas?"
+        (AVG(IF(nota_pct >= 60, lucro, NULL)) - AVG(IF(nota_pct < 20, lucro, NULL))) * 100
+                                                                          AS gap_alta_baixa
+    FROM notas
+    GROUP BY rep
+),
+
+observado AS (SELECT inclinacao, gap_alta_baixa FROM inclinacoes WHERE rep = 0),
+nulo      AS (SELECT * FROM inclinacoes WHERE rep > 0)
+
+SELECT
+    'inclinacao (pp de ROI por ponto de nota)'                    AS metrica,
+    ROUND(ANY_VALUE(o.inclinacao), 3)                             AS observado,
+    ROUND(APPROX_QUANTILES(n.inclinacao, 100)[OFFSET(50)], 3)     AS nulo_mediana,
+    ROUND(APPROX_QUANTILES(n.inclinacao, 100)[OFFSET(5)],  3)     AS nulo_p05,
+    ROUND(APPROX_QUANTILES(n.inclinacao, 100)[OFFSET(95)], 3)     AS nulo_p95,
+    ROUND(MAX(n.inclinacao), 3)                                   AS nulo_max,
+    -- p-valor unicaudal: fração das réplicas embaralhadas que igualam ou superam o
+    -- observado. É a régua que faltava.
+    ROUND(SAFE_DIVIDE(COUNTIF(n.inclinacao >= o.inclinacao), COUNT(*)), 3) AS p_valor
+FROM nulo AS n CROSS JOIN observado AS o
+
+UNION ALL
+
+SELECT
+    'gap faixa alta (>=60) menos faixa baixa (<20), em pp',
+    ROUND(ANY_VALUE(o.gap_alta_baixa), 1),
+    ROUND(APPROX_QUANTILES(n.gap_alta_baixa, 100)[OFFSET(50)], 1),
+    ROUND(APPROX_QUANTILES(n.gap_alta_baixa, 100)[OFFSET(5)],  1),
+    ROUND(APPROX_QUANTILES(n.gap_alta_baixa, 100)[OFFSET(95)], 1),
+    ROUND(MAX(n.gap_alta_baixa), 1),
+    ROUND(SAFE_DIVIDE(COUNTIF(n.gap_alta_baixa >= o.gap_alta_baixa), COUNT(*)), 3)
+FROM nulo AS n CROSS JOIN observado AS o

--- a/dbt_futebol/analyses/task01_teste4_piso.sql
+++ b/dbt_futebol/analyses/task01_teste4_piso.sql
@@ -1,0 +1,160 @@
+{#
+    Task [0.1] — TESTE 4 sob piso de amostra, coerente nas duas pontas, mais a variante
+    de premissa forte.  Ticket #9, spec #3.
+
+    ════════════════════════════════════════════════════════════════════════════════
+    CORRIGE UMA INCOERÊNCIA DO #8: lá o piso de 5 foi aplicado aos PESOS, mas o ROI foi
+    medido no universo inteiro. A decisão registrada era aplicar o MESMO filtro nas duas
+    pontas — senão o artefato de amostra curta entra pelos pesos e sai filtrado na
+    medição, com as duas metades descrevendo universos diferentes.
+
+    Aqui cada corte é coerente: piso P gera os pesos com P e mede o ROI com P.
+    ════════════════════════════════════════════════════════════════════════════════
+    VARIANTE DE PREMISSA FORTE: guarda-corpo contra a nota somar por acúmulo de sinal
+    fraco. Exige que ao menos UMA premissa acesa tenha ganho medido >= 5 pp no Teste 2
+    daquele piso. Usa o ganho CRU e não o peso encolhido de propósito — "forte" é sobre
+    o tamanho do efeito, não sobre quanto dele sobreviveu à amostra.
+
+    COMPOSIÇÃO POR COMPETIÇÃO: o piso não é um botão de qualidade de amostra, é um
+    filtro de competição disfarçado — mata-mata é estruturalmente de amostra curta. O
+    bloco C mostra o que cada corte deixa de pé, para que a escolha do piso seja feita
+    de olhos abertos.
+
+    → RESULTADOS: `docs/TASK01_RESULTADOS.md`.
+
+    Rodar com:
+      dbt compile --select task01_teste4_piso
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/task01_teste4_piso.sql
+#}
+
+{%- set pisos = [0, 5, 10] -%}
+
+WITH {{ task01_base() }},
+
+validas AS (
+    SELECT * FROM apostas WHERE NOT conjunto_incompleto
+),
+
+linhas_prem AS (
+    SELECT a.*, pl.premissa, pl.acesa
+    FROM validas AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+),
+
+{#- Pesos por piso, medidos só no benchmark preferido de cada mercado. -#}
+pesos AS (
+    {%- for piso in pisos %}
+    {%- if not loop.first %}
+    UNION ALL
+    {%- endif %}
+    SELECT
+        {{ piso }} AS piso, market_id, premissa,
+        (AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+       - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100 AS ganho,
+        GREATEST((AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+                - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100, 0)
+        * SAFE_DIVIDE(COUNTIF(acesa), COUNTIF(acesa) + 50)   AS peso
+    FROM linhas_prem
+    WHERE min_jogos >= {{ piso }}
+      AND benchmark = CASE market_id WHEN 12 THEN 'derivada'
+                                     WHEN 8  THEN 'consenso'
+                                     ELSE         'sharp' END
+    GROUP BY market_id, premissa
+    {%- endfor %}
+),
+teto AS (SELECT piso, market_id, SUM(peso) AS pts_max FROM pesos GROUP BY piso, market_id),
+
+{#- Nota por (aposta, piso). O universo de AVALIAÇÃO também respeita o piso. -#}
+notas AS (
+    SELECT
+        l.fixture_id, l.market_id, p.piso,
+        LEAST(GREATEST(SAFE_DIVIDE(SUM(IF(l.acesa, p.peso, 0)),
+                                   ANY_VALUE(t.pts_max)) * 100, 0), 100) AS nota_pct,
+        IF(ANY_VALUE(l.ganhou), ANY_VALUE(l.best_odd), 0) - 1            AS lucro,
+        -- guarda-corpo: alguma premissa acesa com ganho medido >= 5 pp?
+        LOGICAL_OR(l.acesa AND p.ganho >= 5)                             AS tem_forte
+    FROM linhas_prem AS l
+    JOIN pesos AS p
+      ON p.market_id = l.market_id AND p.premissa = l.premissa
+    JOIN teto AS t
+      ON t.piso = p.piso AND t.market_id = l.market_id
+    WHERE l.min_jogos >= p.piso
+    GROUP BY l.fixture_id, l.market_id, l.outcome_side, l.line_value, p.piso
+),
+
+expandido AS (
+    SELECT n.*, v.variante
+    FROM notas AS n
+    CROSS JOIN UNNEST([STRUCT('1. todas'              AS variante),
+                       STRUCT('2. com premissa forte' AS variante)]) AS v
+    WHERE v.variante = '1. todas' OR n.tem_forte
+),
+
+resumo AS (
+    SELECT
+        'A. resumo' AS bloco,
+        CONCAT('piso ', LPAD(CAST(piso AS STRING), 2, '0')) AS corte,
+        variante,
+        COUNT(*)                                            AS n_apostas,
+        COUNT(DISTINCT fixture_id)                          AS n_jogos,
+        ROUND(AVG(lucro) * 100, 1)                          AS roi_geral,
+        ROUND(COVAR_SAMP(lucro, nota_pct)
+              / NULLIF(VAR_SAMP(nota_pct), 0) * 100, 3)     AS inclinacao,
+        ROUND((AVG(IF(nota_pct >= 60, lucro, NULL))
+             - AVG(IF(nota_pct <  20, lucro, NULL))) * 100, 1) AS gap_alta_baixa,
+        CAST(NULL AS STRING)                                AS faixa,
+        CAST(NULL AS FLOAT64)                               AS roi_faixa,
+        CAST(NULL AS FLOAT64)                               AS jogos_medios
+    FROM expandido
+    GROUP BY piso, variante
+),
+
+faixas AS (
+    SELECT
+        'B. faixas' AS bloco,
+        CONCAT('piso ', LPAD(CAST(piso AS STRING), 2, '0')) AS corte,
+        variante,
+        COUNT(*)                                            AS n_apostas,
+        COUNT(DISTINCT fixture_id)                          AS n_jogos,
+        CAST(NULL AS FLOAT64)                               AS roi_geral,
+        CAST(NULL AS FLOAT64)                               AS inclinacao,
+        CAST(NULL AS FLOAT64)                               AS gap_alta_baixa,
+        CASE WHEN nota_pct >= 80 THEN 'e. 80-100'
+             WHEN nota_pct >= 60 THEN 'd. 60-80'
+             WHEN nota_pct >= 40 THEN 'c. 40-60'
+             WHEN nota_pct >= 20 THEN 'b. 20-40'
+             ELSE                     'a. 00-20' END        AS faixa,
+        ROUND(AVG(lucro) * 100, 1)                          AS roi_faixa,
+        CAST(NULL AS FLOAT64)                               AS jogos_medios
+    FROM expandido
+    GROUP BY piso, variante, faixa
+),
+
+{#- O que cada piso deixa de pé, por competição. -#}
+composicao AS (
+    SELECT
+        'C. composicao' AS bloco,
+        CONCAT('piso ', LPAD(CAST(p.piso AS STRING), 2, '0')) AS corte,
+        v.competition                                       AS variante,
+        COUNT(*)                                            AS n_apostas,
+        COUNT(DISTINCT v.fixture_id)                        AS n_jogos,
+        ROUND(AVG(v.lucro_) * 100, 1)                       AS roi_geral,
+        CAST(NULL AS FLOAT64)                               AS inclinacao,
+        CAST(NULL AS FLOAT64)                               AS gap_alta_baixa,
+        CAST(NULL AS STRING)                                AS faixa,
+        CAST(NULL AS FLOAT64)                               AS roi_faixa,
+        ROUND(AVG(v.min_jogos), 1)                          AS jogos_medios
+    FROM (SELECT *, IF(ganhou, best_odd, 0) - 1 AS lucro_ FROM validas) AS v
+    CROSS JOIN (SELECT DISTINCT piso FROM pesos) AS p
+    WHERE v.min_jogos >= p.piso
+    GROUP BY p.piso, v.competition
+)
+
+SELECT * FROM resumo
+UNION ALL SELECT * FROM faixas
+UNION ALL SELECT * FROM composicao
+ORDER BY bloco, corte, variante, faixa

--- a/dbt_futebol/docs/adr/0001-nota-ponderada-exige-controle-out-of-sample.md
+++ b/dbt_futebol/docs/adr/0001-nota-ponderada-exige-controle-out-of-sample.md
@@ -1,0 +1,40 @@
+---
+status: accepted
+---
+
+# A nota ponderada exige controle out-of-sample
+
+O Teste 2 só existe onde existe odd, então os pesos das premissas e o ROI que os
+avalia saem **das mesmas ~168 partidas**. Ajustar e avaliar no mesmo dado produz curva
+de ROI ascendente mesmo em dado aleatório — e o critério de aceite da Task [0.1] ("se
+o ROI subir com a nota, a gente tem produto") aponta exatamente na direção que esse
+viés fabrica. Decidimos, portanto, que **nenhuma conclusão de produto sai só do corte
+in-sample**: o Teste 4 roda como especificado (pesos do Teste 2) acompanhado de dois
+controles — pesos derivados do Teste 1, cujo universo de ~8.400 jogos encerrados é
+disjunto do universo onde o ROI é medido, e um teste de permutação que mostra qual
+curva o acaso produz em 168 jogos.
+
+Pela mesma razão, o peso de uma premissa é `max(ganho, 0) × n/(n+k)` e não o ganho
+cru. O achado central da Task [0] foi que **amostra curta fabrica sinal**: os +9,7%
+vinham inteiramente de competições de mata-mata com 0,8 a 2,4 jogos disputados. Peso
+proporcional ao ganho bruto daria as maiores notas justamente às premissas que
+acenderam poucas vezes, reimportando o artefato pela porta dos pesos.
+
+## Alternativas consideradas
+
+- **Rodar o pedido literal e rotular como in-sample.** Rejeitada: a única leitura que
+  sobreviveria seria um resultado plano, e "subiu" é o resultado que já foi
+  pré-associado a "existe produto".
+- **Tirar os pesos do Teste 1 e só dele.** Rejeitada: contraria a distinção correta do
+  Victor Diody — o Teste 1 mede prever a linha, o Teste 2 mede bater o preço, e foi
+  essa distinção que primeiro salvou e depois derrubou o `xg_combinado_alto`. Vira
+  controle, não fonte.
+- **Validação cruzada dentro das 168 partidas.** Rejeitada por poder: cada fold ficaria
+  com ~34 jogos e a estimativa não distinguiria nada de nada.
+
+## Consequências
+
+Saem três curvas em vez de uma. Se as três concordarem, a conclusão é forte em
+qualquer direção. Se só a in-sample subir, a conclusão é "não há produto detectável
+nesta amostra" — e o gargalo passa a ser a task C2 (ampliar a coleta de odds), não a
+calibragem de peso.

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -3,23 +3,32 @@
 
     Existe para que a reconciliação por resposta conhecida signifique alguma coisa: se
     ela rodasse uma máquina diferente da que produz os resultados finais, não provaria
-    nada. Toda análise da task consome ESTA definição de universo, liquidação e filtro
-    de meia-linha — nenhuma redefine a sua.
+    nada. Toda análise da task consome ESTA definição de universo, liquidação e escopo
+    de mercado — nenhuma redefine a sua.
 
     Uso:
 
         WITH {{ task01_base(cutoff='2026-08-02') }},
         minha_cte AS ( ... )
-        SELECT ... FROM bets
+        SELECT ... FROM apostas
 
-    Expõe duas CTEs finais:
+    ⚠️ O macro emite SEIS CTEs no escopo do chamador, não duas. Uma CTE do chamador com
+    qualquer um destes nomes sombreia a do macro em silêncio:
 
-      bets      grão (market_id, fixture_id, outcome_side, line_value) — uma aposta.
-                Traz melhor odd, edge, prob justa, benchmark de preço, liquidação
-                (`ganhou`), contagem de premissas acesas e o piso de amostra do jogo.
+      jogos_encerrados  grão (fixture_id) — jogos liquidados dentro do `cutoff`.
+      odds              grão (fixture, mercado, lado, linha) — TODOS os mercados
+                        coletados, sem recorte de escopo e sem recorte de janela.
+      prem_long         grão (… , premissa) — uma linha por premissa por linha de
+                        aposta, com `acesa`. Insumo do Teste 2 e da nota ponderada.
+      prem_n            grão de aposta — contagem de premissas acesas.
+      pit               grão (fixture_id) — piso de amostra do jogo.
+      apostas           grão de aposta, JÁ recortado (escopo, janela, meia-linha).
+                        Traz melhor odd, edge, prob justa, benchmark, liquidação
+                        (`ganhou`), contagem de premissas e piso de amostra.
 
-      prem_long grão (… , premissa) — uma linha por premissa por aposta, com `acesa`.
-                É o insumo do Teste 2 e da nota ponderada.
+    As duas que interessam ao consumidor comum são `apostas` e `prem_long`. As outras
+    quatro ficam expostas de propósito: a guarda de descarte silencioso precisa enxergar
+    `odds` ANTES de qualquer recorte, senão não consegue ver o que o recorte come.
 
     Fidelidade: o universo, a liquidação por mercado e o filtro de meia-linha são os
     mesmos que produziram os números publicados no re-run da Task [0]. Mudar qualquer
@@ -27,7 +36,9 @@
 #}
 
 
-{#- Catálogo das 39 premissas por mercado.
+{#- Catálogo das 39 premissas por mercado. É também a FONTE ÚNICA do escopo de mercado
+    do Motor — o filtro `market_id IN (...)` abaixo é derivado daqui, não digitado de
+    novo.
 
     NÃO derivar de "todas as colunas BOOL do modelo": os modelos carregam flags que não
     são premissa (`pick_empate`, `desfalque_proprio`, `is_favorito`, `is_azarao`,
@@ -37,12 +48,14 @@
     {{ return({
         1: {
             'model': 'int_futebol_premissas_1x2',
+            'nome': '1X2',
             'has_line': false,
             'cols': ['forca_mismatch', 'superioridade_xg', 'mando', 'desfalque_adversario',
                      'superioridade_tabela', 'forma', 'h2h_favoravel']
         },
         5: {
             'model': 'int_futebol_premissas_ou',
+            'nome': 'Gols',
             'has_line': true,
             'cols': ['ataque_combinado', 'defesas_vazaveis', 'xg_combinado_alto', 'ritmo_alto',
                      'ambos_vazam', 'historico_over', 'linha_subindo', 'defesas_firmes',
@@ -51,6 +64,7 @@
         },
         4: {
             'model': 'int_futebol_premissas_ah',
+            'nome': 'Handicap',
             'has_line': true,
             'cols': ['supremacia', 'tende_golear', 'adversario_fragil_fora', 'mando_forte',
                      'sem_rodizio', 'raramente_perde_por_2', 'defesa_fora_solida',
@@ -58,12 +72,14 @@
         },
         8: {
             'model': 'int_futebol_premissas_btts',
+            'nome': 'BTTS',
             'has_line': false,
             'cols': ['ambos_marcam', 'ataque_dos_dois', 'defesas_vazaveis', 'historico_btts',
                      'defesa_forte', 'ataque_trava', 'historico_seco']
         },
         12: {
             'model': 'int_futebol_premissas_dc',
+            'nome': 'Dupla Chance',
             'has_line': false,
             'cols': ['lado_coberto_forte', 'equilibrio_defensivo', 'adversario_limitado',
                      'invicto_recente']
@@ -72,11 +88,23 @@
 {% endmacro %}
 
 
+{#- Só meia-linha em Handicap e Over/Under: elimina push, que não tem liquidação
+    binária. MOD() do BQ devolve negativo p/ linha AH negativa -> ABS() antes.
+
+    Existe como macro porque a guarda de descarte precisa do MESMO predicado fora da
+    CTE `apostas`. Duplicá-lo deixaria a guarda derivar em silêncio da coisa que ela
+    guarda. `alias` inclui o ponto: task01_meia_linha('o.') -#}
+{% macro task01_meia_linha(alias='') %}
+    ({{ alias }}market_id NOT IN (4, 5)
+     OR MOD(CAST(ABS({{ alias }}line_value) * 2 AS INT64), 2) = 1)
+{% endmacro %}
+
+
 {% macro task01_base(cutoff=none) %}
 
 {#- Jogos encerrados. `cutoff` congela a janela p/ reconciliar contra número publicado;
-    sem ele, o universo é tudo que já foi liquidado até hoje. -#}
-fx AS (
+    sem ele, o universo é tudo que já foi liquidado até hoje (o caso dos tickets #5+). -#}
+jogos_encerrados AS (
     SELECT
         fixture_id,
         competition,
@@ -94,10 +122,15 @@ fx AS (
       {%- endif %}
 ),
 
-{#- Benchmark de preço: a Pinnacle não precifica todos os mercados. Dupla Chance(12) é
-    DERIVADA do de-vig 1X2 da Pinnacle (âncora sharp); BTTS(8) cai no consenso (mediana
-    das casas), que remove a margem mas mira casa mole. Rotular é obrigatório — ganho
-    contra consenso não é comparável em grau com ganho contra linha sharp. -#}
+{#- TODOS os mercados coletados, SEM recorte de escopo e SEM recorte de janela. O
+    recorte acontece em `apostas`; aqui não, porque a guarda de descarte silencioso
+    precisa de uma referência anterior a ele p/ medir o que ele come.
+
+    Benchmark de preço: a Pinnacle não precifica todos os mercados. Dupla Chance(12) é
+    DERIVADA do de-vig 1X2 da Pinnacle (âncora sharp, e é por isso que ela chega aqui
+    carimbada como valor_fonte='pinnacle'); BTTS(8) cai no consenso (mediana das casas),
+    que remove a margem mas mira casa mole. Rotular é obrigatório — ganho contra
+    consenso não é comparável em grau com ganho contra linha sharp. -#}
 odds AS (
     SELECT
         fixture_id,
@@ -115,20 +148,12 @@ odds AS (
             ELSE valor_fonte
         END AS benchmark
     FROM {{ ref('int_futebol_odds_devig') }}
-    WHERE best_odd IS NOT NULL
-      AND edge     IS NOT NULL
-      -- Escopo do Motor, DECLARADO e não herdado do JOIN. A coleta traz mercados que o
-      -- Motor não pontua — 6 (Goals Over/Under First Half), 7 (HT/FT Double), 10 (Exact
-      -- Score) — e eles não têm modelo de premissas. Sem esta linha eles cairiam pelo
-      -- INNER JOIN com prem_n, o que é correto por acidente: só do 6 são ~3,6 mil linhas
-      -- sumindo em silêncio na janela congelada. Escopo é decisão, não efeito colateral.
-      AND market_id IN (1, 4, 5, 8, 12)
 ),
 
 {#- Premissas em formato longo: uma linha por (aposta, premissa).
 
     ATENÇÃO: `prem_long` NÃO é filtrado pelo `cutoff` nem pelo universo de jogos
-    encerrados — ele é o modelo inteiro. O recorte chega pelo JOIN com `bets`. Quem
+    encerrados — ele é o modelo inteiro. O recorte chega pelo JOIN com `apostas`. Quem
     consumir `prem_long` sozinho (o Teste 1, que não usa odd) precisa aplicar o seu
     próprio universo, senão mede em cima de jogos que ainda não aconteceram. -#}
 prem_long AS (
@@ -173,18 +198,18 @@ prem_n AS (
     degradação graciosa do modelo). -#}
 pit AS (
     SELECT
-        f.fixture_id,
+        j.fixture_id,
         LEAST(COALESCE(h.played_total, 0), COALESCE(a.played_total, 0)) AS min_jogos
-    FROM fx AS f
+    FROM jogos_encerrados AS j
     LEFT JOIN {{ ref('int_futebol_team_form_pit') }} AS h
-           ON h.fixture_id = f.fixture_id
-          AND h.team_id    = f.home_team_id
+           ON h.fixture_id = j.fixture_id
+          AND h.team_id    = j.home_team_id
     LEFT JOIN {{ ref('int_futebol_team_form_pit') }} AS a
-           ON a.fixture_id = f.fixture_id
-          AND a.team_id    = f.away_team_id
+           ON a.fixture_id = j.fixture_id
+          AND a.team_id    = j.away_team_id
 ),
 
-bets AS (
+apostas AS (
     SELECT
         o.market_id,
         o.fixture_id,
@@ -195,43 +220,43 @@ bets AS (
         o.n_casas,
         o.prob_justa_fechamento,
         o.benchmark,
-        f.competition,
-        f.season,
-        f.kickoff_utc,
+        j.competition,
+        j.season,
+        j.kickoff_utc,
         COALESCE(pit.min_jogos, 0) AS min_jogos,
         pn.n_prem,
         pn.n_prem_null,
         CASE
             WHEN o.market_id = 1 THEN
                 CASE o.outcome_side
-                    WHEN 'Home' THEN f.goals_home > f.goals_away
-                    WHEN 'Away' THEN f.goals_away > f.goals_home
-                    ELSE             f.goals_home = f.goals_away
+                    WHEN 'Home' THEN j.goals_home > j.goals_away
+                    WHEN 'Away' THEN j.goals_away > j.goals_home
+                    ELSE             j.goals_home = j.goals_away
                 END
             WHEN o.market_id = 5 THEN
                 IF(o.outcome_side = 'Over',
-                   f.goals_home + f.goals_away > o.line_value,
-                   f.goals_home + f.goals_away < o.line_value)
+                   j.goals_home + j.goals_away > o.line_value,
+                   j.goals_home + j.goals_away < o.line_value)
             -- line_value vem na ÓTICA DO MANDANTE e é igual p/ Home e Away.
             WHEN o.market_id = 4 THEN
                 IF(o.outcome_side = 'Home',
-                   f.goals_home + o.line_value > f.goals_away,
-                   f.goals_away - o.line_value > f.goals_home)
+                   j.goals_home + o.line_value > j.goals_away,
+                   j.goals_away - o.line_value > j.goals_home)
             WHEN o.market_id = 8 THEN
                 IF(o.outcome_side = 'Yes',
-                   f.goals_home > 0 AND f.goals_away > 0,
-                   NOT (f.goals_home > 0 AND f.goals_away > 0))
+                   j.goals_home > 0 AND j.goals_away > 0,
+                   NOT (j.goals_home > 0 AND j.goals_away > 0))
             -- O modelo de premissas da DC só emite '1X' e 'X2'; o ELSE é sempre 'X2'.
             -- As linhas de '12' existem nas odds, não têm premissa e caem no JOIN
             -- abaixo — uma saída inteira fora da medição. Reportado, não corrigido.
             WHEN o.market_id = 12 THEN
                 IF(o.outcome_side = '1X',
-                   f.goals_home >= f.goals_away,
-                   f.goals_away >= f.goals_home)
+                   j.goals_home >= j.goals_away,
+                   j.goals_away >= j.goals_home)
         END AS ganhou
     FROM odds AS o
-    JOIN fx AS f
-      ON f.fixture_id = o.fixture_id
+    JOIN jogos_encerrados AS j
+      ON j.fixture_id = o.fixture_id
     JOIN prem_n AS pn
       ON  pn.market_id                      = o.market_id
       AND pn.fixture_id                     = o.fixture_id
@@ -239,10 +264,15 @@ bets AS (
       AND COALESCE(pn.line_value, -999)     = COALESCE(o.line_value, -999)
     LEFT JOIN pit
       ON pit.fixture_id = o.fixture_id
-    -- Só meia-linha em AH e O/U: elimina push, que não tem liquidação binária.
-    -- MOD() do BQ devolve negativo p/ linha AH negativa -> ABS() antes.
-    WHERE (o.market_id NOT IN (4, 5)
-           OR MOD(CAST(ABS(o.line_value) * 2 AS INT64), 2) = 1)
+    WHERE o.best_odd IS NOT NULL
+      AND o.edge     IS NOT NULL
+      -- Escopo do Motor, DECLARADO e derivado do catálogo de premissas acima — não
+      -- digitado de novo. A coleta traz mercados que o Motor não pontua: 6 (Goals
+      -- Over/Under First Half), 7 (HT/FT Double), 10 (Exact Score). Sem esta linha eles
+      -- cairiam pelo INNER JOIN com prem_n, o que é correto por acidente: só do 6 são
+      -- ~3,6 mil linhas sumindo em silêncio na janela congelada.
+      AND o.market_id IN ({{ task01_markets().keys() | join(', ') }})
+      AND {{ task01_meia_linha('o.') }}
 )
 
 {% endmacro %}

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -100,6 +100,48 @@
 {% endmacro %}
 
 
+{#- Liquidação por mercado: a linha ganhou ou perdeu, dado o placar.
+
+    Existe como macro porque o Teste 1 liquida SEM odds — o universo dele é todo jogo
+    encerrado, não só os que têm preço — e precisa exatamente da mesma regra que o
+    Teste 2 e o Teste 3 usam. Duplicá-la deixaria os testes medindo coisas diferentes
+    sem ninguém perceber.
+
+    `linha` é o alias de quem traz market_id/outcome_side/line_value (a CTE de odds no
+    Teste 2/3, a de premissas no Teste 1); `jogo` é o alias do fixture. Ambos incluem o
+    ponto. -#}
+{% macro task01_liquidacao(linha, jogo) %}
+    CASE
+        WHEN {{ linha }}market_id = 1 THEN
+            CASE {{ linha }}outcome_side
+                WHEN 'Home' THEN {{ jogo }}goals_home > {{ jogo }}goals_away
+                WHEN 'Away' THEN {{ jogo }}goals_away > {{ jogo }}goals_home
+                ELSE             {{ jogo }}goals_home = {{ jogo }}goals_away
+            END
+        WHEN {{ linha }}market_id = 5 THEN
+            IF({{ linha }}outcome_side = 'Over',
+               {{ jogo }}goals_home + {{ jogo }}goals_away > {{ linha }}line_value,
+               {{ jogo }}goals_home + {{ jogo }}goals_away < {{ linha }}line_value)
+        -- line_value vem na ÓTICA DO MANDANTE e é igual p/ Home e Away.
+        WHEN {{ linha }}market_id = 4 THEN
+            IF({{ linha }}outcome_side = 'Home',
+               {{ jogo }}goals_home + {{ linha }}line_value > {{ jogo }}goals_away,
+               {{ jogo }}goals_away - {{ linha }}line_value > {{ jogo }}goals_home)
+        WHEN {{ linha }}market_id = 8 THEN
+            IF({{ linha }}outcome_side = 'Yes',
+               {{ jogo }}goals_home > 0 AND {{ jogo }}goals_away > 0,
+               NOT ({{ jogo }}goals_home > 0 AND {{ jogo }}goals_away > 0))
+        -- O modelo de premissas da DC só emite '1X' e 'X2'; o ELSE é sempre 'X2'. As
+        -- linhas de '12' existem nas odds, não têm premissa e caem no JOIN — uma saída
+        -- inteira fora da medição. Reportado, não corrigido.
+        WHEN {{ linha }}market_id = 12 THEN
+            IF({{ linha }}outcome_side = '1X',
+               {{ jogo }}goals_home >= {{ jogo }}goals_away,
+               {{ jogo }}goals_away >= {{ jogo }}goals_home)
+    END
+{% endmacro %}
+
+
 {% macro task01_base(cutoff=none) %}
 
 {#- Jogos encerrados. `cutoff` congela a janela p/ reconciliar contra número publicado;
@@ -140,13 +182,32 @@ odds AS (
         best_odd,
         edge,
         n_casas,
+        n_outcomes_valor,
         prob_justa_fechamento,
         valor_fonte,
         CASE
             WHEN market_id = 12           THEN 'derivada'
             WHEN valor_fonte = 'pinnacle' THEN 'sharp'
             ELSE valor_fonte
-        END AS benchmark
+        END AS benchmark,
+        -- ⚠️ Conjunto de saídas INCOMPLETO: só um lado da linha foi precificado. O
+        -- de-vig de consenso normaliza sobre o conjunto, então com um único outcome ele
+        -- devolve prob_justa = 1,0 — certeza — e o edge vira `odd − 1`. Uma odd de 150
+        -- aparece como "edge de 14.900%".
+        --
+        -- Medido no universo de análise: 172 linhas, TODAS consenso, 2 vitórias em 172,
+        -- ROI −35,5%. É o pior lugar possível para um erro de sinal — o Motor diz valor
+        -- máximo onde o acerto real é 1,2%.
+        --
+        -- PRODUÇÃO NÃO É AFETADA: o gate do mart exige n_casas >= 4 e conjunto Pinnacle
+        -- completo, e o board hoje tem edge máximo de 23% e odd máxima 4,5. Estas
+        -- linhas nunca chegam ao usuário.
+        --
+        -- Mas elas ESTÃO no universo de backtest, inclusive no que produziu os números
+        -- publicados — o backtest é mais permissivo que o board. Exposto como flag em
+        -- vez de filtrado aqui para que a reconciliação continue reproduzindo o
+        -- publicado; quem mede valor exclui e diz que excluiu.
+        COALESCE(n_outcomes_valor < 2, TRUE) AS conjunto_incompleto
     FROM {{ ref('int_futebol_odds_devig') }}
 ),
 
@@ -220,40 +281,14 @@ apostas AS (
         o.n_casas,
         o.prob_justa_fechamento,
         o.benchmark,
+        o.conjunto_incompleto,
         j.competition,
         j.season,
         j.kickoff_utc,
         COALESCE(pit.min_jogos, 0) AS min_jogos,
         pn.n_prem,
         pn.n_prem_null,
-        CASE
-            WHEN o.market_id = 1 THEN
-                CASE o.outcome_side
-                    WHEN 'Home' THEN j.goals_home > j.goals_away
-                    WHEN 'Away' THEN j.goals_away > j.goals_home
-                    ELSE             j.goals_home = j.goals_away
-                END
-            WHEN o.market_id = 5 THEN
-                IF(o.outcome_side = 'Over',
-                   j.goals_home + j.goals_away > o.line_value,
-                   j.goals_home + j.goals_away < o.line_value)
-            -- line_value vem na ÓTICA DO MANDANTE e é igual p/ Home e Away.
-            WHEN o.market_id = 4 THEN
-                IF(o.outcome_side = 'Home',
-                   j.goals_home + o.line_value > j.goals_away,
-                   j.goals_away - o.line_value > j.goals_home)
-            WHEN o.market_id = 8 THEN
-                IF(o.outcome_side = 'Yes',
-                   j.goals_home > 0 AND j.goals_away > 0,
-                   NOT (j.goals_home > 0 AND j.goals_away > 0))
-            -- O modelo de premissas da DC só emite '1X' e 'X2'; o ELSE é sempre 'X2'.
-            -- As linhas de '12' existem nas odds, não têm premissa e caem no JOIN
-            -- abaixo — uma saída inteira fora da medição. Reportado, não corrigido.
-            WHEN o.market_id = 12 THEN
-                IF(o.outcome_side = '1X',
-                   j.goals_home >= j.goals_away,
-                   j.goals_away >= j.goals_home)
-        END AS ganhou
+        {{ task01_liquidacao('o.', 'j.') }} AS ganhou
     FROM odds AS o
     JOIN jogos_encerrados AS j
       ON j.fixture_id = o.fixture_id

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -117,6 +117,12 @@ odds AS (
     FROM {{ ref('int_futebol_odds_devig') }}
     WHERE best_odd IS NOT NULL
       AND edge     IS NOT NULL
+      -- Escopo do Motor, DECLARADO e não herdado do JOIN. A coleta traz mercados que o
+      -- Motor não pontua — 6 (Goals Over/Under First Half), 7 (HT/FT Double), 10 (Exact
+      -- Score) — e eles não têm modelo de premissas. Sem esta linha eles cairiam pelo
+      -- INNER JOIN com prem_n, o que é correto por acidente: só do 6 são ~3,6 mil linhas
+      -- sumindo em silêncio na janela congelada. Escopo é decisão, não efeito colateral.
+      AND market_id IN (1, 4, 5, 8, 12)
 ),
 
 {#- Premissas em formato longo: uma linha por (aposta, premissa).

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -1,0 +1,242 @@
+{#
+    Base compartilhada das análises da Task [0.1] (issue #3).
+
+    Existe para que a reconciliação por resposta conhecida signifique alguma coisa: se
+    ela rodasse uma máquina diferente da que produz os resultados finais, não provaria
+    nada. Toda análise da task consome ESTA definição de universo, liquidação e filtro
+    de meia-linha — nenhuma redefine a sua.
+
+    Uso:
+
+        WITH {{ task01_base(cutoff='2026-08-02') }},
+        minha_cte AS ( ... )
+        SELECT ... FROM bets
+
+    Expõe duas CTEs finais:
+
+      bets      grão (market_id, fixture_id, outcome_side, line_value) — uma aposta.
+                Traz melhor odd, edge, prob justa, benchmark de preço, liquidação
+                (`ganhou`), contagem de premissas acesas e o piso de amostra do jogo.
+
+      prem_long grão (… , premissa) — uma linha por premissa por aposta, com `acesa`.
+                É o insumo do Teste 2 e da nota ponderada.
+
+    Fidelidade: o universo, a liquidação por mercado e o filtro de meia-linha são os
+    mesmos que produziram os números publicados no re-run da Task [0]. Mudar qualquer
+    um deles quebra a reconciliação de propósito.
+#}
+
+
+{#- Catálogo das 39 premissas por mercado.
+
+    NÃO derivar de "todas as colunas BOOL do modelo": os modelos carregam flags que não
+    são premissa (`pick_empate`, `desfalque_proprio`, `is_favorito`, `is_azarao`,
+    `handicap_alto`, `linha_extrema`) e a contagem infla. Esta lista é a que produziu os
+    números publicados. -#}
+{% macro task01_markets() %}
+    {{ return({
+        1: {
+            'model': 'int_futebol_premissas_1x2',
+            'has_line': false,
+            'cols': ['forca_mismatch', 'superioridade_xg', 'mando', 'desfalque_adversario',
+                     'superioridade_tabela', 'forma', 'h2h_favoravel']
+        },
+        5: {
+            'model': 'int_futebol_premissas_ou',
+            'has_line': true,
+            'cols': ['ataque_combinado', 'defesas_vazaveis', 'xg_combinado_alto', 'ritmo_alto',
+                     'ambos_vazam', 'historico_over', 'linha_subindo', 'defesas_firmes',
+                     'clean_sheets_altos', 'xg_baixo_combinado', 'ataques_fracos',
+                     'historico_under', 'linha_descendo']
+        },
+        4: {
+            'model': 'int_futebol_premissas_ah',
+            'has_line': true,
+            'cols': ['supremacia', 'tende_golear', 'adversario_fragil_fora', 'mando_forte',
+                     'sem_rodizio', 'raramente_perde_por_2', 'defesa_fora_solida',
+                     'favorito_irregular']
+        },
+        8: {
+            'model': 'int_futebol_premissas_btts',
+            'has_line': false,
+            'cols': ['ambos_marcam', 'ataque_dos_dois', 'defesas_vazaveis', 'historico_btts',
+                     'defesa_forte', 'ataque_trava', 'historico_seco']
+        },
+        12: {
+            'model': 'int_futebol_premissas_dc',
+            'has_line': false,
+            'cols': ['lado_coberto_forte', 'equilibrio_defensivo', 'adversario_limitado',
+                     'invicto_recente']
+        }
+    }) }}
+{% endmacro %}
+
+
+{% macro task01_base(cutoff=none) %}
+
+{#- Jogos encerrados. `cutoff` congela a janela p/ reconciliar contra número publicado;
+    sem ele, o universo é tudo que já foi liquidado até hoje. -#}
+fx AS (
+    SELECT
+        fixture_id,
+        competition,
+        season,
+        home_team_id,
+        away_team_id,
+        kickoff_utc,
+        goals_home,
+        goals_away
+    FROM {{ ref('fact_fixtures') }}
+    WHERE status_short = 'FT'
+      AND goals_home IS NOT NULL
+      {%- if cutoff is not none %}
+      AND DATE(kickoff_utc) <= DATE('{{ cutoff }}')
+      {%- endif %}
+),
+
+{#- Benchmark de preço: a Pinnacle não precifica todos os mercados. Dupla Chance(12) é
+    DERIVADA do de-vig 1X2 da Pinnacle (âncora sharp); BTTS(8) cai no consenso (mediana
+    das casas), que remove a margem mas mira casa mole. Rotular é obrigatório — ganho
+    contra consenso não é comparável em grau com ganho contra linha sharp. -#}
+odds AS (
+    SELECT
+        fixture_id,
+        market_id,
+        outcome_side,
+        line_value,
+        best_odd,
+        edge,
+        n_casas,
+        prob_justa_fechamento,
+        valor_fonte,
+        CASE
+            WHEN market_id = 12           THEN 'derivada'
+            WHEN valor_fonte = 'pinnacle' THEN 'sharp'
+            ELSE valor_fonte
+        END AS benchmark
+    FROM {{ ref('int_futebol_odds_devig') }}
+    WHERE best_odd IS NOT NULL
+      AND edge     IS NOT NULL
+),
+
+{#- Premissas em formato longo: uma linha por (aposta, premissa).
+
+    ATENÇÃO: `prem_long` NÃO é filtrado pelo `cutoff` nem pelo universo de jogos
+    encerrados — ele é o modelo inteiro. O recorte chega pelo JOIN com `bets`. Quem
+    consumir `prem_long` sozinho (o Teste 1, que não usa odd) precisa aplicar o seu
+    próprio universo, senão mede em cima de jogos que ainda não aconteceram. -#}
+prem_long AS (
+    {%- for mid, m in task01_markets().items() %}
+    {%- if not loop.first %}
+    UNION ALL
+    {%- endif %}
+    SELECT
+        {{ mid }} AS market_id,
+        p.fixture_id,
+        p.outcome AS outcome_side,
+        {% if m.has_line %}p.line_value{% else %}CAST(NULL AS FLOAT64){% endif %} AS line_value,
+        u.premissa,
+        u.acesa
+    FROM {{ ref(m.model) }} AS p
+    CROSS JOIN UNNEST([
+        {%- for c in m.cols %}
+        STRUCT('{{ c }}' AS premissa, p.{{ c }} AS acesa){{ "," if not loop.last }}
+        {%- endfor %}
+    ]) AS u
+    {%- endfor %}
+),
+
+{#- `n_prem_null` existe p/ diagnóstico: a degradação graciosa promete que premissa
+    nunca é NULL (dado faltante = não acende). Se a promessa falhar, contar por soma
+    (como a query original) e contar por COUNTIF divergem, e o número publicado não é
+    reproduzível. A reconciliação checa isso explicitamente. -#}
+prem_n AS (
+    SELECT
+        market_id,
+        fixture_id,
+        outcome_side,
+        line_value,
+        COUNTIF(acesa)         AS n_prem,
+        COUNTIF(acesa IS NULL) AS n_prem_null
+    FROM prem_long
+    GROUP BY 1, 2, 3, 4
+),
+
+{#- Piso de amostra do jogo: o MENOR played_total entre os dois times, porque as
+    premissas comparam os dois. Sem linha no PIT = sem histórico = 0 (mesma leitura da
+    degradação graciosa do modelo). -#}
+pit AS (
+    SELECT
+        f.fixture_id,
+        LEAST(COALESCE(h.played_total, 0), COALESCE(a.played_total, 0)) AS min_jogos
+    FROM fx AS f
+    LEFT JOIN {{ ref('int_futebol_team_form_pit') }} AS h
+           ON h.fixture_id = f.fixture_id
+          AND h.team_id    = f.home_team_id
+    LEFT JOIN {{ ref('int_futebol_team_form_pit') }} AS a
+           ON a.fixture_id = f.fixture_id
+          AND a.team_id    = f.away_team_id
+),
+
+bets AS (
+    SELECT
+        o.market_id,
+        o.fixture_id,
+        o.outcome_side,
+        o.line_value,
+        o.best_odd,
+        o.edge,
+        o.n_casas,
+        o.prob_justa_fechamento,
+        o.benchmark,
+        f.competition,
+        f.season,
+        f.kickoff_utc,
+        COALESCE(pit.min_jogos, 0) AS min_jogos,
+        pn.n_prem,
+        pn.n_prem_null,
+        CASE
+            WHEN o.market_id = 1 THEN
+                CASE o.outcome_side
+                    WHEN 'Home' THEN f.goals_home > f.goals_away
+                    WHEN 'Away' THEN f.goals_away > f.goals_home
+                    ELSE             f.goals_home = f.goals_away
+                END
+            WHEN o.market_id = 5 THEN
+                IF(o.outcome_side = 'Over',
+                   f.goals_home + f.goals_away > o.line_value,
+                   f.goals_home + f.goals_away < o.line_value)
+            -- line_value vem na ÓTICA DO MANDANTE e é igual p/ Home e Away.
+            WHEN o.market_id = 4 THEN
+                IF(o.outcome_side = 'Home',
+                   f.goals_home + o.line_value > f.goals_away,
+                   f.goals_away - o.line_value > f.goals_home)
+            WHEN o.market_id = 8 THEN
+                IF(o.outcome_side = 'Yes',
+                   f.goals_home > 0 AND f.goals_away > 0,
+                   NOT (f.goals_home > 0 AND f.goals_away > 0))
+            -- O modelo de premissas da DC só emite '1X' e 'X2'; o ELSE é sempre 'X2'.
+            -- As linhas de '12' existem nas odds, não têm premissa e caem no JOIN
+            -- abaixo — uma saída inteira fora da medição. Reportado, não corrigido.
+            WHEN o.market_id = 12 THEN
+                IF(o.outcome_side = '1X',
+                   f.goals_home >= f.goals_away,
+                   f.goals_away >= f.goals_home)
+        END AS ganhou
+    FROM odds AS o
+    JOIN fx AS f
+      ON f.fixture_id = o.fixture_id
+    JOIN prem_n AS pn
+      ON  pn.market_id                      = o.market_id
+      AND pn.fixture_id                     = o.fixture_id
+      AND pn.outcome_side                   = o.outcome_side
+      AND COALESCE(pn.line_value, -999)     = COALESCE(o.line_value, -999)
+    LEFT JOIN pit
+      ON pit.fixture_id = o.fixture_id
+    -- Só meia-linha em AH e O/U: elimina push, que não tem liquidação binária.
+    -- MOD() do BQ devolve negativo p/ linha AH negativa -> ABS() antes.
+    WHERE (o.market_id NOT IN (4, 5)
+           OR MOD(CAST(ABS(o.line_value) * 2 AS INT64), 2) = 1)
+)
+
+{% endmacro %}

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -12,8 +12,11 @@
         minha_cte AS ( ... )
         SELECT ... FROM apostas
 
-    ⚠️ O macro emite SEIS CTEs no escopo do chamador, não duas. Uma CTE do chamador com
+    ⚠️ O macro emite SETE CTEs no escopo do chamador, não duas. Uma CTE do chamador com
     qualquer um destes nomes sombreia a do macro em silêncio:
+
+      prem_linha        grão de aposta — atributos de linha vindos dos modelos de
+                        premissas (hoje a penalidade específica do mercado).
 
       jogos_encerrados  grão (fixture_id) — jogos liquidados dentro do `cutoff`.
       odds              grão (fixture, mercado, lado, linha) — TODOS os mercados
@@ -48,6 +51,7 @@
     {{ return({
         1: {
             'model': 'int_futebol_premissas_1x2',
+            'pen': 'penalidades_1x2_pts',
             'nome': '1X2',
             'has_line': false,
             'cols': ['forca_mismatch', 'superioridade_xg', 'mando', 'desfalque_adversario',
@@ -55,6 +59,7 @@
         },
         5: {
             'model': 'int_futebol_premissas_ou',
+            'pen': 'penalidades_ou_pts',
             'nome': 'Gols',
             'has_line': true,
             'cols': ['ataque_combinado', 'defesas_vazaveis', 'xg_combinado_alto', 'ritmo_alto',
@@ -64,6 +69,7 @@
         },
         4: {
             'model': 'int_futebol_premissas_ah',
+            'pen': 'penalidades_ah_pts',
             'nome': 'Handicap',
             'has_line': true,
             'cols': ['supremacia', 'tende_golear', 'adversario_fragil_fora', 'mando_forte',
@@ -72,6 +78,7 @@
         },
         8: {
             'model': 'int_futebol_premissas_btts',
+            'pen': 'penalidades_btts_pts',
             'nome': 'BTTS',
             'has_line': false,
             'cols': ['ambos_marcam', 'ataque_dos_dois', 'defesas_vazaveis', 'historico_btts',
@@ -79,6 +86,7 @@
         },
         12: {
             'model': 'int_futebol_premissas_dc',
+            'pen': 'penalidades_dc_pts',
             'nome': 'Dupla Chance',
             'has_line': false,
             'cols': ['lado_coberto_forte', 'equilibrio_defensivo', 'adversario_limitado',
@@ -185,6 +193,7 @@ odds AS (
         n_outcomes_valor,
         prob_justa_fechamento,
         valor_fonte,
+        penalidades_globais_pts,
         CASE
             WHEN market_id = 12           THEN 'derivada'
             WHEN valor_fonte = 'pinnacle' THEN 'sharp'
@@ -254,6 +263,25 @@ prem_n AS (
     GROUP BY 1, 2, 3, 4
 ),
 
+{#- Atributos de LINHA (não de premissa) que vivem nos modelos de premissas: hoje só a
+    penalidade específica do mercado. Separado de `prem_long` porque o grão é outro —
+    uma linha por aposta, não uma por premissa. Insumo da composição "Score pós-A1" do
+    Teste 4. -#}
+prem_linha AS (
+    {%- for mid, m in task01_markets().items() %}
+    {%- if not loop.first %}
+    UNION ALL
+    {%- endif %}
+    SELECT
+        {{ mid }} AS market_id,
+        fixture_id,
+        outcome AS outcome_side,
+        {% if m.has_line %}line_value{% else %}CAST(NULL AS FLOAT64){% endif %} AS line_value,
+        {{ m.pen }} AS penalidades_especificas_pts
+    FROM {{ ref(m.model) }}
+    {%- endfor %}
+),
+
 {#- Piso de amostra do jogo: o MENOR played_total entre os dois times, porque as
     premissas comparam os dois. Sem linha no PIT = sem histórico = 0 (mesma leitura da
     degradação graciosa do modelo). -#}
@@ -288,6 +316,14 @@ apostas AS (
         COALESCE(pit.min_jogos, 0) AS min_jogos,
         pn.n_prem,
         pn.n_prem_null,
+        -- Insumos da composição "Score pós-A1" do Teste 4. A A1 remove o componente de
+        -- VALOR da nota; corroboração e penalidades continuam. Nota: a corroboração
+        -- hoje só está implementada p/ 1X2 e o /predictions era ~vazio no histórico,
+        -- então ela é majoritariamente 0 — o que na prática torna o Score pós-A1
+        -- ≈ nota de premissas menos penalidades.
+        COALESCE(c.pts_corroboracao, 0)              AS pts_corroboracao,
+        COALESCE(o.penalidades_globais_pts, 0)       AS penalidades_globais_pts,
+        COALESCE(px.penalidades_especificas_pts, 0)  AS penalidades_especificas_pts,
         {{ task01_liquidacao('o.', 'j.') }} AS ganhou
     FROM odds AS o
     JOIN jogos_encerrados AS j
@@ -299,6 +335,16 @@ apostas AS (
       AND COALESCE(pn.line_value, -999)     = COALESCE(o.line_value, -999)
     LEFT JOIN pit
       ON pit.fixture_id = o.fixture_id
+    LEFT JOIN prem_linha AS px
+      ON  px.market_id                  = o.market_id
+      AND px.fixture_id                 = o.fixture_id
+      AND px.outcome_side               = o.outcome_side
+      AND COALESCE(px.line_value, -999) = COALESCE(o.line_value, -999)
+    LEFT JOIN {{ ref('int_futebol_corroboracao') }} AS c
+      ON  c.market_id                  = o.market_id
+      AND c.fixture_id                 = o.fixture_id
+      AND c.outcome_side               = o.outcome_side
+      AND COALESCE(c.line_value, -999) = COALESCE(o.line_value, -999)
     WHERE o.best_odd IS NOT NULL
       AND o.edge     IS NOT NULL
       -- Escopo do Motor, DECLARADO e derivado do catálogo de premissas acima — não

--- a/docs/TASK01_RESULTADOS.md
+++ b/docs/TASK01_RESULTADOS.md
@@ -515,6 +515,69 @@ para o corte temporal.
 
 ---
 
+## Ticket #9 — Piso coerente e a variante de premissa forte
+
+`analyses/task01_teste4_piso.sql` e `task01_premissa_forte.sql`
+
+Corrige uma incoerência do #8: lá o piso de 5 foi aplicado aos **pesos** mas o ROI foi
+medido no universo inteiro. Aqui cada corte é coerente — piso P gera os pesos com P e
+mede o ROI com P.
+
+### O piso é um filtro de competição, e o dado agora mostra o tamanho disso
+
+| Piso | Jogos | Competições que sobram |
+|---|---|---|
+| 0 | **169** | Copa do Mundo (79), Série B (39), Brasileirão (28), Sudamericana (15), Copa do Brasil (8) |
+| 5 | **69** | Brasileirão (28), Série B (39), Copa do Mundo (2) |
+| 10 | **67** | Brasileirão (28), Série B (39) |
+
+**Copa do Mundo é 47% da amostra e desaparece inteira.** O piso não corta jogos ruins,
+corta competições — e as que ele remove não são as piores: Sudamericana rende −1,6% e
+Copa do Mundo −9,7%, contra −13,4% do Brasileirão e −10,0% da Série B, que ficam.
+
+Exigir piso 10 reduz o universo a **67 jogos**. Qualquer calibragem fina em cima disso é
+ilusão, e é o argumento mais concreto que apareceu para a prioridade da task C2.
+
+### ⚠️ A variante de premissa forte: +10,0% que não sobrevive
+
+O corte "ao menos uma premissa com ganho ≥ 5 pp" produziu o **primeiro ROI positivo de
+toda a investigação**. Mas "forte" é definido pelo Teste 2 medido nos mesmos dados em que
+o ROI é medido — selecionar por critério ajustado à amostra e avaliar na mesma amostra é
+o procedimento que produziu os +9,7% que a Task [0] matou, trocando vazamento temporal
+por vazamento de seleção.
+
+O teste que decide, com "forte" definido **só na 1ª metade** e ROI medido **na 2ª**:
+
+| Piso | Cenário | n | ROI | ± EP |
+|---|---|---|---|---|
+| 5 | 1. todas as apostas, 2ª metade | 2.962 | −10,0 | 3,9 |
+| 5 | 2. forte de TODA a janela, ROI em toda (**in-sample**) | 1.235 | **+7,5** | 5,1 |
+| 5 | 3. forte de TODA a janela, ROI na 2ª metade | 1.065 | +8,3 | 5,7 |
+| 5 | 4. **forte só da 1ª metade, ROI na 2ª (OUT-OF-SAMPLE)** | 1.438 | **−6,2** | 3,4 |
+
+E o mesmo padrão nos outros pisos: **+10,0 → −3,5** (piso 0) e **+8,3 → −5,1** (piso 10).
+
+**A distância entre o cenário 3 e o 4 — 14,5 pontos percentuais — é viés de seleção
+puro.** Os dois medem o mesmo conjunto de jogos; a única diferença é se a definição de
+"forte" pôde ou não enxergar os resultados que ela seleciona.
+
+### O contraste que dá coerência a tudo
+
+| Objeto | In-sample | Out-of-sample | Sobrevive? |
+|---|---|---|---|
+| Nota ponderada (inclinação) | +0,228 | **+0,223** | **sim** |
+| Filtro "tem premissa forte" (ROI) | +7,5% | **−6,2%** | **não** |
+
+Não é contradição — é o mecanismo. A nota usa **todas** as premissas com peso contínuo,
+e erro de peso individual se cancela na soma. O filtro de premissa forte é um **limiar
+duro sobre o ganho individual**, e por construção seleciona exatamente as premissas que
+tiveram sorte na amostra. Um agrega ruído, o outro o concentra.
+
+É a mesma lição da Task [0] numa forma nova: o problema nunca foi a premissa, foi o
+procedimento de seleção.
+
+---
+
 ## Instabilidade: terceira medição, dentro da mesma sessão
 
 O `dbt_loaded_at` das origens era 12:09 na primeira execução do dia e **15:01** três horas

--- a/docs/TASK01_RESULTADOS.md
+++ b/docs/TASK01_RESULTADOS.md
@@ -136,6 +136,101 @@ segundo é ruído.
 
 ---
 
+## Ticket #5 — Teste 2 completo nos 5 mercados e peso medido
+
+`analyses/task01_teste2.sql` · execução 2026-08-04 · janela **16/06 a 04/08/2026**, 169 jogos
+
+As 39 premissas medidas. `diferença = acerto − prob justa`, em pp, só nas linhas em que
+a premissa acendeu.
+
+### Peso medido (melhor benchmark de cada mercado)
+
+**20 das 39 têm diferença positiva; 19 vão a zero.** Com peso ≥ 1,0 sobram **17**.
+
+| Mercado | Premissa | n | A odd dava | Aconteceu | Dif. | Jogos méd. | % amostra curta | peso k50 | peso k0 |
+|---|---|---|---|---|---|---|---|---|---|
+| Gols | `clean_sheets_altos` | 105 | 51,5 | 68,6 | **+17,1** | 5,3 | **77,1** | 11,58 | 17,10 |
+| Handicap | `raramente_perde_por_2` | 445 | 63,1 | 69,4 | **+6,3** | 14,1 | 20,9 | 5,67 | 6,31 |
+| Handicap | `favorito_irregular` | 453 | 62,3 | 68,2 | **+5,9** | 14,8 | 17,4 | 5,29 | 5,88 |
+| BTTS | `ataque_dos_dois` | 32 | 50,6 | 62,5 | +11,9 | 12,1 | 37,5 | 4,65 | 11,91 |
+| 1X2 | `superioridade_xg` | 109 | 38,0 | 43,1 | +5,2 | 6,3 | **71,6** | 3,54 | 5,17 |
+| Handicap | `defesa_fora_solida` | 322 | 62,5 | 66,5 | +3,9 | 8,4 | 58,4 | 3,39 | 3,92 |
+| Gols | `defesas_firmes` | 246 | 64,6 | 68,3 | +3,7 | 11,4 | 40,7 | 3,05 | 3,67 |
+| Handicap | `tende_golear` | 154 | 44,2 | 48,1 | +3,9 | 3,5 | **88,3** | 2,91 | 3,86 |
+| Gols | `linha_descendo` | 405 | 53,0 | 56,0 | +3,1 | 10,3 | 46,9 | 2,74 | 3,08 |
+| Dupla Chance | `lado_coberto_forte` | 112 | 74,0 | 76,8 | +2,8 | 8,6 | 58,0 | 1,92 | 2,78 |
+| Gols | `ataques_fracos` | 357 | 51,7 | 53,8 | +2,1 | 9,6 | 50,1 | 1,81 | 2,07 |
+| BTTS | `defesa_forte` | 70 | 52,9 | 55,7 | +2,8 | 4,4 | **82,9** | 1,65 | 2,82 |
+| 1X2 | `mando` | 107 | 43,4 | 45,8 | +2,4 | 9,0 | 55,1 | 1,63 | 2,39 |
+| Dupla Chance | `equilibrio_defensivo` | 144 | 63,3 | 65,3 | +2,0 | 9,0 | 54,2 | 1,49 | 2,01 |
+| Gols | `xg_baixo_combinado` | 307 | 64,9 | 66,4 | +1,5 | 8,7 | 56,7 | 1,31 | 1,52 |
+| BTTS | `defesas_vazaveis` | 58 | 47,8 | 50,0 | +2,2 | 10,3 | 46,6 | 1,20 | 2,24 |
+| Gols | `historico_under` | 144 | 70,0 | 71,5 | +1,5 | 17,0 | 3,5 | 1,11 | 1,50 |
+| 1X2 | `superioridade_tabela` | 98 | 50,2 | 51,0 | +0,8 | 7,6 | 64,3 | 0,55 | 0,82 |
+| Dupla Chance | `adversario_limitado` | 160 | 68,7 | 69,4 | +0,7 | 9,7 | 50,0 | 0,51 | 0,66 |
+| BTTS | `historico_btts` | 16 | 50,0 | 50,0 | 0,0 | 18,4 | 0,0 | 0,01 | 0,03 |
+
+As 19 com peso zero, da menos ruim para a pior: `historico_over` −0,5 · `forma` −1,4 ·
+`linha_subindo` −1,5 · `supremacia` −1,9 · `ataque_trava` −2,2 · `ambos_marcam` −2,5 ·
+`xg_combinado_alto` −2,6 · `sem_rodizio` −2,7 · `adversario_fragil_fora` −2,8 ·
+`historico_seco` −0,9 · `mando_forte` −3,1 · `forca_mismatch` −3,1 ·
+`ataque_combinado` −3,6 · `ambos_vazam` −3,7 · `defesas_vazaveis` (Gols) −5,0 ·
+`ritmo_alto` −5,3 · `h2h_favoravel` −10,7 · `invicto_recente` −10,7 ·
+`desfalque_adversario` −24,9 (n=7).
+
+### ⚠️ O encolhimento não protege contra o artefato que matou a medição anterior
+
+São **dois eixos diferentes**, e o `k=50` só cobre um deles:
+
+- **n pequeno** — a premissa acendeu poucas vezes. É o que o encolhimento trata.
+  `ataque_dos_dois` (n=32) cai de 11,9 para 4,65: funcionou.
+- **amostra curta** — os jogos em que ela acendeu tinham pouco histórico. O
+  encolhimento **não vê isso**.
+
+E os três maiores sinais estão contaminados pelo segundo eixo:
+
+| Premissa | Dif. | n | % das linhas com < 5 jogos |
+|---|---|---|---|
+| `clean_sheets_altos` | +17,1 | 105 (grande) | **77,1** |
+| `superioridade_xg` | +5,2 | 109 (grande) | **71,6** |
+| `tende_golear` | +3,9 | 154 (grande) | **88,3** |
+| `defesa_forte` (BTTS) | +2,8 | 70 | **82,9** |
+
+`clean_sheets_altos` tem o maior peso da tabela e acende quase só em jogo sem histórico
+— a assinatura exata dos +9,7% que morreram. **Isso torna o ticket #9 (piso de amostra)
+não-opcional**: sem ele, a nota do #8 é dominada por uma premissa cujo sinal pode ser o
+mesmo artefato de novo.
+
+O contraste: `raramente_perde_por_2` (+6,3, n=445, só 20,9% de amostra curta) e
+`favorito_irregular` (+5,9, n=453, 17,4%) são os únicos sinais fortes que **não**
+dependem de jogo sem passado.
+
+### `favorito_irregular` é o 3º maior sinal de valor da tabela
+
+A premissa que os documentos da proposta mandavam remover — "vale 0 ponto, é
+decorativa" — mede **+5,9 pp contra o preço**, com n=453 e a segunda menor exposição a
+amostra curta. A Task [0] já tinha mostrado que ela vale +8 pontos e é premissa do
+azarão; o Teste 2 agora mostra que ela também é uma das poucas que batem o mercado.
+
+### Por que as linhas de consenso não foram pooled
+
+O consenso não é "o mesmo jogo com benchmark pior" — é **outro conjunto de linhas**. A
+prob justa média da mesma premissa muda de forma estrutural:
+
+| Mercado | Premissa | `a_odd_dava` sharp | `a_odd_dava` consenso |
+|---|---|---|---|
+| Handicap | `raramente_perde_por_2` | 63,1 | **87,7** |
+| Handicap | `mando_forte` | 43,9 | **17,1** |
+| Gols | `xg_baixo_combinado` | 64,9 | **88,1** |
+| Gols | `ritmo_alto` | 49,4 | **42,7** |
+
+A Pinnacle precifica as linhas principais; as extremas caem no consenso. Uma linha com
+17% ou 88% de probabilidade implícita é handicap grande ou total distante — população
+diferente, não amostra a mais. Juntar as duas metades teria produzido uma média sem
+referente.
+
+---
+
 ## Ressalvas que valem para tudo neste documento
 
 - **A amostra é o gargalo, não a análise.** 168 jogos, cerca de um mês e meio, com

--- a/docs/TASK01_RESULTADOS.md
+++ b/docs/TASK01_RESULTADOS.md
@@ -288,6 +288,154 @@ referente.
 
 ---
 
+## Ticket #6 — Teste 1 completo (fonte do peso de controle)
+
+`analyses/task01_teste1.sql` · **6.042 jogos encerrados**, sem exigir odd
+
+Reconciliação contra os valores publicados no re-run da Task [0]: `tende_golear` +8,1,
+`mando` +5,8, `clean_sheets_altos` +5,6 e `forca_mismatch` +11,6 **exatos**;
+`superioridade_tabela` +12,0 contra +12,1 e `defesa_forte` +3,4 contra +3,3. A definição
+de "média da mesma linha" está certa.
+
+### Os dois testes discordam quase por completo
+
+| Premissa | Teste 1 (prevê a linha) | Teste 2 (bate o preço) |
+|---|---|---|
+| `superioridade_tabela` | **+12,0** | +0,8 |
+| `forca_mismatch` | **+11,6** | −3,1 |
+| `supremacia` | **+11,2** | −1,9 |
+| `lado_coberto_forte` | **+9,7** | +2,8 |
+| `invicto_recente` | **+7,2** | **−10,7** |
+| `h2h_favoravel` | **+6,4** | **−10,7** |
+| `forma` | **+6,8** | −1,4 |
+| `clean_sheets_altos` | +5,6 | **+17,1** |
+| `raramente_perde_por_2` | +1,9 | **+6,3** |
+| `favorito_irregular` | +1,8 | **+5,9** |
+
+As premissas que melhor **preveem** o resultado da linha — superioridade de tabela,
+mismatch de força, supremacia — são as que o mercado já sabe, e valem perto de zero ou
+menos contra o preço. As que **geram valor** estão no fundo do Teste 1.
+
+Isso confirma a distinção que sustenta toda a metodologia: prever não é pagar. E confirma
+que o Teste 2 tem de ser a fonte de peso.
+
+### ⚠️ Mas isso enfraquece o controle desenhado no ADR 0001
+
+O ADR previa usar pesos do Teste 1 como controle out-of-sample dos pesos do Teste 2. A
+premissa era que os dois medissem a mesma coisa em universos diferentes. **Eles não
+medem.** São construtos distintos e quase ortogonais.
+
+Consequência: uma curva de ROI plana sob pesos do Teste 1 **não** prova que a curva sob
+pesos do Teste 2 é ajuste in-sample — prova apenas que prever a linha não gera valor, o
+que a tabela acima já mostrou.
+
+O controle continua valendo a pena (responde "premissa que prevê bem gera valor?" — não),
+mas **não substitui** um teste out-of-sample dos pesos do Teste 2. Quem carrega essa
+carga passa a ser o teste de permutação, e o ticket #8 precisa ganhar uma **divisão
+temporal** — ajustar peso na primeira metade da janela de odds e medir ROI na segunda.
+Foi a opção descartada na sessão de grilling por falta de poder; hoje é a única
+verdadeiramente out-of-sample sobre a métrica certa.
+
+---
+
+## Ticket #7 — Varredura de edge (Pedido 3)
+
+`analyses/task01_edge.sql`
+
+### ⚠️ Primeiro, um artefato que contamina o universo publicado
+
+O de-vig de **consenso** normaliza a probabilidade sobre o conjunto de saídas da linha.
+Quando só **um lado** foi precificado, ele normaliza sobre um único outcome e devolve
+`prob_justa = 1,0` — certeza. O edge vira `odd − 1`.
+
+| | |
+|---|---|
+| Linhas afetadas no universo | **172**, todas consenso, mercados 4 e 5 |
+| Edge reportado | de **+820%** a **+14.900%** |
+| Odd máxima | 150,0 |
+| Vitórias reais | **2 de 172** |
+| ROI | **−35,5%** |
+
+O Motor anuncia valor máximo exatamente onde o acerto real é 1,2%.
+
+**Produção NÃO é afetada.** O gate do mart exige ≥ 4 casas e conjunto Pinnacle completo;
+o board hoje tem 90 oportunidades, edge máximo 23%, odd máxima 4,5 e mínimo de 4 casas.
+Nenhuma dessas linhas chega ao usuário.
+
+Mas elas **estão** no universo de backtest, inclusive no que produziu os números
+publicados. O backtest é mais permissivo que o board — mede apostas que o produto nunca
+faria. Isso vale para toda a série histórica e precisa entrar no relatório final.
+
+Excluídas dos blocos abaixo, com o descarte auditado no próprio SQL.
+
+### A resposta ao Pedido 3: o filtro é VAZIO, não neutro
+
+| Corte | n | ROI |
+|---|---|---|
+| sem filtro (referência) | 8.567 | **−9,8%** |
+| edge > −30% | 8.567 | −9,8% |
+| edge > −20% | 8.567 | −9,8% |
+| edge > −10% | 8.564 | −9,8% |
+| edge > −5% | 6.759 | −9,2% |
+| edge > 0% (regra de hoje) | 1.677 | **−10,4%** |
+
+**O edge mínimo de todo o universo é −10,6%.** Não existe cauda de "preço muito pior que
+o justo" para barrar: cortar em −30% ou −20% remove **zero** linhas, e −10% remove três.
+
+A razão é estrutural: `edge = melhor odd × prob justa − 1`, e a melhor odd é tomada entre
+**todas** as casas. Pegar o melhor preço entre ~14 casas impede, por construção, que o
+preço fique muito abaixo do justo.
+
+Então a resposta não é "o filtro é neutro, fica como proteção de reputação". É **"não há o
+que filtrar"** — a regra proposta na A3 não teria agido sobre nenhuma aposta.
+
+### O preço não ordena, em nenhuma direção
+
+| Decil de edge | Faixa | n | ROI |
+|---|---|---|---|
+| 1 (pior preço) | −10,6 a −7,4 | 857 | −15,7 |
+| 5 | −3,6 a −3,0 | 857 | −11,0 |
+| 8 | −1,7 a −0,1 | 856 | **−5,7** |
+| 9 | −0,1 a +4,2 | 856 | −9,1 |
+| 10 (melhor preço) | +4,2 a +173 | 856 | −11,3 |
+
+Sem ordenação. O melhor decil é o oitavo. **A A1 (tirar o preço da nota) está
+confirmada**, e a regra de hoje (`edge > 0`) piora o resultado: −10,4% contra −9,8% de
+apostar tudo.
+
+### O maior discriminador de ROI da base não é o preço — é o benchmark
+
+| Recorte | n | ROI |
+|---|---|---|
+| sharp (Pinnacle precifica) | 3.329 | **−5,0%** |
+| derivada (Dupla Chance) | 299 | −3,9% |
+| consenso (Pinnacle não precifica) | 3.262 | **−14,9%** |
+
+Quase **10 pontos** de diferença, contra ~0 de qualquer filtro de preço. Restringir o
+board às linhas com preço sharp vale mais do que toda a família de regras de edge junta.
+Não estava no escopo desta task e não foi investigado — mas é a maior alavanca que
+apareceu.
+
+---
+
+## Instabilidade: terceira medição, dentro da mesma sessão
+
+O `dbt_loaded_at` das origens era 12:09 na primeira execução do dia e **15:01** três horas
+depois. A mesma reconciliação, mesmo código, devolveu:
+
+| Métrica | Publicado | Build 12:09 | Build 15:01 |
+|---|---|---|---|
+| Teste 3, 2+ premissas | −7,6 | −7,4 | **−7,6** |
+| Teste 3, 3+ premissas | −6,0 | −6,1 | **−6,0** |
+| Teste 3 por mercado, Gols | −7,3 | −6,9 | −7,2 |
+
+Não é uma deriva que aconteceu uma vez: é **oscilação contínua**, e desta vez ela voltou a
+cair sobre os valores publicados. Reforça a exigência de carimbar o build em qualquer
+número de Gols — e mostra que "reproduziu" e "não reproduziu" podem ser a mesma medição
+tirada em horas diferentes.
+
+---
+
 ## Ressalvas que valem para tudo neste documento
 
 - **A amostra é o gargalo, não a análise.** 168 jogos, cerca de um mês e meio, com

--- a/docs/TASK01_RESULTADOS.md
+++ b/docs/TASK01_RESULTADOS.md
@@ -418,6 +418,103 @@ apareceu.
 
 ---
 
+## Ticket #8 — Teste 4: o ROI sobe com a nota?
+
+`analyses/task01_teste4.sql` e `task01_teste4_permutacao.sql`
+
+Pesos do Teste 2 **com piso de 5 jogos** (sem o piso a nota herdaria
+`clean_sheets_altos`, +17,1 sem piso e −1,7 com). Artefato de conjunto incompleto
+excluído. Normalização 0–100 por mercado, faixas agrupadas depois.
+
+### A inclinação sobrevive out-of-sample praticamente intacta
+
+O controle real é o par B/C: **mesmos pesos**, universos de avaliação diferentes.
+
+| Avaliação | Pesos ajustados em | ROI medido em | Inclinação (pp por ponto de nota) |
+|---|---|---|---|
+| A. `t2_full` | toda a janela | toda a janela | **+0,238** |
+| B. `t2_h1` | 1ª metade | **1ª metade** (in-sample) | **+0,228** |
+| C. `t2_h1` | 1ª metade | **2ª metade** (out-of-sample) | **+0,223** |
+| D. `t1_controle` | Teste 1, 6.042 jogos | toda a janela | +0,149 |
+
+**B → C perde 0,005.** A inflação in-sample, que o ADR 0001 existia para vigiar, é
+desprezível para a inclinação. O sinal não é ajuste.
+
+E o controle do ADR (D) fica claramente atrás, confirmando de novo que peso tem de sair
+do Teste 2 e não do Teste 1.
+
+### Mas a ordenação não é monótona — o topo não é o melhor
+
+Faixas de C (out-of-sample, nota de premissas), com erro-padrão agrupado por fixture:
+
+| Faixa | n apostas | n jogos | ROI | ± EP |
+|---|---|---|---|---|
+| 00–20 | 2.419 | 84 | **−16,7** | 6,5 |
+| 20–40 | 436 | 81 | −3,6 | 4,6 |
+| 40–60 | 279 | 57 | **+10,3** | 16,4 |
+| 60–80 | 506 | 73 | **+8,1** | 6,2 |
+| 80–100 | 512 | 66 | −3,9 | 4,1 |
+
+O que a nota faz bem é **separar o fundo**: −16,7% na faixa baixa, a 2,6 erros-padrão de
+zero. O que ela não faz é ordenar o topo — a faixa 80–100 é pior que a 60–80, e nenhuma
+faixa positiva cruza dois erros-padrão.
+
+### A nota de premissas ordena MELHOR que o Score pós-A1
+
+| Composição | Inclinação (A) | Inclinação (C, out-of-sample) |
+|---|---|---|
+| nota de premissas | +0,238 | **+0,223** |
+| Score pós-A1 (+ corroboração − penalidades) | +0,158 | **+0,114** |
+
+Somar corroboração e penalidades **piora** a ordenação, e piora mais fora da amostra. Na
+faixa 80–100 do Score pós-A1 o ROI out-of-sample é −17,0.
+
+A corroboração é praticamente inerte (só implementada p/ 1X2, e o `/predictions` era
+~vazio no histórico), então quem degrada são as **penalidades** — que são calculadas
+sobre características da odd (outlier, poucas casas, longshot, juice) e empurram para
+baixo linhas por razões descorrelacionadas do resultado. É um achado acionável e não
+estava em nenhuma frente aberta.
+
+### A régua: qual inclinação o acaso produz?
+
+200 réplicas embaralhando os pesos **entre premissas do mesmo mercado** — a distribuição
+de pesos fica idêntica, muda só quem recebe qual.
+
+| Métrica | Observado | Nulo mediana | Nulo p05 | Nulo p95 | Nulo máx | p |
+|---|---|---|---|---|---|---|
+| Inclinação | **+0,238** | +0,078 | −0,178 | +0,276 | +0,335 | **0,070** |
+| Gap alta(≥60) − baixa(<20) | **+17,3 pp** | +5,6 | −8,7 | +16,4 | +29,1 | **0,035** |
+
+**O nulo NÃO está centrado em zero, e isso não é defeito.** Embaralhar pesos dentro do
+mercado preserva quantas premissas acenderam — e o Teste 3 já mostrou que contagem tem
+sinal fraco. Então a mediana nula de +0,078 é o que **a contagem sozinha** compra; o
+excedente até +0,238 é o que a **ponderação correta** acrescenta.
+
+O critério de aceite do ticket dizia "se a curva embaralhada subir, o defeito é nosso".
+Ele foi escrito antes de eu entender que a permutação preserva a contagem por
+construção. O critério certo é se o observado excede o nulo — e excede, mas por pouco:
+**p = 0,035 no gap e 0,070 na inclinação.**
+
+### Veredito de produto
+
+**Existe sinal de ordenação, e ele é real — mas fraco, e não chega a rentabilidade.**
+
+1. Sobrevive out-of-sample quase intacto (+0,228 → +0,223). Não é ajuste in-sample.
+2. Excede a curva nula, mas com folga pequena (p = 0,035 no gap).
+3. Ordena o **fundo**, não o topo: −16,7% na faixa baixa é o achado sólido; nenhuma
+   faixa positiva se distingue de zero com confiança.
+4. O objeto que iria pro ar (Score pós-A1) ordena **pior** que a nota de premissas pura.
+
+A leitura honesta não é "temos produto" nem "não sobrou nada". É: **a nota serve hoje
+para excluir, não para escolher.** Um corte que descarte a faixa baixa é defensável pelo
+dado; um corte que selecione a faixa alta não é.
+
+⚠️ A permutação foi rodada contra os pesos in-sample (+0,238). Como a inclinação
+out-of-sample é quase idêntica, a conclusão carrega — mas o p-valor não foi recalculado
+para o corte temporal.
+
+---
+
 ## Instabilidade: terceira medição, dentro da mesma sessão
 
 O `dbt_loaded_at` das origens era 12:09 na primeira execução do dia e **15:01** três horas

--- a/docs/TASK01_RESULTADOS.md
+++ b/docs/TASK01_RESULTADOS.md
@@ -178,7 +178,64 @@ As 19 com peso zero, da menos ruim para a pior: `historico_over` −0,5 · `form
 `ritmo_alto` −5,3 · `h2h_favoravel` −10,7 · `invicto_recente` −10,7 ·
 `desfalque_adversario` −24,9 (n=7).
 
-### ⚠️ O encolhimento não protege contra o artefato que matou a medição anterior
+### O piso de amostra não atenua os sinais — ele INVERTE os maiores
+
+O piso entrou como **coluna** do Teste 2, não como varredura posterior, porque o
+encolhimento (`k`) e o piso tratam eixos diferentes (ver abaixo). O resultado é o achado
+mais forte do ticket.
+
+**Desabam ao exigir 5 jogos disputados nos dois times:**
+
+| Premissa | dif. piso 0 | dif. piso 5 | dif. piso 10 | n: 0 → 5 |
+|---|---|---|---|---|
+| `clean_sheets_altos` | **+17,1** | **−1,7** | **−10,1** | 105 → 24 |
+| `superioridade_xg` | **+5,2** | **−8,9** | **−12,3** | 109 → 31 |
+| `tende_golear` | **+3,9** | **−18,5** | **−22,3** | 154 → 18 |
+| `superioridade_tabela` | +0,8 | −8,2 | −8,2 | 98 → 35 |
+| `mando` | +2,4 | −6,4 | −8,3 | 107 → 48 |
+| `defesa_forte` (BTTS) | +2,8 | −3,3 | −6,3 | 70 → 12 |
+| `ataques_fracos` | +2,1 | −1,1 | −1,1 | 357 → 178 |
+
+**Sobrevivem — e a maioria fica MAIS forte:**
+
+| Premissa | dif. piso 0 | dif. piso 5 | dif. piso 10 | n: 0 → 5 |
+|---|---|---|---|---|
+| `raramente_perde_por_2` | +6,3 | **+7,4** | **+7,7** | 445 → 352 |
+| `favorito_irregular` | +5,9 | **+7,1** | **+7,9** | 453 → 374 |
+| `defesas_vazaveis` (BTTS) | +2,2 | **+8,7** | +8,7 | 58 → 31 |
+| `equilibrio_defensivo` | +2,0 | **+6,4** | **+7,7** | 144 → 66 |
+| `linha_descendo` | +3,1 | **+5,3** | +5,3 | 405 → 215 |
+| `xg_baixo_combinado` | +1,5 | +3,6 | +4,1 | 307 → 133 |
+| `defesa_fora_solida` | +3,9 | +2,6 | +2,8 | 322 → 134 |
+| `historico_under` | +1,5 | +1,2 | +2,1 | 144 → 139 |
+
+### Leitura
+
+**O ranking sem piso está de cabeça para baixo.** As três maiores diferenças medidas —
+`clean_sheets_altos` (+17,1), `superioridade_xg` (+5,2) e `tende_golear` (+3,9) — são as
+três que mais dependem de jogo sem histórico (77%, 72% e 88% das linhas), e as três
+viram negativo assim que se exige 5 partidas disputadas. É o mesmo padrão dos +9,7% que
+morreram na Task [0], agora premissa por premissa em vez de agregado.
+
+Ressalva honesta: com piso 5 essas três ficam com n de 18 a 31, então o valor negativo
+também não é bem medido. A afirmação defensável não é "elas são ruins" — é **"não existe
+evidência de que funcionem fora de jogo sem passado, e o pouco que dá para medir é
+negativo"**.
+
+**Os dois sinais mais robustos do conjunto inteiro são premissas do lado azarão do
+Handicap** — `raramente_perde_por_2` e `favorito_irregular` —, que mantêm ~80% da amostra
+sob o piso e ficam mais fortes com ele (+7,7 e +7,9 no piso 10). São as únicas com sinal
+alto que não dependem de amostra curta.
+
+E `favorito_irregular` é justamente a premissa que os documentos da proposta mandavam
+remover por "valer 0 ponto e ser decorativa". A Task [0] mostrou que ela vale +8 pontos;
+o Teste 2 mostra que ela é o sinal de valor mais robusto que existe na base.
+
+**Consequência para o plano:** os pesos do ticket #8 têm de sair da medição COM piso. Os
+pesos sem piso são dominados por artefato, e usá-los faria a nota ponderada herdar
+exatamente o que a Task [0] acabou de remover. O piso deixou de ser calibragem opcional.
+
+### ⚠️ Por que o encolhimento sozinho não bastava
 
 São **dois eixos diferentes**, e o `k=50` só cobre um deles:
 

--- a/docs/TASK01_RESULTADOS.md
+++ b/docs/TASK01_RESULTADOS.md
@@ -1,0 +1,145 @@
+# Task [0.1] — Resultados
+
+Documento vivo. Cada ticket da [issue #3](https://github.com/tech-lamjav/analytics-engineering/issues/3)
+acrescenta a sua seção aqui. O SQL que produz cada número está em `dbt_futebol/analyses/`.
+
+Os resultados moram neste arquivo, e não no cabeçalho das análises, para que o SQL mude
+quando a lógica muda e não quando os números mudam.
+
+---
+
+## Carimbo de execução
+
+**Toda tabela desta seção precisa de carimbo.** O mercado de Gols não é reproduzível
+entre builds (ver §Estabilidade), então número de Gols sem data de build não é
+verificável.
+
+| Execução | Corte do universo | `dbt_loaded_at` das origens |
+|---|---|---|
+| 2026-08-04 | jogos com kickoff ≤ 2026-08-02 | `odds_devig` 12:09:33 · `team_form_pit` 12:09:56 · `premissas_ah` 12:10:00 · `premissas_1x2` e `premissas_ou` 12:10:11 |
+
+---
+
+## Ticket #4 — Reconciliação por resposta conhecida (Seam 1)
+
+`analyses/task01_reconciliacao.sql`
+
+### Veredito
+
+**A máquina generalizada está certa. A base não é estável.**
+
+22 das 25 linhas de comparação com delta **exatamente 0,0** — incluindo as seis do
+Teste 2 e quatro dos cinco mercados. A Dupla Chance bate inclusive o `n = 154` publicado.
+
+As três que divergem são todas do mercado de Gols, direta ou indiretamente:
+
+| Bloco | Métrica | n | Esperado | Obtido | Delta |
+|---|---|---|---|---|---|
+| Teste 3 | 2+ premissas | 4.066 | −7,6 | −7,4 | **+0,2** |
+| Teste 3 | 3+ premissas | 1.892 | −6,0 | −6,1 | **−0,1** |
+| Teste 3 por mercado | Gols | 2.182 | −7,3 | −6,9 | **+0,4** |
+
+Gols é 2.182 das 4.066 apostas do corte "2+", então a deriva agregada vem inteiramente
+dele. 1X2 (−2,5), Handicap (−9,9), BTTS (−1,1) e Dupla Chance (+1,4) reproduzem exato.
+
+**Não é regressão da generalização:** a query ad-hoc original da Task [0], rodada hoje
+sem alterar um byte, também devolve −7,4 onde ontem devolveu −7,6.
+
+### Descartes
+
+A guarda de descarte silencioso lê as odds **antes** de qualquer recorte e classifica
+tudo que não vira aposta. Nenhum descarte inesperado:
+
+| Motivo | Linhas |
+|---|---|
+| Fora do escopo do Motor (market 6, Goals O/U First Half) | 3.642 |
+| Linha inteira, push possível (AH e O/U) | 5.903 |
+| Gap conhecido: Dupla Chance não emite premissa para a saída `12` | 168 |
+| **INESPERADOS** | **0** |
+
+Dois destes eram invisíveis antes. O market 6 só ficava de fora por acidente do INNER
+JOIN com as premissas — hoje o escopo `market_id IN (1,4,5,8,12)` é declarado e derivado
+do catálogo de premissas. As 5.903 linhas inteiras são exclusão de desenho (push não tem
+liquidação binária) e batem com a metodologia publicada, mas nunca tinham sido contadas.
+
+O gap da saída `12` da Dupla Chance segue **reportado e não corrigido**: uma saída
+inteira de um mercado está fora de toda a medição, na rodada anterior e nesta.
+
+### Cobertura por benchmark
+
+Os mercados 4 e 5 são **mistos** — a Pinnacle cobre a maior parte, não todos os jogos:
+
+| Mercado | Benchmark | Linhas | ROI sem porta |
+|---|---|---|---|
+| 1X2 | sharp | 504 | −11,8 |
+| Handicap | sharp | 1.848 | −6,5 |
+| Handicap | consenso | 1.837 | −26,7 |
+| Gols | sharp | 1.722 | −1,8 |
+| Gols | consenso | 2.105 | −7,1 |
+| BTTS | consenso | 336 | −4,3 |
+| Dupla Chance | derivada | 336 | −5,7 |
+
+⚠️ A diferença entre sharp e consenso no Handicap (−6,5 contra −26,7) é grande demais
+para ser ignorada na leitura do Teste 2. Não investigada neste ticket.
+
+---
+
+## Estabilidade das tabelas entre rebuilds
+
+`analyses/task01_estabilidade.sql`
+
+Compara o estado congelado em `futebol_task0` (2026-08-03) contra o atual, sobre as
+premissas do mercado de Gols. Só as quatro que a Task [0] **não** alterou são
+comparáveis; as outras nove aparecem para dar escala à correção.
+
+| Classe | Premissa | Flips / 50.608 | % |
+|---|---|---|---|
+| **Lê odds** | `linha_descendo` | **20** | 0,040 |
+| **Lê odds** | `linha_subindo` | **16** | 0,032 |
+| **Controle** (lê histórico) | `historico_over` | **0** | 0,000 |
+| **Controle** (lê histórico) | `historico_under` | **0** | 0,000 |
+| Corrigida na Task 0 | `defesas_firmes` | 7.124 | 14,08 |
+| Corrigida na Task 0 | `ataques_fracos` | 6.735 | 13,31 |
+| Corrigida na Task 0 | `ambos_vazam` | 5.745 | 11,35 |
+| Corrigida na Task 0 | `defesas_vazaveis` | 5.716 | 11,30 |
+| Corrigida na Task 0 | `ataque_combinado` | 4.403 | 8,70 |
+| Corrigida na Task 0 | `ritmo_alto` | 4.212 | 8,32 |
+| Corrigida na Task 0 | `xg_baixo_combinado` | 1.950 | 3,85 |
+| Corrigida na Task 0 | `xg_combinado_alto` | 1.807 | 3,57 |
+| Corrigida na Task 0 | `clean_sheets_altos` | 1.766 | 3,49 |
+
+### Leitura
+
+**O controle em zero fecha o argumento.** `historico_over` e `historico_under` estão na
+mesma classe de premissa não afetada pela Task [0], mas leem histórico de jogos em vez
+de odd — e não mexeram uma linha. As duas que leem `fact_odds_snapshot` mexeram.
+
+Gols é o **único** dos cinco mercados do Motor com premissa derivada de odd
+(`linha_subindo`/`linha_descendo` usam a média das probabilidades implícitas de todas as
+casas, t24h → t15m, e o modelo ainda monta o universo de linhas a partir das odds
+presentes). Os outros quatro não leem odd em premissa nenhuma — e são exatamente os
+quatro que reproduziram byte a byte.
+
+**A escala importa:** a correção da Task [0] moveu de 3,5% a 14,1% das linhas. A
+instabilidade move 0,03–0,04%. São fenômenos de ordens de grandeza diferentes, e só o
+segundo é ruído.
+
+### Consequências
+
+1. **Número de Gols exige carimbo de build.** Sem ele, uma diferença de 0,2–0,4pp entre
+   execuções vira caça a bug inexistente — ou pior, vira "achado".
+2. **0,07% das linhas viraram e o ROI do mercado andou 0,4pp**, porque a porta "N+
+   premissas" é um **limiar**: uma linha que sai de `n_prem=1` para `2` entra inteira no
+   universo. Vale checar no ticket #8 se a nota ponderada, sendo contínua, é menos
+   sensível a esse ruído. Se for, é um argumento a favor dela que ninguém levantou — e
+   que **não depende do resultado de ROI**.
+
+---
+
+## Ressalvas que valem para tudo neste documento
+
+- **A amostra é o gargalo, não a análise.** 168 jogos, cerca de um mês e meio, com
+  apostas correlacionadas dentro do mesmo jogo. Nenhum número aqui é definitivo.
+- Os valores `esperado` das reconciliações são os **publicados**, e a procedência de cada
+  bloco está comentada no SQL. Reproduzir não valida a metodologia original — valida que
+  esta implementação é a mesma.

--- a/docs/TASK01_RESULTADOS.md
+++ b/docs/TASK01_RESULTADOS.md
@@ -8,6 +8,82 @@ quando a lógica muda e não quando os números mudam.
 
 ---
 
+# Veredito
+
+## A pergunta de produto
+
+> **A nota serve para excluir, não para escolher.**
+
+Existe sinal de ordenação e ele é real: a inclinação do ROI contra a nota é +0,228
+in-sample e **+0,223 out-of-sample** — a inflação por ajuste é desprezível. Ele excede a
+curva nula de permutação (p = 0,035 no gap entre faixa alta e baixa).
+
+Mas ele ordena o **fundo**, não o topo. Fora da amostra a faixa 00–20 rende −16,7% a 2,6
+erros-padrão de zero, enquanto a faixa 80–100 rende −3,9% e é **pior** que a 60–80.
+Nenhuma faixa positiva se distingue de zero com confiança.
+
+Um corte que **descarte** a faixa baixa é defensável pelo dado de hoje. Um corte que
+**selecione** a faixa alta não é.
+
+## O que eu quase reportei errado
+
+O filtro "ao menos uma premissa forte" deu **+10,0% de ROI** — o primeiro número positivo
+de toda a investigação. Ele não sobrevive: com "forte" definido só na primeira metade da
+janela e o ROI medido na segunda, vira **−6,2%**. São **14,5 pp de viés de seleção puro**.
+
+O mecanismo é o mesmo dos +9,7% que a Task [0] matou, trocando vazamento temporal por
+vazamento de seleção. Vale registrar que ele passou perto: sem o teste temporal, esse
+número teria virado manchete.
+
+## Recomendações
+
+**B1 a B5 — não reescrever peso. Manter bloqueadas.**
+
+A medição do Teste 2 está pronta e reproduzível, mas ela **não sustenta** reescrever os
+39 pesos de catálogo. A prova está na própria task: os ganhos individuais **não se
+replicam** fora da amostra — é exatamente isso que o teste de premissa forte mediu. A
+nota agregada sobrevive porque o erro de peso individual se cancela na soma; escrever
+cada peso de catálogo a partir do seu ganho medido faria o oposto, fixando o ruído.
+
+O que dá para fazer **agora**, sem depender de peso novo:
+- **B3** — a correção do teto do azarão (30, não 13) e a decisão de **não remover**
+  `favorito_irregular` estão confirmadas duas vezes: ela vale +8 pontos em produção e é
+  o 3º maior sinal de valor do Teste 2, com uma das menores exposições a amostra curta.
+- **B4 / B5** — os diagnósticos estruturais (BTTS sem cotação Pinnacle, DC barrada por
+  aritmética) não dependem de peso e seguem válidos.
+
+**A4 — a régua que substitui o preço: adotar como exclusão, não como seleção.**
+*(Inferindo o escopo da A4 a partir do comentário de fechamento da [0]; a busca do
+ClickUp falhou e não consegui ler a task.)* O dado sustenta descartar a faixa baixa da
+nota. Não sustenta um corte de seleção no topo, nem a porta de contagem simples.
+
+**C2 (ampliar a coleta de odds) — subir de prioridade, com número.**
+O piso de amostra derruba o universo de 169 para **67 jogos**. Metade dos resultados
+desta task carrega intervalo maior que o efeito medido. Não é calibragem fina que falta,
+é amostra.
+
+**Duas frentes novas que apareceram e não existiam em nenhuma task:**
+1. **As penalidades degradam a ordenação.** O Score pós-A1 ordena pior que a nota de
+   premissas pura (+0,114 contra +0,223 out-of-sample). A corroboração é inerte, então
+   são as penalidades — calculadas sobre características da odd e descorrelacionadas do
+   resultado.
+2. **O benchmark é a maior alavanca de ROI da base.** Linhas com preço sharp rendem
+   −5,0% contra −14,9% das de consenso: **~10 pontos**, contra ~0 de qualquer filtro de
+   preço. Restringir o board a linhas com cotação Pinnacle vale mais que toda a família
+   de regras de edge junta.
+
+## Achados colaterais que precisam de dono
+
+| Achado | Produção afetada? |
+|---|---|
+| De-vig de consenso com uma só saída precificada dá `prob_justa = 1,0` e edge de até 14.900% (172 linhas, 2 vitórias em 172) | **Não** — o gate barra. Mas contamina todo backtest, inclusive o publicado |
+| O modelo de premissas da Dupla Chance não emite a saída `12`; 1 linha por jogo fora de toda medição | Não medido |
+| O backtest é mais permissivo que o board (não aplica gate de casas nem completude) | Toda a série histórica |
+| `linha_subindo`/`linha_descendo` leem odds; número de Gols muda entre builds | Backtest, não board |
+| `fact_standings_snapshot` com 13 times fora de `dim_teams` (Chapecoense B, Nacional) | `dbt test` vermelho desde 14/07 |
+
+---
+
 ## Carimbo de execução
 
 **Toda tabela desta seção precisa de carimbo.** O mercado de Gols não é reproduzível


### PR DESCRIPTION
Fecha os tickets #4 a #10 da spec #3 (Task [0.1] no ClickUp: `wdx6zevfgf`).

Nove análises não materializadas em `dbt_futebol/analyses/` mais um documento de
resultados. **Nada materializa, nada entra no DAG do pipeline, nenhum modelo de produção
foi tocado.** `dbt test` idêntico ao baseline (PASS=253, WARN=9, ERROR=1 — o erro é
anterior à branch).

## A resposta

> **A nota serve para excluir, não para escolher.**

Existe sinal de ordenação e ele sobrevive fora da amostra: inclinação +0,228 in-sample e
**+0,223 out-of-sample**, excedendo a curva nula de 200 permutações (p = 0,035). Mas ele
ordena o **fundo** — a faixa 00–20 rende −16,7% a 2,6 erros-padrão de zero, enquanto a
80–100 rende −3,9% e é pior que a 60–80. Nenhuma faixa positiva se distingue de zero.

## O que mudou de método no caminho

**O controle do ADR 0001 foi substituído.** Ele previa usar pesos do Teste 1 como
controle out-of-sample. O Teste 1 completo (ticket #6) mostrou que os dois testes medem
construtos quase ortogonais — `superioridade_tabela` é +12,0 no Teste 1 e +0,8 no Teste
2 —, então curva plana sob ele não prova ajuste in-sample. Trocado por **divisão
temporal**: mesmos pesos, universos de avaliação diferentes.

**O piso de amostra virou dimensão do Teste 2**, não varredura posterior. Ele não atenua
os sinais, **inverte os maiores**: `clean_sheets_altos` +17,1 → −1,7, `superioridade_xg`
+5,2 → −8,9, `tende_golear` +3,9 → −18,5.

## O número que não foi reportado

A variante de premissa forte deu **+10,0% de ROI** — o primeiro positivo da
investigação. Com "forte" definido só na 1ª metade da janela e o ROI medido na 2ª, vira
**−6,2%**. São 14,5 pp de viés de seleção puro, o mesmo mecanismo dos +9,7% que a Task
[0] matou.

## Achados colaterais

- **De-vig de consenso com uma só saída precificada** devolve `prob_justa = 1,0` e edge
  de até 14.900% — 172 linhas com 2 vitórias em 172. **Produção não é afetada** (o gate
  barra; board tem edge máximo 23%), mas contamina todo backtest, inclusive o publicado.
- **O backtest é mais permissivo que o board** — não aplica gate de casas nem de
  completude.
- **O número de Gols muda entre builds**: `linha_subindo`/`linha_descendo` leem a tabela
  de odds. Medido contra snapshot congelado: 36 flips em 50.608, contra **zero** nas
  premissas de controle que leem histórico.
- **A Dupla Chance não emite a saída `12`** — 1 linha por jogo fora de toda medição.
- **As penalidades degradam a ordenação** (Score pós-A1 +0,114 contra +0,223 da nota
  pura).
- **O benchmark é a maior alavanca de ROI da base**: sharp −5,0% contra consenso −14,9%.

## Como revisar

O commit `2a5ddfd` (ADR + glossário) carrega as decisões de método e é o melhor ponto de
partida. Depois `eade3ae` (base compartilhada + reconciliação), que é o red-green de
tudo: ele reproduz 22 de 25 números publicados com delta exatamente 0,0 antes de
qualquer análise nova ser construída.

Resultados completos e ressalvas em `docs/TASK01_RESULTADOS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbS9jrduVWPXS2ASshZWnp
