### PR TITLE
analise(futebol): linha de base do board e transporte da porta de 40 (task [A])

### DIFF
--- a/dbt_futebol/analyses/taskA_a40_transporte.sql
+++ b/dbt_futebol/analyses/taskA_a40_transporte.sql
@@ -1,0 +1,357 @@
+{#
+    A4.0 — A PORTA DE 40 TRANSPORTA PARA A NOTA DE CATÁLOGO?
+
+    A tabela de ROI por faixa que sustenta a porta de 40 foi medida sobre a NOTA PONDERADA:
+    premissas pesadas pelo ganho do Teste 2 (`max(ganho,0) × n/(n+k)`, piso de 5 jogos),
+    normalizada 0–100 por mercado. O que a A4 põe em produção é a NOTA DE CATÁLOGO, com os
+    pesos postos à mão — e a decisão de não reescrever os 39 pesos está fechada.
+
+    São dois vetores de peso diferentes. Esta análise mede se a curva sobrevive à troca.
+
+    Mesma máquina da `task01_teste4.sql` (metades temporais por jogo, faixas, erro-padrão
+    agrupado por fixture, inclinação contínua). O que muda:
+
+      FONTES DE PESO
+        A/B/C/D  as do Teste 4, intactas — servem de referência e reproduzem o publicado.
+        E        catálogo: os pesos que estão em produção HOJE, lidos dos modelos.
+        F        catálogo sem `linha_subindo`/`linha_descendo` (decisão D1 da spec, que
+                 tira da nota as duas premissas que leem movimento de odd). Pesa 0 nelas,
+                 o que derruba o teto do Gols de 56/52 p/ 50/46.
+        E e F não são ajustadas em metade nenhuma — o catálogo é fixo. Por isso saem
+        avaliadas nas duas metades, e é a 2ª que compara com a C.
+
+      NORMALIZAÇÃO POR LADO
+        O teto passa a ser por (fonte, mercado, LADO). As fontes A–D têm todas as premissas
+        marcadas 'ambos', então o teto por lado colapsa no teto por mercado e elas
+        reproduzem o publicado byte a byte. Só E/F usam os lados de verdade:
+          1X2       Home 51 · Away 47 (só `mando` difere: 8 em casa, 4 fora) · Draw 43*
+          Gols      Over 56 · Under 52   (E)  |  Over 50 · Under 46  (F)
+          Handicap  Favorito 40 · Azarão 30 · Pick 0
+          BTTS      Sim 34 · Não 28
+          DC        34
+        * o Draw não tem lado apostado, então nenhuma premissa dispara e o numerador é
+          sempre 0 — o teto dele é irrelevante e a nota sai 0 de qualquer jeito.
+
+      COMPOSIÇÕES
+        1. nota_premissas            Σ dos pesos acesos. Comparável com o publicado.
+        2. score_pos_a1              + corroboração − penalidades. Comparável com o publicado.
+        3. nota_menos_pen_contexto   Σ − penalidades específicas do mercado, com piso em 0.
+                                     É a fórmula que vai a produção (decisão D5 da spec).
+
+    O fatorial que interessa:
+      C × comp.1   a curva publicada (peso medido, sem penalidade).
+      E × comp.3   o que vai ao ar (peso de catálogo, com penalidade de contexto).
+      E × comp.1   isola o efeito do vetor de peso.
+      C × comp.3   isola o efeito da penalidade de contexto.
+
+    REGRA DE DECISÃO, fixada antes de olhar:
+      · faixa 00–20 de E×3 segue negativa a >= 2 EP  ->  a porta de 40 transporta, A4 segue.
+      · faixas achatam                               ->  o corte sai desta medição, não da outra.
+      · ordenação inverte                            ->  A4 trava e a decisão volta pro PM.
+
+    ⚠️ Linhas de conjunto incompleto (o bug da task [D], `prob_justa = 1,0` com um só lado
+    precificado) já saem fora aqui, como no Teste 4. A [D] torna a proteção estrutural.
+
+    Rodar com:
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_a40_transporte
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/taskA_a40_transporte.sql
+#}
+
+WITH {{ task01_base() }},
+
+validas AS (
+    SELECT * FROM apostas WHERE NOT conjunto_incompleto
+),
+
+metades AS (
+    SELECT
+        fixture_id,
+        NTILE(2) OVER (ORDER BY kickoff_utc, fixture_id) AS metade
+    FROM (SELECT DISTINCT fixture_id, kickoff_utc FROM validas)
+),
+
+{# LADO da aposta. É o eixo que a normalização passa a respeitar: dentro do mesmo mercado
+   os dois lados têm conjuntos de premissa disjuntos (menos no 1X2 e na DC, onde só o
+   `mando` difere). No Handicap o lado sai do SINAL do handicap na ótica do próprio lado —
+   `line_value` vem na ótica do mandante e é o mesmo p/ Home e Away. #}
+apostas_m AS (
+    SELECT
+        v.*,
+        m.metade,
+        CASE v.market_id
+            WHEN 4 THEN CASE
+                            WHEN IF(v.outcome_side = 'Home', v.line_value, -v.line_value) < 0 THEN 'Favorito'
+                            WHEN IF(v.outcome_side = 'Home', v.line_value, -v.line_value) > 0 THEN 'Azarao'
+                            ELSE 'Pick'
+                        END
+            WHEN 12 THEN 'unico'
+            ELSE v.outcome_side
+        END AS lado
+    FROM validas AS v
+    JOIN metades AS m USING (fixture_id)
+),
+
+lados AS (
+    SELECT  1 AS market_id, lado FROM UNNEST(['Home', 'Away', 'Draw'])        AS lado
+    UNION ALL SELECT 5, lado FROM UNNEST(['Over', 'Under'])                   AS lado
+    UNION ALL SELECT 4, lado FROM UNNEST(['Favorito', 'Azarao', 'Pick'])      AS lado
+    UNION ALL SELECT 8, lado FROM UNNEST(['Yes', 'No'])                       AS lado
+    UNION ALL SELECT 12, 'unico'
+),
+
+para_peso AS (
+    SELECT a.*, pl.premissa, pl.acesa
+    FROM apostas_m AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    WHERE a.benchmark = CASE a.market_id
+                            WHEN 12 THEN 'derivada'
+                            WHEN 8  THEN 'consenso'
+                            ELSE         'sharp'
+                        END
+      AND a.min_jogos >= 5
+),
+
+pesos_t2 AS (
+    SELECT 'A. t2_full' AS fonte, market_id, premissa, 'ambos' AS lado,
+           GREATEST((AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+                   - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100, 0)
+           * SAFE_DIVIDE(COUNTIF(acesa), COUNTIF(acesa) + 50) AS peso
+    FROM para_peso
+    GROUP BY market_id, premissa
+
+    UNION ALL
+    SELECT 'B. t2_h1', market_id, premissa, 'ambos',
+           GREATEST((AVG(IF(acesa, CAST(ganhou AS INT64), NULL))
+                   - AVG(IF(acesa, prob_justa_fechamento, NULL))) * 100, 0)
+           * SAFE_DIVIDE(COUNTIF(acesa), COUNTIF(acesa) + 50)
+    FROM para_peso WHERE metade = 1
+    GROUP BY market_id, premissa
+),
+
+t1_linhas AS (
+    SELECT
+        pl.market_id, pl.fixture_id, pl.outcome_side, pl.line_value, pl.premissa, pl.acesa,
+        COALESCE(pit.min_jogos, 0)          AS min_jogos,
+        {{ task01_liquidacao('pl.', 'j.') }} AS ganhou
+    FROM prem_long AS pl
+    JOIN jogos_encerrados AS j ON j.fixture_id = pl.fixture_id
+    LEFT JOIN pit ON pit.fixture_id = pl.fixture_id
+    WHERE {{ task01_meia_linha('pl.') }}
+),
+t1_base AS (
+    SELECT market_id, outcome_side, line_value, AVG(CAST(ganhou AS INT64)) AS taxa_base
+    FROM (SELECT DISTINCT market_id, fixture_id, outcome_side, line_value, ganhou FROM t1_linhas)
+    GROUP BY 1, 2, 3
+),
+pesos_t1 AS (
+    SELECT 'D. t1_controle' AS fonte, l.market_id, l.premissa, 'ambos' AS lado,
+           GREATEST((AVG(IF(l.acesa, CAST(l.ganhou AS INT64), NULL))
+                   - AVG(IF(l.acesa, b.taxa_base, NULL))) * 100, 0)
+           * SAFE_DIVIDE(COUNTIF(l.acesa), COUNTIF(l.acesa) + 50) AS peso
+    FROM t1_linhas AS l
+    JOIN t1_base AS b
+      ON  b.market_id                  = l.market_id
+      AND b.outcome_side               = l.outcome_side
+      AND COALESCE(b.line_value, -999) = COALESCE(l.line_value, -999)
+    WHERE l.min_jogos >= 5
+    GROUP BY l.market_id, l.premissa
+),
+
+{# OS PESOS DE CATÁLOGO — os que estão em produção hoje, lidos dos cinco modelos de
+   premissa. Se um peso mudar lá, muda aqui. `mando` é a única premissa com peso por lado
+   (8 em casa, 4 fora), e é o que separa o teto 51 do 47 no 1X2. #}
+catalogo AS (
+    SELECT * FROM UNNEST([
+        {# 1X2 — Home Σ51 · Away Σ47 #}
+        STRUCT( 1 AS market_id, 'forca_mismatch'         AS premissa, 'ambos' AS lado, 12.0 AS peso),
+        STRUCT( 1, 'superioridade_xg',       'ambos',  8.0),
+        STRUCT( 1, 'mando',                  'Home',   8.0),
+        STRUCT( 1, 'mando',                  'Away',   4.0),
+        STRUCT( 1, 'desfalque_adversario',   'ambos',  8.0),
+        STRUCT( 1, 'superioridade_tabela',   'ambos',  6.0),
+        STRUCT( 1, 'forma',                  'ambos',  5.0),
+        STRUCT( 1, 'h2h_favoravel',          'ambos',  4.0),
+
+        {# Gols — Over Σ56 · Under Σ52 #}
+        STRUCT( 5, 'ataque_combinado',       'Over',  12.0),
+        STRUCT( 5, 'defesas_vazaveis',       'Over',  10.0),
+        STRUCT( 5, 'xg_combinado_alto',      'Over',   8.0),
+        STRUCT( 5, 'ritmo_alto',             'Over',   8.0),
+        STRUCT( 5, 'ambos_vazam',            'Over',   6.0),
+        STRUCT( 5, 'historico_over',         'Over',   6.0),
+        STRUCT( 5, 'linha_subindo',          'Over',   6.0),
+        STRUCT( 5, 'defesas_firmes',         'Under', 12.0),
+        STRUCT( 5, 'clean_sheets_altos',     'Under', 10.0),
+        STRUCT( 5, 'xg_baixo_combinado',     'Under', 10.0),
+        STRUCT( 5, 'ataques_fracos',         'Under',  8.0),
+        STRUCT( 5, 'historico_under',        'Under',  6.0),
+        STRUCT( 5, 'linha_descendo',         'Under',  6.0),
+
+        {# Handicap — Favorito Σ40 · Azarão Σ30 #}
+        STRUCT( 4, 'supremacia',             'Favorito', 12.0),
+        STRUCT( 4, 'tende_golear',           'Favorito', 10.0),
+        STRUCT( 4, 'adversario_fragil_fora', 'Favorito',  8.0),
+        STRUCT( 4, 'mando_forte',            'Favorito',  6.0),
+        STRUCT( 4, 'sem_rodizio',            'Favorito',  4.0),
+        STRUCT( 4, 'raramente_perde_por_2',  'Azarao',   12.0),
+        STRUCT( 4, 'defesa_fora_solida',     'Azarao',   10.0),
+        STRUCT( 4, 'favorito_irregular',     'Azarao',    8.0),
+
+        {# BTTS — Sim Σ34 · Não Σ28 #}
+        STRUCT( 8, 'ambos_marcam',           'Yes',  12.0),
+        STRUCT( 8, 'ataque_dos_dois',        'Yes',   8.0),
+        STRUCT( 8, 'defesas_vazaveis',       'Yes',   8.0),
+        STRUCT( 8, 'historico_btts',         'Yes',   6.0),
+        STRUCT( 8, 'defesa_forte',           'No',   12.0),
+        STRUCT( 8, 'ataque_trava',           'No',   10.0),
+        STRUCT( 8, 'historico_seco',         'No',    6.0),
+
+        {# Dupla Chance — Σ34, lado único #}
+        STRUCT(12, 'lado_coberto_forte',     'ambos', 12.0),
+        STRUCT(12, 'equilibrio_defensivo',   'ambos',  8.0),
+        STRUCT(12, 'adversario_limitado',    'ambos',  8.0),
+        STRUCT(12, 'invicto_recente',        'ambos',  6.0)
+    ])
+),
+
+pesos_catalogo AS (
+    SELECT 'E. catalogo' AS fonte, market_id, premissa, lado, peso FROM catalogo
+    UNION ALL
+    SELECT 'F. catalogo_sem_mov', market_id, premissa, lado,
+           IF(premissa IN ('linha_subindo', 'linha_descendo'), 0.0, peso)
+    FROM catalogo
+),
+
+pesos AS (
+    SELECT * FROM pesos_t2
+    UNION ALL SELECT * FROM pesos_t1
+    UNION ALL SELECT * FROM pesos_catalogo
+),
+
+{# Teto por (fonte, mercado, LADO). Peso marcado 'ambos' conta em todos os lados — é o que
+   faz A–D reproduzirem o teto por mercado do Teste 4. #}
+teto AS (
+    SELECT p.fonte, l.market_id, l.lado, SUM(p.peso) AS pts_max
+    FROM lados AS l
+    JOIN pesos AS p
+      ON  p.market_id = l.market_id
+      AND (p.lado = 'ambos' OR p.lado = l.lado)
+    GROUP BY p.fonte, l.market_id, l.lado
+),
+
+notas AS (
+    SELECT
+        a.fixture_id, a.market_id, a.lado, a.metade, a.ganhou, a.best_odd,
+        a.pts_corroboracao, a.penalidades_globais_pts, a.penalidades_especificas_pts,
+        p.fonte,
+        SUM(IF(pl.acesa, p.peso, 0)) AS nota_pts,
+        ANY_VALUE(t.pts_max)         AS pts_max
+    FROM apostas_m AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    JOIN pesos AS p
+      ON  p.market_id = pl.market_id
+      AND p.premissa  = pl.premissa
+      AND (p.lado = 'ambos' OR p.lado = a.lado)
+    JOIN teto AS t
+      ON t.fonte = p.fonte AND t.market_id = a.market_id AND t.lado = a.lado
+    GROUP BY a.fixture_id, a.market_id, a.lado, a.metade, a.ganhou, a.best_odd,
+             a.pts_corroboracao, a.penalidades_globais_pts, a.penalidades_especificas_pts,
+             a.outcome_side, a.line_value, p.fonte
+),
+
+avaliado AS (
+    SELECT
+        CASE
+            WHEN fonte = 'B. t2_h1' AND metade = 2 THEN 'C. t2_h1 -> 2a metade (OUT-OF-SAMPLE)'
+            WHEN fonte = 'B. t2_h1'                THEN 'B. t2_h1 -> 1a metade (in-sample)'
+            {# E/F não são ajustadas em metade nenhuma: o catálogo é fixo. As duas metades
+               são igualmente válidas, e a 2ª é a que compara com a C. #}
+            WHEN fonte IN ('E. catalogo', 'F. catalogo_sem_mov')
+                 THEN CONCAT(fonte, IF(metade = 2, ' -> 2a metade', ' -> 1a metade'))
+            ELSE fonte
+        END                                                          AS avaliacao,
+        composicao.nome                                              AS composicao,
+        fixture_id,
+        LEAST(GREATEST(SAFE_DIVIDE(composicao.pts, composicao.teto) * 100, 0), 100) AS nota_pct,
+        IF(ganhou, best_odd, 0) - 1                                  AS lucro
+    FROM notas
+    CROSS JOIN UNNEST([
+        STRUCT('1. nota_premissas' AS nome, nota_pts AS pts, pts_max AS teto),
+        STRUCT('2. score_pos_a1',
+               nota_pts + pts_corroboracao
+                        - penalidades_globais_pts - penalidades_especificas_pts,
+               pts_max + 15),
+        {# A fórmula que vai a produção: contexto menos penalidade de contexto, piso em 0. #}
+        STRUCT('3. nota_menos_pen_contexto',
+               GREATEST(nota_pts - penalidades_especificas_pts, 0),
+               pts_max)
+    ]) AS composicao
+    WHERE pts_max > 0
+),
+
+com_faixa AS (
+    SELECT *,
+           CASE WHEN nota_pct >= 80 THEN 'e. 80-100'
+                WHEN nota_pct >= 60 THEN 'd. 60-80'
+                WHEN nota_pct >= 40 THEN 'c. 40-60'
+                WHEN nota_pct >= 20 THEN 'b. 20-40'
+                ELSE                     'a. 00-20' END AS faixa,
+           AVG(lucro) OVER (PARTITION BY avaliacao, composicao,
+                            CASE WHEN nota_pct >= 80 THEN 5 WHEN nota_pct >= 60 THEN 4
+                                 WHEN nota_pct >= 40 THEN 3 WHEN nota_pct >= 20 THEN 2
+                                 ELSE 1 END)            AS media_faixa
+    FROM avaliado
+),
+
+por_fixture AS (
+    SELECT avaliacao, composicao, faixa, fixture_id,
+           SUM(lucro - media_faixa) AS resid_jogo
+    FROM com_faixa
+    GROUP BY 1, 2, 3, 4
+),
+erro AS (
+    SELECT avaliacao, composicao, faixa,
+           SUM(POW(resid_jogo, 2)) AS soma_quad,
+           COUNT(*)                AS n_jogos
+    FROM por_fixture GROUP BY 1, 2, 3
+),
+
+faixas AS (
+    SELECT
+        c.avaliacao, c.composicao, c.faixa,
+        COUNT(*)                                   AS n_apostas,
+        e.n_jogos,
+        ROUND(AVG(c.nota_pct), 1)                  AS nota_media,
+        ROUND(AVG(c.lucro) * 100, 1)               AS roi,
+        ROUND(SAFE_DIVIDE(SQRT(e.soma_quad), COUNT(*)) * 100, 1) AS ep_cluster,
+        CAST(NULL AS FLOAT64)                      AS inclinacao
+    FROM com_faixa AS c
+    JOIN erro AS e USING (avaliacao, composicao, faixa)
+    GROUP BY c.avaliacao, c.composicao, c.faixa, e.soma_quad, e.n_jogos
+),
+
+continuo AS (
+    SELECT
+        avaliacao, composicao, 'z. CONTINUO (todas)' AS faixa,
+        COUNT(*)                                       AS n_apostas,
+        COUNT(DISTINCT fixture_id)                     AS n_jogos,
+        ROUND(AVG(nota_pct), 1)                        AS nota_media,
+        ROUND(AVG(lucro) * 100, 1)                     AS roi,
+        CAST(NULL AS FLOAT64)                          AS ep_cluster,
+        ROUND(COVAR_SAMP(lucro, nota_pct)
+              / NULLIF(VAR_SAMP(nota_pct), 0) * 100, 3) AS inclinacao
+    FROM com_faixa
+    GROUP BY avaliacao, composicao
+)
+
+SELECT * FROM faixas
+UNION ALL SELECT * FROM continuo
+ORDER BY composicao, avaliacao, faixa

--- a/dbt_futebol/analyses/taskA_linha_de_base.sql
+++ b/dbt_futebol/analyses/taskA_linha_de_base.sql
@@ -1,0 +1,279 @@
+{#
+    LINHA DE BASE DO BOARD — entregável de aceite da task [A].
+
+    "Uma query mostrando, no board de hoje, quantas oportunidades cada porta remove,
+    separadamente. Serve de linha de base."
+
+    Reproduz os 5 ramos do `fact_value_opportunities` SEM gate nenhum e depois mede, sobre
+    esse universo, o efeito de cada porta — a de hoje e a proposta — em duas leituras:
+
+      isolado     quantas linhas ESTA porta sozinha removeria do universo bruto.
+                  As somas se sobrepõem: uma linha pode falhar em três portas.
+      marginal    quantas linhas ESTA porta remove depois das anteriores da fila.
+                  As somas fecham, e é esta que diz o que cada porta ainda acrescenta.
+
+    ESCOPO: duas janelas, porque "o board de hoje" pode ter poucas partidas e a leitura
+    ficar refém do dia.
+      a. board_atual   fixtures que ainda não começaram (o board de verdade).
+      b. ultimos_30d   fixtures com kickoff nos últimos 30 dias (volume p/ estabilizar).
+
+    ⚠ A nota nova é `clamp(pts_premissas − penalidades de contexto, 0) / teto × 100`, com
+    TETO POR MERCADO E POR LADO — os tetos abaixo saem da leitura dos modelos de premissa
+    e são a mesma tabela da seção D2 da spec. Se um peso mudar lá, muda aqui.
+
+    ⚠ A variante `sem_mov_linha` tira `linha_subindo`/`linha_descendo` (6 pts cada, Gols),
+    que leem movimento de odd. É a decisão D1 da spec, ainda pendente de confirmação —
+    por isso as duas notas saem lado a lado em vez de uma escolhida.
+
+    Rodar com:
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_linha_de_base
+      bq query --use_legacy_sql=false < ../target/compiled/dbt_futebol/analyses/taskA_linha_de_base.sql
+#}
+
+WITH fixtures AS (
+    SELECT
+        fixture_id,
+        CASE
+            WHEN kickoff_utc > CURRENT_TIMESTAMP()                                  THEN 'a. board_atual'
+            WHEN DATE(kickoff_utc) >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)      THEN 'b. ultimos_30d'
+        END AS escopo
+    FROM {{ ref('fact_fixtures') }}
+),
+board AS (
+    SELECT fixture_id, escopo FROM fixtures WHERE escopo IS NOT NULL
+),
+
+devig AS (
+    SELECT *, COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
+    FROM {{ ref('int_futebol_odds_devig') }}
+),
+corro AS (
+    SELECT *, COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
+    FROM {{ ref('int_futebol_corroboracao') }}
+),
+
+{#- ─────────────────────────────────────────────────────────────────────────────────
+    Os 5 ramos, SEM gate. Cada um devolve o mesmo shape: pontos, penalidade de contexto,
+    teto do lado, e o bloco de odds. `pen_contexto` é a penalidade específica do mercado
+    (as de odd saem da nota por decisão da task, então não entram aqui).
+    ───────────────────────────────────────────────────────────────────────────────── -#}
+ramo_1x2 AS (
+    SELECT
+        b.escopo, p.fixture_id, 'match_winner' AS market, p.outcome,
+        CAST(NULL AS FLOAT64) AS line_value,
+        p.pts_premissas,
+        p.pts_premissas                                   AS pts_sem_mov,
+        p.penalidades_1x2_pts                             AS pen_contexto,
+        {#- Home alcança pts_mando=8; Away só 4; Draw não tem lado apostado -> nada dispara. -#}
+        CASE p.outcome WHEN 'Home' THEN 51 WHEN 'Away' THEN 47 ELSE 0 END AS teto,
+        CASE p.outcome WHEN 'Home' THEN 51 WHEN 'Away' THEN 47 ELSE 0 END AS teto_sem_mov,
+        d.pts_valor, d.penalidades_globais_pts, d.pen_odd_outlier,
+        d.best_odd, d.n_casas, d.prob_justa_fechamento, d.valor_fonte, d.edge,
+        COALESCE(c.pts_corroboracao, 0) AS pts_corroboracao,
+        COALESCE(d.pin_n_outcomes >= 3, FALSE)            AS passa_completude,
+        TRUE                                              AS passa_meia_linha
+    FROM {{ ref('int_futebol_premissas_1x2') }} p
+    JOIN board b        ON b.fixture_id = p.fixture_id
+    JOIN devig d        ON d.market_id = 1 AND d.fixture_id = p.fixture_id AND d.outcome_side = p.outcome
+    LEFT JOIN corro c   ON c.market_id = 1 AND c.fixture_id = p.fixture_id AND c.outcome_side = p.outcome
+),
+
+ramo_ou AS (
+    SELECT
+        b.escopo, p.fixture_id, 'goals_over_under' AS market, p.outcome,
+        p.line_value,
+        p.pts_premissas,
+        {#- D1: sem as duas premissas que leem movimento de odd (6 pts cada). -#}
+        p.pts_premissas - 6 * CAST(p.linha_subindo AS INT64) - 6 * CAST(p.linha_descendo AS INT64) AS pts_sem_mov,
+        p.penalidades_ou_pts                              AS pen_contexto,
+        IF(p.outcome = 'Over', 56, 52)                    AS teto,
+        IF(p.outcome = 'Over', 50, 46)                    AS teto_sem_mov,
+        d.pts_valor, d.penalidades_globais_pts, d.pen_odd_outlier,
+        d.best_odd, d.n_casas, d.prob_justa_fechamento, d.valor_fonte, d.edge,
+        COALESCE(c.pts_corroboracao, 0) AS pts_corroboracao,
+        COALESCE(d.pin_n_outcomes >= 2, FALSE)            AS passa_completude,
+        COALESCE(MOD(CAST(ROUND(ABS(p.line_value) * 2) AS INT64), 2) = 1, FALSE) AS passa_meia_linha
+    FROM {{ ref('int_futebol_premissas_ou') }} p
+    JOIN board b        ON b.fixture_id = p.fixture_id
+    JOIN devig d        ON d.market_id = 5 AND d.fixture_id = p.fixture_id AND d.outcome_side = p.outcome
+                       AND d.line_key = COALESCE(CAST(p.line_value AS STRING), 'NONE')
+    LEFT JOIN corro c   ON c.market_id = 5 AND c.fixture_id = p.fixture_id AND c.outcome_side = p.outcome
+                       AND c.line_key = COALESCE(CAST(p.line_value AS STRING), 'NONE')
+),
+
+ramo_ah AS (
+    SELECT
+        b.escopo, p.fixture_id, 'asian_handicap' AS market, p.outcome,
+        p.line_value,
+        p.pts_premissas,
+        p.pts_premissas                                   AS pts_sem_mov,
+        p.penalidades_ah_pts                              AS pen_contexto,
+        {#- line_value vem na ótica do mandante; o handicap DO LADO é o oposto p/ o visitante.
+            <0 = favorito (Σ40) · >0 = azarão (Σ30) · =0 = pick (nada dispara). -#}
+        CASE
+            WHEN IF(p.outcome = 'Home', p.line_value, -p.line_value) < 0 THEN 40
+            WHEN IF(p.outcome = 'Home', p.line_value, -p.line_value) > 0 THEN 30
+            ELSE 0
+        END                                               AS teto,
+        CASE
+            WHEN IF(p.outcome = 'Home', p.line_value, -p.line_value) < 0 THEN 40
+            WHEN IF(p.outcome = 'Home', p.line_value, -p.line_value) > 0 THEN 30
+            ELSE 0
+        END                                               AS teto_sem_mov,
+        d.pts_valor, d.penalidades_globais_pts, d.pen_odd_outlier,
+        d.best_odd, d.n_casas, d.prob_justa_fechamento, d.valor_fonte, d.edge,
+        COALESCE(c.pts_corroboracao, 0) AS pts_corroboracao,
+        COALESCE(d.pin_n_outcomes >= 2, FALSE)            AS passa_completude,
+        COALESCE(MOD(CAST(ROUND(ABS(p.line_value) * 2) AS INT64), 2) = 1, FALSE) AS passa_meia_linha
+    FROM {{ ref('int_futebol_premissas_ah') }} p
+    JOIN board b        ON b.fixture_id = p.fixture_id
+    JOIN devig d        ON d.market_id = 4 AND d.fixture_id = p.fixture_id AND d.outcome_side = p.outcome
+                       AND d.line_key = COALESCE(CAST(p.line_value AS STRING), 'NONE')
+    LEFT JOIN corro c   ON c.market_id = 4 AND c.fixture_id = p.fixture_id AND c.outcome_side = p.outcome
+                       AND c.line_key = COALESCE(CAST(p.line_value AS STRING), 'NONE')
+),
+
+ramo_btts AS (
+    SELECT
+        b.escopo, p.fixture_id, 'btts' AS market, p.outcome,
+        CAST(NULL AS FLOAT64) AS line_value,
+        p.pts_premissas,
+        p.pts_premissas                                   AS pts_sem_mov,
+        p.penalidades_btts_pts                            AS pen_contexto,
+        IF(p.outcome = 'Yes', 34, 28)                     AS teto,
+        IF(p.outcome = 'Yes', 34, 28)                     AS teto_sem_mov,
+        d.pts_valor, d.penalidades_globais_pts, d.pen_odd_outlier,
+        d.best_odd, d.n_casas, d.prob_justa_fechamento, d.valor_fonte, d.edge,
+        COALESCE(c.pts_corroboracao, 0) AS pts_corroboracao,
+        COALESCE(d.n_outcomes_valor >= 2, FALSE)          AS passa_completude,
+        TRUE                                              AS passa_meia_linha
+    FROM {{ ref('int_futebol_premissas_btts') }} p
+    JOIN board b        ON b.fixture_id = p.fixture_id
+    JOIN devig d        ON d.market_id = 8 AND d.fixture_id = p.fixture_id AND d.outcome_side = p.outcome
+    LEFT JOIN corro c   ON c.market_id = 8 AND c.fixture_id = p.fixture_id AND c.outcome_side = p.outcome
+),
+
+ramo_dc AS (
+    SELECT
+        b.escopo, p.fixture_id, 'double_chance' AS market, p.outcome,
+        CAST(NULL AS FLOAT64) AS line_value,
+        p.pts_premissas,
+        p.pts_premissas                                   AS pts_sem_mov,
+        0                                                 AS pen_contexto,
+        34                                                AS teto,
+        34                                                AS teto_sem_mov,
+        d.pts_valor, d.penalidades_globais_pts, d.pen_odd_outlier,
+        d.best_odd, d.n_casas, d.prob_justa_fechamento, d.valor_fonte, d.edge,
+        COALESCE(c.pts_corroboracao, 0) AS pts_corroboracao,
+        COALESCE(d.n_outcomes_valor >= 3, FALSE)          AS passa_completude,
+        TRUE                                              AS passa_meia_linha
+    FROM {{ ref('int_futebol_premissas_dc') }} p
+    JOIN board b        ON b.fixture_id = p.fixture_id
+    JOIN devig d        ON d.market_id = 12 AND d.fixture_id = p.fixture_id AND d.outcome_side = p.outcome
+    LEFT JOIN corro c   ON c.market_id = 12 AND c.fixture_id = p.fixture_id AND c.outcome_side = p.outcome
+),
+
+universo AS (
+    SELECT * FROM ramo_1x2
+    UNION ALL SELECT * FROM ramo_ou
+    UNION ALL SELECT * FROM ramo_ah
+    UNION ALL SELECT * FROM ramo_btts
+    UNION ALL SELECT * FROM ramo_dc
+),
+
+notas AS (
+    SELECT
+        *,
+        {#- Score de HOJE, p/ contraste. -#}
+        LEAST(GREATEST(pts_valor + pts_premissas + pts_corroboracao
+                       - penalidades_globais_pts - pen_contexto, 0), 100)          AS score_hoje,
+        {#- Nota NOVA: só contexto, normalizada pelo teto do lado. Teto 0 (empate, pick de
+            handicap) devolve 0 em vez de erro — é a guarda da D3 da spec. -#}
+        CAST(ROUND(COALESCE(SAFE_DIVIDE(GREATEST(pts_premissas - pen_contexto, 0), teto), 0) * 100) AS INT64) AS nota,
+        CAST(ROUND(COALESCE(SAFE_DIVIDE(GREATEST(pts_sem_mov  - pen_contexto, 0), teto_sem_mov), 0) * 100) AS INT64) AS nota_sem_mov,
+        {#- Faixa de odd por mercado (A5). -#}
+        IF(market = 'double_chance', 1.25, 1.50)                                   AS odd_min,
+        IF(market = 'double_chance', 2.00, 4.00)                                   AS odd_max
+    FROM universo
+),
+
+portas AS (
+    SELECT
+        escopo, market, fixture_id, outcome, line_value, valor_fonte,
+        edge, best_odd, n_casas, score_hoje, nota, nota_sem_mov,
+
+        {#- ── Portas estruturais, iguais nos dois regimes ── -#}
+        (prob_justa_fechamento IS NOT NULL) AS p0_devig,
+        passa_completude                    AS p1_completude,
+        passa_meia_linha                    AS p2_meia_linha,
+
+        {#- ── Regime de HOJE ── -#}
+        (n_casas >= 3)                                                    AS h1_casas3,
+        (edge > IF(valor_fonte = 'consenso', 0.03, 0))                    AS h2_edge,
+        (score_hoje >= 40)                                                AS h3_score40,
+
+        {#- ── Regime NOVO ── -#}
+        (n_casas >= 4)                                                    AS n1_casas4,
+        (NOT pen_odd_outlier)                                             AS n2_outlier,
+        (best_odd BETWEEN odd_min AND odd_max)                            AS n3_faixa_odd,
+        (nota >= 40)                                                      AS n4_nota40,
+        (valor_fonte <> 'consenso' OR nota >= 50)                         AS n5_consenso50,
+        (nota_sem_mov >= 40)                                              AS n4b_nota40_sem_mov,
+        (valor_fonte <> 'consenso' OR nota_sem_mov >= 50)                 AS n5b_consenso50_sem_mov
+    FROM notas
+),
+
+{#- Cumulativo em ordem de fila, p/ a leitura MARGINAL. Cada `cum_k` é "passou em todas
+    até aqui". A porta k remove (cum_{k-1} AND NOT passa_k). -#}
+cum AS (
+    SELECT
+        *,
+        p0_devig AND p1_completude AND p2_meia_linha                                   AS cum_estrutural,
+        p0_devig AND p1_completude AND p2_meia_linha AND h1_casas3                     AS cum_h1,
+        p0_devig AND p1_completude AND p2_meia_linha AND h1_casas3 AND h2_edge         AS cum_h2,
+        p0_devig AND p1_completude AND p2_meia_linha AND h1_casas3 AND h2_edge AND h3_score40 AS cum_h3,
+        p0_devig AND p1_completude AND p2_meia_linha AND n1_casas4                     AS cum_n1,
+        p0_devig AND p1_completude AND p2_meia_linha AND n1_casas4 AND n2_outlier      AS cum_n2,
+        p0_devig AND p1_completude AND p2_meia_linha AND n1_casas4 AND n2_outlier AND n3_faixa_odd AS cum_n3,
+        p0_devig AND p1_completude AND p2_meia_linha AND n1_casas4 AND n2_outlier AND n3_faixa_odd AND n4_nota40 AS cum_n4,
+        p0_devig AND p1_completude AND p2_meia_linha AND n1_casas4 AND n2_outlier AND n3_faixa_odd AND n4_nota40 AND n5_consenso50 AS cum_n5,
+        p0_devig AND p1_completude AND p2_meia_linha AND n1_casas4 AND n2_outlier AND n3_faixa_odd AND n4b_nota40_sem_mov AND n5b_consenso50_sem_mov AS cum_n5_sem_mov
+    FROM portas
+),
+
+funil AS (
+    SELECT escopo, market, f.*
+    FROM cum
+    CROSS JOIN UNNEST([
+        STRUCT('00. universo bruto'        AS porta, 'ambos'  AS regime, TRUE AS entrou, TRUE  AS passou),
+        STRUCT('01. de-vig válido',                  'ambos',  TRUE,                    p0_devig),
+        STRUCT('02. completude do conjunto',         'ambos',  p0_devig,                p0_devig AND p1_completude),
+        STRUCT('03. linha meia (AH/Gols)',           'ambos',  p0_devig AND p1_completude, cum_estrutural),
+
+        STRUCT('10. liquidez >= 3 casas',            'hoje',   cum_estrutural,          cum_h1),
+        STRUCT('11. edge positivo',                  'hoje',   cum_h1,                  cum_h2),
+        STRUCT('12. score antigo >= 40',             'hoje',   cum_h2,                  cum_h3),
+
+        STRUCT('20. liquidez >= 4 casas',            'novo',   cum_estrutural,          cum_n1),
+        STRUCT('21. odd fora da curva',              'novo',   cum_n1,                  cum_n2),
+        STRUCT('22. faixa de odd do mercado',        'novo',   cum_n2,                  cum_n3),
+        STRUCT('23. nota >= 40',                     'novo',   cum_n3,                  cum_n4),
+        STRUCT('24. régua de consenso >= 50',        'novo',   cum_n4,                  cum_n5),
+        STRUCT('25. [variante D1] sem mov. de linha','novo',   cum_n3,                  cum_n5_sem_mov)
+    ]) AS f
+)
+
+SELECT
+    escopo,
+    regime,
+    porta,
+    mercado,
+    COUNTIF(entrou)                                              AS n_entrada,
+    COUNTIF(entrou AND NOT passou)                               AS removidas_marginal,
+    COUNTIF(passou)                                              AS n_saida,
+    ROUND(SAFE_DIVIDE(COUNTIF(entrou AND NOT passou), NULLIF(COUNTIF(entrou), 0)) * 100, 1) AS pct_removido
+{# Cada linha conta duas vezes: no seu mercado e no total. Evita ROLLUP, que no BigQuery
+   não convive com outros elementos de agrupamento. #}
+FROM funil, UNNEST([market, 'ZZ. TODOS']) AS mercado
+GROUP BY escopo, regime, porta, mercado
+ORDER BY escopo, regime, porta, mercado


### PR DESCRIPTION
Duas análises da task **[A]** (redesenho do Score). **Nenhuma toca em produção** — são `analyses/`, não modelos, e a `task01_teste4.sql` original fica intocada.

Spec e resultados completos: https://github.com/tech-lamjav/analytics-engineering/issues/15

## `taskA_linha_de_base.sql` — entregável de aceite

Reproduz os 5 ramos do `fact_value_opportunities` **sem gate** e mede quanto cada porta remove, no regime de hoje e no proposto. Validada contra o mart: reproduz exatamente as 50 linhas que ele tem.

| Porta | Entra | Remove | Sai |
|---|---:|---:|---:|
| universo bruto | — | — | 9.579 |
| completude do conjunto | 9.579 | **4.735 (49%)** | 4.844 |
| linha meia (AH/Gols) | 4.844 | 1.674 (35%) | 3.170 |
| **hoje** · edge > 0 | 3.170 | **2.744 (87%)** | 426 |
| **hoje** · score antigo ≥ 40 | 426 | 376 (88%) | **50** |
| **novo** · liquidez ≥ 4 casas | 3.170 | 28 (0,9%) | 3.142 |
| **novo** · odd fora da curva | 3.142 | 340 (11%) | 2.802 |
| **novo** · faixa de odd | 2.802 | 887 (32%) | 1.915 |
| **novo** · nota ≥ 40 | 1.915 | **1.208 (63%)** | 707 |
| **novo** · régua de consenso ≥ 50 | 707 | 18 (2,5%) | **689** |

**O board passa de 50 para 689 — 13,8×.** Maior consequência da task, não estava dimensionada. E a porta de nota herda o trabalho que era do `edge > 0`.

## `taskA_a40_transporte.sql` — a porta de 40 transporta?

A evidência da [0.1] foi medida sobre a **nota ponderada** (pesos do Teste 2). Produção usa a **nota de catálogo** (pesos à mão), e a decisão de não reescrevê-los está fechada. Dois vetores diferentes.

Acrescenta as fontes **E** (catálogo) e **F** (catálogo sem as premissas que leem movimento de odd) e normaliza por `(fonte, mercado, LADO)`. As fontes A–D ficam com todas as premissas em `'ambos'`, então o teto por lado colapsa no teto por mercado e **elas reproduzem a `task01_teste4.sql` byte a byte** — verificado rodando as duas hoje.

**Resultado: o 40 não transporta.** Faixa 00–20 a **1,72 EP**, abaixo da régua de 2 EP que foi fixada antes da medição.

| Corte | 1ª metade | 2ª metade |
|---|---:|---:|
| nenhum | −11,3 | −8,1 |
| ≥ 40 | −2,5 | −3,6 |
| ≥ 60 | **+1,5** | **−0,9** |

O que **não** dá para concluir: que o catálogo é pior que o vetor medido. Sendo fixo, ele oscila 0,27 → 0,119 entre as metades — mais que a distância para o medido (0,226). A amostra não distingue os dois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGVfqgzeeLjbEBJ4Z6ZxpS