### PR TITLE
feat(futebol): slug bundesliga, teste de cobertura per-fixture e a dupla contagem medida

### DIFF
--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
@@ -137,6 +137,12 @@ flags AS (
         -- pontos corridos (Brasileirão, Série B, La Liga, Premier League e Serie A ITA — 20 times, mesma dinâmica
         -- G6/Z3 de Europa/rebaixamento, então rank<=6 / rank>=n-3 vale sem mudança; revisar na recalibração por
         -- liga) e S em zona de disputa (G6 ou Z4). Copa -> FALSE (rank é por grupo, proxy não vale).
+        -- Bundesliga -> TRUE, mas é a 1ª da lista com 18 times (as outras 5 têm 20). Entra porque
+        -- n_teams vem do standings por (liga, season), então `rank >= n_teams - 3` se ajusta sozinho
+        -- (15-18) sem constante nova. RESSALVA: a Bundesliga tem 3 vagas em risco (2 quedas diretas
+        -- + 1 playoff contra a 2. Bundesliga), então a faixa de 4 posições sobre-inclui o 15º — o
+        -- proxy fica levemente mais frouxo que nas ligas de 20 (22% do grid vs 20%). Aceitável no
+        -- nível de grosseria que este proxy já assume; refinar pertence à recalibração por liga.
         -- Copa do Brasil -> FALSE também (mata-mata sem standings: s_rank/n_teams vêm NULL do
         -- LEFT JOIN e o COALESCE já derruba; fica fora do IN por decisão, não por acidente).
         -- Libertadores/Sudamericana -> FALSE também, mas por outro motivo: elas TÊM standings
@@ -147,7 +153,7 @@ flags AS (
         -- Champions League -> FALSE pelo mesmo motivo: fase de liga (36 times, 8 jogos) vira
         -- mata-mata em fevereiro e a tabela congela; G6/Z3 não modela a dinâmica top-8/9-24.
         -- TODO: refinar com rodada/congestionamento de calendário.
-        m.is_favorito AND m.competition IN ('brasileirao', 'serie_b', 'la_liga', 'premier_league', 'serie_a_ita')
+        m.is_favorito AND m.competition IN ('brasileirao', 'serie_b', 'la_liga', 'premier_league', 'serie_a_ita', 'bundesliga')
             AND COALESCE(m.s_rank <= 6 OR m.s_rank >= m.n_teams - 3, FALSE)     AS sem_rodizio,
         -- Azarão (Σ30)
         m.is_azarao AND COALESCE(m.s_n_games >= 5 AND m.s_lost2 / m.s_n_games < 0.30, FALSE) AS raramente_perde_por_2,

--- a/dbt_futebol/models/marts/fact_fixtures.sql
+++ b/dbt_futebol/models/marts/fact_fixtures.sql
@@ -18,6 +18,7 @@ SELECT
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
         WHEN 135 THEN 'serie_a_ita'
+        WHEN 78  THEN 'bundesliga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS competition_id,

--- a/dbt_futebol/models/marts/fact_injuries_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_injuries_snapshot.sql
@@ -21,6 +21,7 @@ SELECT
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
         WHEN 135 THEN 'serie_a_ita'
+        WHEN 78  THEN 'bundesliga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS league_id,

--- a/dbt_futebol/models/marts/fact_odds_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_odds_snapshot.sql
@@ -21,6 +21,7 @@ SELECT
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
         WHEN 135 THEN 'serie_a_ita'
+        WHEN 78  THEN 'bundesliga'
         ELSE 'unknown'
     END                                              AS competition,
     league_id,

--- a/dbt_futebol/models/marts/fact_predictions_api.sql
+++ b/dbt_futebol/models/marts/fact_predictions_api.sql
@@ -21,6 +21,7 @@ SELECT
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
         WHEN 135 THEN 'serie_a_ita'
+        WHEN 78  THEN 'bundesliga'
         ELSE 'unknown'
     END                                              AS competition,
     league_id,

--- a/dbt_futebol/models/marts/fact_standings_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_standings_snapshot.sql
@@ -21,6 +21,7 @@ SELECT
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
         WHEN 135 THEN 'serie_a_ita'
+        WHEN 78  THEN 'bundesliga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS league_id,

--- a/dbt_futebol/models/marts/fact_team_season_stats.sql
+++ b/dbt_futebol/models/marts/fact_team_season_stats.sql
@@ -23,6 +23,7 @@ SELECT
         WHEN 39 THEN 'premier_league'
         WHEN 2  THEN 'champions_league'
         WHEN 135 THEN 'serie_a_ita'
+        WHEN 78  THEN 'bundesliga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS competition_id,

--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -139,8 +139,9 @@ models:
       endpoints de jogo (stats/events/lineups/player_stats, subtasks 5-8). Derivada de
       /fixtures?league=&season= (espinha: fixture, league, teams, goals, score).
       Particionada por DATE(date_utc) em UTC e clusterizada por (competition, season,
-      home_team_id). Cobre Brasileirão (71) 2024/25/26, Copa do Mundo (1) 2026, Série B (72)
-      2024/25/26, Copa do Brasil (73) 2024/25/26, CONMEBOL Libertadores (13) 2024/25/26 e CONMEBOL Sudamericana (11) 2024/25/26.
+      home_team_id). As ligas cobertas são as tuplas (league_id, season) configuradas na ingestão
+      — ver o accepted_values de `competition` abaixo, que é a lista viva; enumerá-las aqui só
+      cria drift (esta descrição parou nas 6 primeiras enquanto o pipeline chegou a 11).
     columns:
       - name: fixture_id
         description: "ID do jogo na API-Football (chave primária; destrava endpoints de jogo)"
@@ -148,9 +149,20 @@ models:
           - not_null
           - unique
       - name: competition
-        description: "'brasileirao' | 'copa_mundo' | 'serie_b' | 'copa_do_brasil' | 'libertadores' | 'sudamericana' (derivado de requested_league_id; cluster key)"
+        description: >
+          Slug de produto derivado de requested_league_id (cluster key). Os valores válidos são a
+          lista de accepted_values abaixo — a descrição não os enumera de propósito, p/ não drenar
+          p/ a lista real a cada liga nova.
+          ⚠️ Este é o accepted_values da TABELA MÃE, e é o único que cobre o CASE de fact_fixtures.
+          Os 5 fatos per-fixture (stats/events/lineups/lineups_players/player_stats) herdam
+          `competition` por JOIN daqui, então não precisam do seu próprio — mas os 5 marts que
+          fazem o CASE por conta própria (odds/standings/injuries/predictions/team_season_stats)
+          precisam, e têm. Ao acrescentar liga: 6 CASE + 6 accepted_values.
+        tests:
+          - accepted_values:
+              values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga']
       - name: competition_id
-        description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana)"
+        description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana, 140 = La Liga, 39 = Premier League, 2 = Champions League, 135 = Serie A ITA, 78 = Bundesliga)"
       - name: season
         description: "Ano da temporada requisitada (cluster key)"
       - name: round

--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -693,7 +693,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga']
       - name: competition_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana)"
       - name: season
@@ -844,7 +844,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 13 = Libertadores, 11 = Sudamericana; cluster key — 73 nunca ocorre, mata-mata sem standings)"
         tests:
@@ -969,7 +969,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão)"
         tests:
@@ -1066,7 +1066,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana)"
         tests:
@@ -1187,7 +1187,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga']
       - name: league_id
         description: "ID da liga na API-Football (71 = Brasileirão, 1 = Copa do Mundo, 72 = Série B, 73 = Copa do Brasil, 13 = Libertadores, 11 = Sudamericana)"
         tests:

--- a/dbt_futebol/tests/assert_per_fixture_coverage.sql
+++ b/dbt_futebol/tests/assert_per_fixture_coverage.sql
@@ -1,0 +1,67 @@
+{{ config(severity='warn') }}
+-- Cobertura per-fixture: fixture FINALIZADA no spine que não tem NENHUMA linha no fato.
+--
+-- Complemento (direção oposta) dos assert_*_reconciled: aqueles pegam fixture presente no
+-- STG e ausente do spine; este pega fixture presente no SPINE e ausente do fato. As duas
+-- direções juntas fecham o quadrado.
+--
+-- Por que existe: backfill que estoura a quota da API-Football NÃO falha. A API responde
+-- HTTP 200 com `errors` preenchido e o workflow termina SUCCEEDED — na Serie A ITA (03/08)
+-- isso cortou fact_fixture_player_stats em 123 de 380 jogos sem nenhum sinal. O único jeito
+-- de ver o corte é este LEFT JOIN, que até aqui era passo manual de D+1 na cabeça de quem
+-- rodou o backfill. O count de `sem_linha` é, ao mesmo tempo, o alarme e o custo EXATO em
+-- chamadas p/ fechar o buraco com o extractor cirúrgico.
+--
+-- severity warn (mesma justificativa dos gêmeos de reconciliação): existem buracos LEGÍTIMOS
+-- e conhecidos da API — jogo que devolve `results: 0` sem erro (ex.: Fiorentina 3x0 Inter,
+-- fixture 1223728, em /fixtures/statistics), mata-mata sem statistics, e liga-temporada cujo
+-- per-fixture nunca foi backfillado por decisão. Um teste que falha sempre vira teste ignorado.
+-- O que se lê aqui é a VARIAÇÃO contra o baseline registrado na issue do rollout, não o zero.
+--
+-- Grão: (competition, season, fato). Agregado de propósito — "liga X, season Y, N jogos mudos"
+-- é o que se age em cima; a lista de fixture_id só interessa depois, na hora de fechar.
+
+WITH finalizadas AS (
+    SELECT fixture_id, competition, season
+    FROM {{ ref('fact_fixtures') }}
+    WHERE status_short IN ('FT', 'AET', 'PEN')  -- "finalizado" do projeto inclui prorrogação e pênaltis
+),
+
+-- 1 linha por (fato, fixture) presente. DISTINCT porque todos os fatos per-fixture são
+-- multi-linha por jogo (2 times, N eventos, N jogadores).
+presentes AS (
+    SELECT DISTINCT 'fact_fixture_stats'        AS fato, fixture_id FROM {{ ref('fact_fixture_stats') }}
+    UNION ALL
+    SELECT DISTINCT 'fact_fixture_events'       AS fato, fixture_id FROM {{ ref('fact_fixture_events') }}
+    UNION ALL
+    SELECT DISTINCT 'fact_fixture_lineups'      AS fato, fixture_id FROM {{ ref('fact_fixture_lineups') }}
+    UNION ALL
+    SELECT DISTINCT 'fact_fixture_player_stats' AS fato, fixture_id FROM {{ ref('fact_fixture_player_stats') }}
+),
+
+-- Produto (fixture finalizada × 4 fatos) = o que DEVERIA existir.
+esperado AS (
+    SELECT f.fixture_id, f.competition, f.season, fato
+    FROM finalizadas f
+    CROSS JOIN UNNEST([
+        'fact_fixture_stats',
+        'fact_fixture_events',
+        'fact_fixture_lineups',
+        'fact_fixture_player_stats'
+    ]) AS fato
+)
+
+SELECT
+    e.competition,
+    e.season,
+    e.fato,
+    COUNT(*)                                                     AS fixtures_finalizadas,
+    COUNTIF(p.fixture_id IS NULL)                                AS sem_linha,
+    ROUND(100 * COUNTIF(p.fixture_id IS NULL) / COUNT(*), 1)     AS pct_sem_linha
+FROM esperado e
+LEFT JOIN presentes p
+    ON  p.fixture_id = e.fixture_id
+    AND p.fato       = e.fato
+GROUP BY e.competition, e.season, e.fato
+HAVING sem_linha > 0
+ORDER BY sem_linha DESC

--- a/docs/MOTOR_SCORE_CONFIABILIDADE.md
+++ b/docs/MOTOR_SCORE_CONFIABILIDADE.md
@@ -309,18 +309,20 @@ Preencher a coluna **Status/Notas** in-place quando cada uma for implementada �
 
 **Penalidade específica:** `linha_extrema` (−10, quando L ≤ 0,5 ou L ≥ 4,5 — odd vira juice/longshot).
 
-#### 12.2.1 — Baseline de calibração por liga (medido 2026-08-03)
+#### 12.2.1 — Baseline de calibração por liga (medido 2026-08-03; Bundesliga em 2026-08-05)
 
-Cinco das treze regras acima usam **thresholds absolutos** (`35%`, `40%`, `35%`, e os offsets
-`+0,5` / `±0,3`) calibrados no **Brasileirão**. Num ambiente de gols deslocado, todas as premissas
-de um mesmo lado disparam juntas e inflam o `PTS_PREMISSAS` de um outcome que **o mercado já
-precifica** — dupla contagem, não edge. As premissas que já são relativas à liga (`ritmo_alto`, via
-`league_pace_median`) não sofrem disso.
+Regras com **thresholds absolutos** calibrados no **Brasileirão** existem em três mercados, não só
+no Gols (ver o escopo corrigido no item aberto, abaixo). Num ambiente de gols deslocado, todas as
+premissas de um mesmo lado disparam juntas e inflam o `PTS_PREMISSAS` de um outcome que **o mercado
+já precifica** — dupla contagem, não edge. As premissas que já são relativas à liga (`ritmo_alto`,
+via `league_pace_median`) não sofrem disso.
 
-Ambiente real, 760 jogos FT por liga-temporada (`/fixtures`, seasons 2024 e 2025):
+Ambiente real por liga-temporada (`/fixtures`, seasons 2024 e 2025 — 760 jogos FT nas ligas de 20
+times, 616 na Bundesliga, que tem 18):
 
 | liga | gols/jogo | Δ vs baseline | Over 2.5 | Δ | clean sheet | viés esperado |
 |---|---|---|---|---|---|---|
+| **Bundesliga (78)** | **3,18** | **+0,70** | **61,9%** | **+15,2pp** | 40,4% | superpontua **Over** — o maior desvio do portfólio |
 | Premier League (39) | 2,84 | **+0,36** | 55,8% | **+9,1pp** | 43,3% | superpontua **Over** |
 | La Liga (140) | 2,66 | +0,17 | 49,3% | +2,6pp | 44,6% | leve, pró-Over |
 | Serie A ITA (135) | 2,49 | +0,01 | 47,0% | +0,3pp | 51,6% | — (na baseline) |
@@ -331,10 +333,31 @@ Observação contraintuitiva registrada no rollout da Serie A ITA: a fama de "li
 é folclore do catenaccio — a Serie A moderna é a liga **mais próxima da baseline** de todo o
 portfólio. O desvio real está em Premier League e Série B, ambas em produção.
 
-**Item aberto (Fase 5):** tornar os cinco thresholds relativos à mediana da própria liga-temporada,
-replicando o padrão do `league_pace_median` que já existe em `int_futebol_premissas_ou`. Isso
-autocalibra qualquer liga futura e dispensa tabela de constantes por liga. Validar com backtest
-RPS/CLV antes de aplicar — muda o comportamento de ligas já em produção.
+O rollout da Bundesliga (2026-08-05) é o caso **oposto**: ali o briefing pedia "liga de muitos gols,
+ajustar O/U pra cima" e a medição **confirmou e subestimou** — +0,70 gol/jogo e +15,2pp de Over 2.5,
+quase o dobro do desvio da Premier League. Com clean sheet de **23,1% por time-jogo** (o menor do
+portfólio, contra 29,9% do Brasileirão) e ~1,59 gol por time-jogo, as premissas do lado "muitos
+gols" disparam quase sempre nessa liga: `ambos_vazam` (Over), `ambos_marcam` + `ataque_dos_dois` +
+`defesas_vazaveis` (BTTS-Sim) e `adversario_fragil_fora` (AH). A liga entrou em produção **sem gate**,
+como as demais europeias — a decisão foi registrar o viés, não segurar a liga.
+
+**Item aberto (Fase 5):** tornar os thresholds absolutos relativos à mediana da própria
+liga-temporada, replicando o padrão do `league_pace_median` que já existe em
+`int_futebol_premissas_ou`. Isso autocalibra qualquer liga futura e dispensa tabela de constantes
+por liga. Validar com backtest RPS/CLV antes de aplicar — muda o comportamento de ligas já em
+produção.
+
+**Escopo real do item (corrigido em 2026-08-05):** não são cinco regras do Gols O/U — são ≈11, em
+**três mercados**. A varredura feita no rollout da Bundesliga encontrou o mesmo padrão em:
+
+| mercado | regras com threshold absoluto |
+|---|---|
+| Gols O/U (5) | `ambos_vazam` (cs < 35%), `clean_sheets_altos` (cs ≥ 40%), `ataques_fracos` (fts ≥ 35%), + os offsets `+0,5` / `±0,3` de `gf_comb`/`ga_comb`/`xg_comb` contra a linha |
+| BTTS (8) | `ambos_marcam` (fts < 30%), `ataque_dos_dois` (gf ≥ 1,2), `defesas_vazaveis` (cs < 35%), `ataque_trava` (fts ≥ 35%) |
+| Handicap (4) | `tende_golear` (gf ≥ 2,0 **e** ga ≤ 1,0), `adversario_fragil_fora` (ga ≥ 1,6), `defesa_fora_solida` (ga ≤ 1,1) |
+
+Todas se movem junto com o ambiente de gols da liga, e nenhuma delas é relativa hoje. Dimensionar a
+Fase 5 pelos cinco thresholds do O/U subestima o trabalho por um fator de ~2.
 
 ### 12.3 — Handicap asiático, meia-linha (`market_id` 4)
 `H` = handicap na ótica do mandante. **Valor quando** a supremacia real difere do que a linha pede (favorito dando handicap; azarão recebendo).

--- a/docs/MOTOR_SCORE_CONFIABILIDADE.md
+++ b/docs/MOTOR_SCORE_CONFIABILIDADE.md
@@ -346,6 +346,25 @@ gols" disparam quase sempre nessa liga: `ambos_vazam` (Over), `ambos_marcam` + `
 `defesas_vazaveis` (BTTS-Sim) e `adversario_fragil_fora` (AH). A liga entrou em produção **sem gate**,
 como as demais europeias — a decisão foi registrar o viés, não segurar a liga.
 
+**A dupla contagem, medida (2026-08-05).** Deixou de ser argumento: `int_futebol_premissas_ou`,
+linha 2.5, seasons 2024+2025, por liga —
+
+| liga | gols/jogo | `ataque_combinado` | `defesas_vazaveis` | **PTS Over** | **PTS Under** |
+|---|---|---|---|---|---|
+| bundesliga | 3,18 | 53,9% | 77,6% | **29,3** | 6,2 |
+| premier_league | 2,84 | 40,4% | 61,6% | 24,7 | 7,9 |
+| la_liga | 2,66 | 29,5% | 51,6% | 20,6 | 11,1 |
+| serie_a_ita | 2,49 | 25,3% | 47,8% | 17,7 | 13,3 |
+| **brasileirao** *(baseline)* | 2,48 | 17,9% | 42,1% | **15,2** | 14,2 |
+| serie_b | 2,20 | 8,8% | 24,9% | 11,9 | 17,9 |
+
+**A ordem de `PTS Over` é idêntica à ordem de gols/jogo, liga a liga** — e a de `PTS Under` é o
+espelho invertido. O `PTS_PREMISSAS` do lado Over não está medindo confiança naquela aposta; está
+medindo o ambiente de gols da liga, que é exatamente o que o mercado já precificou na odd. Uma liga
+extrema entra com ~2× o crédito de premissa da liga onde os limiares foram calibrados (29,3 vs 15,2),
+sem nenhum edge adicional. Como a faixa Alta começa em 60, o efeito prático é que um Over de
+Bundesliga alcança Alta com menos edge real que um Over de Brasileirão equivalente.
+
 **Item aberto (Fase 5):** tornar os thresholds absolutos relativos à mediana da própria
 liga-temporada, replicando o padrão do `league_pace_median` que já existe em
 `int_futebol_premissas_ou`. Isso autocalibra qualquer liga futura e dispensa tabela de constantes

--- a/docs/MOTOR_SCORE_CONFIABILIDADE.md
+++ b/docs/MOTOR_SCORE_CONFIABILIDADE.md
@@ -320,7 +320,12 @@ via `league_pace_median`) não sofrem disso.
 Ambiente real por liga-temporada (`/fixtures`, seasons 2024 e 2025 — 760 jogos FT nas ligas de 20
 times, 616 na Bundesliga, que tem 18):
 
-| liga | gols/jogo | Δ vs baseline | Over 2.5 | Δ | clean sheet | viés esperado |
+⚠️ A coluna `clean sheet` desta tabela é **por jogo** (% de jogos em que ao menos um dos times
+não sofreu gol) — NÃO é a mesma métrica dos thresholds das premissas, que são **por time-jogo**
+(`clean_sheet_total / played_total`). As duas convivem no mesmo texto e não são comparáveis entre
+si: Brasileirão dá 49,7% por jogo e 29,9% por time-jogo. Ao conferir um threshold, use a de time-jogo.
+
+| liga | gols/jogo | Δ vs baseline | Over 2.5 | Δ | clean sheet (por jogo) | viés esperado |
 |---|---|---|---|---|---|---|
 | **Bundesliga (78)** | **3,18** | **+0,70** | **61,9%** | **+15,2pp** | 40,4% | superpontua **Over** — o maior desvio do portfólio |
 | Premier League (39) | 2,84 | **+0,36** | 55,8% | **+9,1pp** | 43,3% | superpontua **Over** |


### PR DESCRIPTION
Rollout da **Bundesliga (id 78)** no lado dbt, mais dois achados que valem além desta liga.

Spec: #14 · Par na ingestão: tech-lamjav/data-engineering#20 · ClickUp: https://app.clickup.com/t/wdx6zengh1

> ⚠️ **Já está em produção.** Imagem do `dbt-futebol` reconstruída e job re-apontado em 2026-08-05.
> Este PR alinha o remoto com o que roda hoje.

## O rollout

Slug `bundesliga` nos **6** marts que traduzem `competition_id` e nas listas de `accepted_values`.
`sem_rodizio` recebe a liga na allowlist — é a 1ª com **18 times** (as outras 5 têm 20), mas
`n_teams` vem do standings por (liga, season), então `rank >= n_teams - 3` se ajusta sozinho;
ressalva registrada em comentário: a faixa de 4 posições sobre-inclui o 15º numa liga com 3 vagas
em risco.

## Achado 1 — o seam declarado não existia

Dos 6 marts com `CASE` de slug, **`fact_fixtures` — a tabela mãe — era o único sem
`accepted_values`** na coluna `competition`. A garantia que todos os rollouts anteriores assumiram
("esqueci um `CASE` → teste vermelho") era falsa justamente no modelo do qual o grafo inteiro
depende, incluindo o teste de cobertura novo, que agrupa por `fact_fixtures.competition`. Um `CASE`
esquecido ali passaria batido e contaminaria os 5 fatos per-fixture, que herdam `competition` por
JOIN. Agora são 6 `CASE` + 6 `accepted_values`, e a descrição da coluna explica por que os 5
per-fixture **não** precisam do seu próprio — p/ a próxima liga não "consertar" isso com 5 testes
redundantes.

## Achado 2 — a dupla contagem, medida

O §12.2.1 argumentava que thresholds absolutos inflam o `PTS_PREMISSAS` de um lado em liga com
ambiente de gols deslocado. Agora está medido (`int_futebol_premissas_ou`, linha 2.5, 2024+2025):

| liga | gols/jogo | `defesas_vazaveis` | **PTS Over** | **PTS Under** |
|---|---|---|---|---|
| bundesliga | 3,18 | 77,6% | **29,3** | 6,2 |
| premier_league | 2,84 | 61,6% | 24,7 | 7,9 |
| la_liga | 2,66 | 51,6% | 20,6 | 11,1 |
| serie_a_ita | 2,49 | 47,8% | 17,7 | 13,3 |
| **brasileirao** *(baseline)* | 2,48 | 42,1% | **15,2** | 14,2 |
| serie_b | 2,20 | 24,9% | 11,9 | 17,9 |

**A ordem de `PTS Over` é idêntica à ordem de gols/jogo, liga a liga** — mesma sequência exata, não
correlação aproximada; e o Under é o espelho invertido. Ou seja, esse componente do score não mede
confiança na aposta: mede o ambiente de gols da liga, que já está na odd. A Bundesliga entra com ~2×
o crédito do Brasileirão sem edge adicional, e como a faixa Alta começa em 60, alcança Alta com
menos edge real.

O escopo do item da Fase 5 também estava errado: não são 5 regras do O/U, são **≈11 em 3 mercados**
(O/U, BTTS e AH). Dimensionar pelos 5 subestima por ~2×. A Fase 5 em si continua **fora de escopo**
— muda 4 ligas em produção e exige backtest RPS/CLV. A liga entrou **sem gate**, como as outras
europeias.

## Teste de cobertura per-fixture (novo)

Singular test (`severity='warn'`) p/ fixture **finalizada no spine sem nenhuma linha no fato**. Os
`assert_*_reconciled` cobrem a direção oposta (stg sem spine) e nenhum deles pegaria o truncamento
por quota que cortou `fact_fixture_player_stats` da Serie A em 123 de 380 jogos com o workflow em
`SUCCEEDED`. Baseline de 24 linhas registrado em #16 — todo ruído é estrutural (mata-mata e
qualificatórias) e o teste reencontrou sozinho o furo isolado já documentado da Serie A.

⚠️ Ele só roda quando alguém executa `dbt test`: **nenhum workflow roda testes** (só `dbt run`).
Endereçado em tech-lamjav/data-engineering#19.

## Verificação

`dbt build` completo: **`PASS=297 WARN=11 ERROR=0`**. Cobertura per-fixture **idêntica ao baseline**
de 24 linhas, **nenhuma da Bundesliga**. Zero órfão atribuível à liga (os 14 de standings são
brasileirao 2026 e libertadores 2024).

Fecha #16, #17, #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhFB5gkPMXaswujM5CaN94
