### PR TITLE
fix(futebol): dbt test verde — troca o teste falso de standings por um verdadeiro em fixtures

### DIFF
--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -179,12 +179,27 @@ models:
         description: "Cidade do estádio"
       - name: home_team_id
         description: "ID do time mandante (cluster key; FK p/ dim_teams)"
+        # ESTRITO de propósito. Esta é a invariante que de fato vale: todo time que
+        # DISPUTA uma partida tem metadado em dim_teams. Verificado em 2026-08-04 —
+        # 534 times distintos em fact_fixtures, ZERO fora da dim_teams.
+        # Substitui, como guarda de integridade referencial de time, o teste de
+        # fact_standings_snapshot.team_id, que afirmava algo falso sobre a fonte.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_id
       - name: home_team_name
         description: "Nome do time mandante"
       - name: home_team_winner
         description: "TRUE/FALSE/NULL — vencedor mandante. NULL p/ jogos não finalizados ou empate."
       - name: away_team_id
         description: "ID do time visitante (FK p/ dim_teams)"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_teams')
+                field: team_id
       - name: away_team_name
         description: "Nome do time visitante"
       - name: away_team_winner
@@ -843,13 +858,33 @@ models:
         tests:
           - not_null
       - name: team_id
-        description: "ID do time na API-Football (FK p/ dim_teams; cluster key)"
+        description: >
+          ID do time na API-Football (cluster key). ⚠️ NÃO é FK garantida p/ dim_teams:
+          o /standings pode devolver entidade que o /teams (fonte da dim_teams) não
+          traz, e as duas discordam sem que nada esteja errado do nosso lado.
         tests:
           - not_null
+          # warn, e não error: a invariante "todo time de standings está em dim_teams" é
+          # FALSA na fonte, não no nosso pipeline. Dois casos vivos, ambos confirmados
+          # como inconsistência da API-Football e não gap de coleta (issue #12):
+          #   · Brasileirão 2026: a tabela traz `22722 "Chapecoense B"` (rank 20, 20
+          #     jogos), enquanto /teams e /fixtures usam `132 "Chapecoense-sc"`. O
+          #     /teams p/ (71,2026) devolve os 20 times e 22722 não está entre eles,
+          #     então re-extrair não resolve.
+          #   · Libertadores 2024: `225 "Nacional"`, clube de fase não coberta pelo
+          #     backfill daquela season.
+          # Impacto medido: NENHUM. O único consumidor de standings é o
+          # int_futebol_team_form_pit (group_name p/ particionar o rank), e a
+          # Chapecoense recebe rank PIT correto (18,2 de média sobre n_teams=20).
+          # Nada no app lê esta tabela.
+          # A invariante que É verdadeira ficou testada de forma ESTRITA em
+          # fact_fixtures.home_team_id/away_team_id — ver ali.
           - relationships:
               arguments:
                 to: ref('dim_teams')
                 field: team_id
+              config:
+                severity: warn
       - name: team_name
         description: "Nome do time"
       - name: rank


### PR DESCRIPTION
Fecha #12. O `dbt test` do `dbt_futebol` estava com **ERROR=1 desde 14/07**.

## A causa não era o dado, era o teste

Ele afirmava que *todo time que aparece em standings está em `dim_teams`*. Essa
invariante é **falsa na fonte**, não no nosso pipeline. `dim_teams` vem de
`stg_futebol_teams`, ou seja do endpoint `/teams`, e a API-Football discorda dela mesma:

- **Brasileirão 2026** — a tabela do `/standings` traz `22722 "Chapecoense B"` (rank 20,
  10 pts, 20 jogos), enquanto `/teams` e `/fixtures` usam `132 "Chapecoense-sc"`, com 42
  jogos em 2026. O `/teams` para (71, 2026) devolve os 20 times e `22722` **não está
  entre eles** — re-extrair não resolve.
- **Libertadores 2024** — `225 "Nacional"`, clube de fase que não entrou no backfill
  daquela season.

Ajustar o dado para satisfazer uma afirmação falsa seria ao contrário.

## Impacto medido antes de decidir

**Nenhum.** O único consumidor de `fact_standings_snapshot` é o
`int_futebol_team_form_pit` (usa `group_name` para particionar o rank), e a Chapecoense
recebe rank PIT **correto**: 18,2 de média sobre `n_teams=20`.

E nada no app lê a tabela — os hits de "standings" no front são do bolão, que calcula os
grupos a partir de `wc_matches`. As RPCs de futebol que o app chama são
`get_futebol_value_board`, `get_futebol_odds_board` e `get_futebol_access`.

## Não é afrouxar, é trocar

| Coluna | Antes | Depois |
|---|---|---|
| `fact_standings_snapshot.team_id` | `relationships` estrito | `warn`, com os dois casos documentados na própria coluna |
| `fact_fixtures.home_team_id` | **nenhum teste** | `relationships` **estrito** |
| `fact_fixtures.away_team_id` | **nenhum teste** | `relationships` **estrito** |

A invariante que **é** verdadeira — *todo time que disputa uma partida tem metadado em
`dim_teams`* — passou a ser verificada onde nunca tinha sido. Conferido antes de
adicionar: **534 times distintos em `fact_fixtures`, ZERO fora da `dim_teams`**.

```
antes   PASS=253  WARN=9   ERROR=1
depois  PASS=255  WARN=10  ERROR=0
```

Duas garantias estritas **a mais**, e a falsa vira aviso documentado.

## Deploy

**Não exige.** O pipeline agendado roda `dbt run`, não `dbt build`, então teste não
executa lá. A mudança só passa a valer no pipeline quando a **C4** (guards de look-ahead
no `dbt build`) entrar — e é justamente por isso que precisava sair antes dela, senão a
C4 nasce vermelha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbS9jrduVWPXS2ASshZWnp
