### PR TITLE
docs(futebol): ADR 0003/0004 — o dado faltante diagnostica, e o grão do de-vig é a janela

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -50,8 +50,27 @@ External confirmation points: the API's prediction model agrees, or the sharp li
 moved toward our side.
 
 **Degradação graciosa**:
-Missing data means the premissa simply does not fire — never an error or NULL. The
-score gets honestly lower.
+Missing data means the premissa simply does not fire — never an error or NULL. The rule
+holds when the absence is **in the world** ("there is no desfalque"): the score gets
+honestly lower. It does not hold when the absence is **in the collection** ("we never
+asked", or "we asked and kept no record") — reading that as a negative is a fabricated
+claim, not a degraded one. See ADR 0003.
+
+**Premissas sem dado**:
+The count, per rated line, of premissas whose declared input was unavailable. It is
+diagnosis, never penalty: it does not move the score. It is what makes a low score
+readable as *little evidence* instead of *evidence against*.
+
+**Insumo declarado**:
+The inputs a premissa depends on, declared per premissa in one place — the same idiom as
+the conjunto de saídas. A premissa whose input is undeclared cannot be counted as missing,
+so the declaration is what makes **premissas sem dado** honest rather than optimistic.
+
+**Dado não perguntado**:
+An input absent because the source was never consulted — as opposed to consulted and
+answered "nothing". The two are indistinguishable downstream unless the asking itself is
+recorded, and the Motor then reports the second while in fact holding the first.
+_Avoid_: dado faltante (silent about which of the two it is)
 
 ### Odds and value
 
@@ -97,8 +116,19 @@ side is corroboration.
 _Avoid_: soft book (that is the opposite concept)
 
 **Janela**:
-The odds collection window relative to kickoff: t24h, t1h, t15m. The latest available
-acts as the fechamento (closing).
+The odds collection window relative to kickoff: daily (anything beyond 24h, one capture
+per day), t24h, t1h, t15m. t15m is the fechamento (closing).
+
+**Janela de avaliação**:
+The janela whose prices a given rating was computed from. It is part of the identity of a
+rating, not a property resolved away: the same line is rated once per janela it has, and
+no janela is discarded in favour of a fresher one. See ADR 0004.
+
+**Janela de detecção**:
+The earliest janela in which a line passed the gate. Stamped on the board so an
+opportunity is published once and followed from there, instead of re-announced whenever a
+fresher price arrives.
+_Avoid_: janela usada (ambiguous between the two above)
 
 **Consenso**:
 Fallback fair probability from the median of all bookmakers, used when Pinnacle does
@@ -130,8 +160,17 @@ signal.
 
 **Desfalque**:
 A player missing a fixture. Only a desfalque of a titular importante fires premissas;
-"Questionable" (dúvida) is displayed but never fires.
+"Questionable" (dúvida) is displayed but never fires. The source publishes the list
+roughly two to three days out and not before — so on the earlier part of the board the
+premissa has **no input**, which is not the same as a negative one.
 _Avoid_: injury (a desfalque may be suspension or other absence)
+
+**Escalação confirmada**:
+The starting eleven as announced before kickoff, roughly forty minutes out — distinct
+from the escalação real recorded after the match. It is the only pre-kickoff evidence of
+who actually plays, and it arrives too late to inform any janela but t15m. Its value is
+therefore corroboration and measurement, not the desfalque premissa itself.
+_Avoid_: escalação provável (the source does not publish one)
 
 **Titular importante**:
 A regular starter by minutes played and start share — the importance proxy that makes
@@ -142,8 +181,10 @@ Squad rotation — resting starters when a bigger match looms. "Sem rodízio" me
 game matters and no midweek decision competes.
 
 **xG (expected goals)**:
-Shot-quality-based goal expectation; the strongest form signal. Only rich for the
-Brasileirão — elsewhere xG premissas degrade gracefully.
+Shot-quality-based goal expectation; the strongest form signal. Rich in the Brasileirão
+**and in the top-5 European leagues** (~100% of finished fixtures); thin in the cups and
+in Série B, with Copa do Brasil the extreme at ~10%. Where it is thin the xG premissas
+have no input at all — that is **premissas sem dado**, not a weak reading.
 
 **Forma**:
 Recent results run (wins in last 5). Deliberately low-weight: it mostly duplicates

--- a/dbt_futebol/docs/adr/0003-dado-faltante-diagnostica-nao-elimina.md
+++ b/dbt_futebol/docs/adr/0003-dado-faltante-diagnostica-nao-elimina.md
@@ -1,0 +1,86 @@
+---
+status: accepted
+---
+
+# Dado faltante diagnostica, não elimina
+
+A ADR 0002 decidiu que conjunto de saídas incompleto **não emite valor nenhum** — fail-closed.
+A pergunta natural em seguida é por que a mesma régua não vale para premissa sem insumo, que
+é o mesmo formato de problema. Decidimos que **não vale**: premissa sem insumo continua não
+acendendo, o score não muda, e o que entra é um contador — `premissas_sem_dado` — mais o aviso
+correspondente no board.
+
+A distinção que sustenta as duas decisões opostas é entre **número fabricado** e **número
+incompleto**. O de-vig sobre uma saída só devolvia `prob = 1,0` onde a verdade era 0,3, e um
+edge de +14.900%: o número estava *errado*, e um número errado carimbado como benchmark sharp
+é pior que número nenhum. Premissa que não acende por falta de insumo devolve um score de 45
+onde poderia ser 53: o número está *incompleto*, e incompleto é auditável — desde que alguém
+conte.
+
+O tamanho de aplicar o fail-closed aqui decide sozinho. Dos **8.355 fixtures** que passam pelo
+Motor, **28** têm lista de desfalque coletada antes do apito — **0,34%**. Barrar a linha cuja
+premissa não pôde ser avaliada apagaria o board inteiro, e ele só voltaria conforme a base
+pré-jogo acumulasse, a ~5–10 fixtures por dia, forward-only. Uma regra correta que zera o
+produto por dois meses não é uma regra que sobrevive; é uma regra que alguém desliga.
+
+## O que muda mesmo com o score intacto
+
+Três insumos chegam ao CTE de métricas já COALESCEados para zero — `s_missing`,
+`n_wins_last5`, `h2h_total`. Enquanto isso for verdade, `IS NULL` não detecta cegueira nenhuma
+e o contador nasceria zerado. **Remover esses COALESCE é o trabalho**; o contador é a
+consequência.
+
+Dois dos três só suprimem: zero nunca satisfaz `>= 3` nem `>= 1`, então a premissa já não
+acendia e continua não acendendo. O terceiro fabrica: `desfalque_adversario` é
+`o_missing >= 1 AND s_missing = 0`, e o zero forçado do nosso lado é **condição para a premissa
+acender**. Cegueira habilitando premissa é o caso que a ADR 0002 chamaria de número fabricado,
+e é o único aqui. Atinge no máximo **7 linhas em 25.065** — o que torna "score intacto" uma
+afirmação verificável, não uma esperança.
+
+## A dependência que não é opcional
+
+O `s_missing` só pode virar NULL se existir de onde tirar o NULL, e hoje não existe. O
+extractor de injuries, ao receber resposta vazia, não grava arquivo — com a justificativa
+escrita no código de que "gravar vazio travaria o skip-if-exists e viraria linha NULL". O
+efeito é que **"perguntamos e a fonte não tinha" e "nunca perguntamos" são o mesmo estado no
+armazenamento**, e nenhum modelo a jusante consegue distinguir os dois por mais correto que
+seja.
+
+Logo esta decisão depende de a coleta passar a registrar o vazio. A mesma mudança paga a si
+mesma: sem arquivo, o skip-if-exists não trava e o poll horário repergunta o vazio até o
+kickoff — ~648 chamadas por dia, 8,6% da cota diária, para reconfirmar de hora em hora que a
+fonte ainda não publicou.
+
+## Por que declarar o insumo, e não contar NULL na mão
+
+O contador escrito à mão em cada modelo de premissa fica correto no dia em que é escrito e
+apodrece na premissa seguinte: quem acrescentar uma premissa nova precisa lembrar de somá-la,
+e esquecer é silencioso — o contador segue verde, só que menor do que a verdade. É exatamente
+o modo de falha que a ADR 0002 já tratou no mercado órfão.
+
+Então o insumo de cada premissa é **declarado num macro que é a fonte única**, e uma guarda
+compara o declarado com as premissas que os modelos realmente produzem. Premissa presente no
+modelo e ausente do mapa deixa a guarda vermelha, em vez de nascer muda.
+
+## Alternativas consideradas
+
+- **Fail-closed, igual à 0002.** Rejeitada pelo tamanho: 99,66% do board hoje. A consistência
+  seria real, e o produto pararia — e a régua voltaria a ser afrouxada sob pressão, o que é
+  pior que nunca tê-la apertado.
+- **Score normalizado sobre o que dava para saber** (pontos ganhos ÷ pontos disponíveis).
+  Rejeitada por inverter o incentivo: infla a nota justamente onde se sabe menos, que é o
+  contrário do que o contador existe para comunicar. E mexeria na escala das faixas (Alta ≥ 60,
+  Média 40–59), forçando recalibrar tudo por causa de um diagnóstico.
+- **Só consertar o `s_missing`**, que é o que o ticket pedia. Rejeitada porque o contador
+  continuaria mentindo, só que sobre outra premissa: `superioridade_xg` (+8) não tem insumo em
+  90,5% da Copa do Brasil e 50,3% da Série B — cegueira maior em volume que a de desfalque.
+- **Heurística de janela** ("é NULL se o jogo estava a mais de 72h da coleta"). Rejeitada por
+  ser o mesmo conhecimento fabricado com outro nome, derivado de 28 fixtures observados, e por
+  não economizar chamada nenhuma.
+
+## Consequência conhecida e aceita
+
+Ampliar o horizonte do board para além de 24h aumenta `premissas_sem_dado` por construção: a
+lista de desfalque não existe a 7 dias do apito, e a escalação confirmada só aparece a ~40
+minutos. O board mais cedo é, necessariamente, o board que sabe menos — e a decisão aqui é que
+ele **diga isso**, em vez de exibir um score mais baixo que se parece com evidência contrária.

--- a/dbt_futebol/docs/adr/0004-o-grao-do-devig-e-a-janela.md
+++ b/dbt_futebol/docs/adr/0004-o-grao-do-devig-e-a-janela.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+---
+
+# O grão do de-vig é a janela, e o multiplicador não é ganho de amostra
+
+O `int_futebol_odds_devig` resolvia cada linha para **uma** janela — a mais recente disponível,
+via `QUALIFY window_priority = MAX(...)` — e descartava as outras duas. Decidimos que a janela
+passa a fazer parte da chave: o grão vira `(fixture, market, outcome, line, janela)`, e quem
+escolhe qual janela vale é o consumidor, não o de-vig.
+
+O board continua com **uma linha por linha**, avaliada na janela corrente, e ganha
+`janela_deteccao` — a janela mais cedo em que a linha passou no gate. Oportunidade que perdeu
+edge sai do board: preço que o usuário não consegue mais pegar não é oportunidade, é ruído com
+carimbo de oportunidade. O histórico do que foi anunciado já tem lugar próprio no snapshot
+`fact_value_opportunities_hist`.
+
+## O que esta decisão NÃO compra
+
+O ticket de origem justificava a mudança por multiplicar a base de medição: 21.407 linhas
+únicas contra 60.818 combinações de linha com janela, um multiplicador de 2,84, e daí "quase
+triplica a base, e a amostra é o gargalo de toda a investigação".
+
+**O multiplicador é real e a conclusão é falsa.** No recorte liquidado são 19.649 linhas e
+56.440 pares linha×janela — sobre **179 jogos, antes e depois**. As três janelas de uma linha
+são três preços do mesmo palpite, liquidados pelo mesmo placar. Nos Testes 3 e 4 isso é apostar
+três vezes na mesma partida: o ROI esperado não se move e o intervalo de confiança encolhe por
+√3 sem que tenha entrado informação nenhuma.
+
+Esse é precisamente o mecanismo que a ADR 0001 foi escrita para impedir — "amostra curta
+fabrica sinal" — e ela já havia nomeado o gargalo real: *"o gargalo passa a ser a task C2
+(ampliar a coleta de odds)"*, que é coletar mais **jogos**, não mais fotos dos mesmos jogos.
+Registrar isto aqui é metade do propósito desta ADR: sem o registro, o 2,84× volta pela porta
+dos pesos na próxima vez que alguém precisar de um n maior.
+
+Portanto: **os Testes 2, 3 e 4 seguem com uma observação por linha**, com a janela fixada antes
+de olhar resultado.
+
+## O que ela compra
+
+Uma pergunta que hoje não dá nem para formular: **o edge de t24h prevê melhor ou pior que o de
+t15m?** É a pergunta de CLV, e é ela que decide se alertar cedo é virtude ou armadilha. Há
+6.885 linhas com as duas janelas para respondê-la.
+
+O tamanho do que está em jogo: recomputando o gate de valor por janela nos mercados 1/4/5,
+passam **931** linhas em t15m, **1.350** em alguma janela, e **368 passam em t24h e já não
+passam em t15m**. Essas 368 são exatamente as linhas em que o mercado se moveu **contra** nós
+até o fechamento — CLV negativo, que a literatura trata como o sinal mais confiável de que a
+aposta era ruim. Podem ser a maior descoberta da fila ou a maior armadilha dela, e hoje não
+temos como saber qual.
+
+## Sobre "o alerta pode sair mais cedo"
+
+Não é o que esta mudança faz, e vale registrar porque o ticket afirmava o contrário. Quando um
+jogo está a 24h do apito, a única janela que existe para ele é t24h; o `QUALIFY` escolhe t24h
+por falta de alternativa, o mart reconstrói a cada ~15 minutos e o board **já publica ali**. O
+que se perdia era o registro depois do jogo, não o alerta.
+
+Quem faz o alerta sair mais cedo é ampliar o horizonte de coleta de odds, que hoje para em 24h
+por causa da banda `(1320, 1440)` — escolha nossa, não limite da fonte: a API entrega 12–13
+casas, Pinnacle inclusa, a 147h do apito.
+
+## Alternativas consideradas
+
+- **Colunas por janela na mesma linha** (`edge_t24h`, `edge_t1h`, `edge_t15m`, …). Rejeitada:
+  congela o conjunto de janelas no schema. Acrescentar uma janela passa a exigir cinco colunas
+  novas em cada modelo a jusante — e a próxima janela já está decidida.
+- **Trocar "mais recente" por "mais cedo que passou"** no próprio `QUALIFY`. Rejeitada por ser
+  circular: saber se a janela passou depende de `best_odd`, `n_casas` e do de-vig, que só
+  existem *depois* de escolher a janela. Avaliar as três é pré-requisito, não alternativa.
+- **Board também por janela**, deixando o agrupamento para o front. Rejeitada: quebraria
+  `opportunity_key` do snapshot, triplicaria o que o sync materializa no Postgres, e empurraria
+  para o front uma decisão de produto — qual das três mostrar.
+- **Board segurando a oportunidade morta até o apito**, com odd e edge congelados na detecção.
+  Rejeitada: exibe um preço que já não existe. A leitura literal de "publicar uma vez e
+  acompanhar dali" custaria mostrar 2,35 onde a casa hoje paga 2,05.

--- a/dbt_futebol/docs/adr/0004-o-grao-do-devig-e-a-janela.md
+++ b/dbt_futebol/docs/adr/0004-o-grao-do-devig-e-a-janela.md
@@ -49,6 +49,25 @@ até o fechamento — CLV negativo, que a literatura trata como o sinal mais con
 aposta era ruim. Podem ser a maior descoberta da fila ou a maior armadilha dela, e hoje não
 temos como saber qual.
 
+### Emenda de 2026-08-06: esses três números têm prazo de validade
+
+Vieram de um gate que inclui **edge positivo**, que é o gate de hoje. A subtask **A2 da task [A]
+tira o edge do gate**, e a **A1** remove as premissas que leem preço. Depois das duas, a nota
+passa a ser função pura do contexto do jogo e **não se move entre janelas** — então uma linha
+deixa de sair do board por perder evidência e passa a sair por **preço**: porta de odd, liquidez,
+completude do conjunto.
+
+As 368 continuam sendo uma pergunta de CLV legítima, mas passam a ser **outro conjunto**.
+**Remedir, não reaproveitar** — e quem for medir depois da A1+A2 e reusar este número vai estar
+comparando duas populações diferentes com o mesmo rótulo.
+
+Nada disso enfraquece a decisão desta ADR; ao contrário, deixa o motivo mais limpo. Se a nota é
+constante entre janelas, então **tudo que varia por janela é preço e veredito** — que é
+exatamente o que o grão por janela preserva e o que a pergunta de CLV interroga. O que muda é a
+frase "perder evidência", que era imprecisa mesmo antes: já hoje é o preço que move o edge.
+
+Achado da sessão de grelha da A6/A7 (ADRs 0005 e 0006), que mediu o funil do outro lado.
+
 ## Sobre "o alerta pode sair mais cedo"
 
 Não é o que esta mudança faz, e vale registrar porque o ticket afirmava o contrário. Quando um


### PR DESCRIPTION
Saída da grelha (`/grill-with-docs`) da task **[C] Coleta** (ClickUp `wdx6zev64z`). **Só documentação** — nenhum modelo, macro ou config de produção foi tocado.

Entra agora porque as duas specs já abertas — `analytics-engineering#26` e `tech-lamjav/data-engineering#23`, ambas `ready-for-agent` — citam estas ADRs como fonte da decisão. Enquanto elas viverem só nesta branch, uma sessão de `/implement` que nasça de um worktree a partir do `master` lê a referência, não acha o arquivo e improvisa.

## ADR 0003 — Dado faltante diagnostica, não elimina

A ADR 0002 decidiu fail-closed para conjunto de saídas incompleto. A pergunta seguinte era se a mesma régua vale para premissa sem insumo. **Não vale**: a premissa continua não acendendo, o score não muda, e o que entra é um contador (`premissas_sem_dado`) mais o aviso no board.

A distinção que sustenta as duas decisões opostas é **número fabricado** contra **número incompleto**. O de-vig sobre uma saída devolvia `prob = 1,0` onde a verdade era 0,3 — errado, e errado carimbado como benchmark sharp é pior que nada. Premissa sem insumo devolve 45 onde poderia ser 53 — incompleto, e incompleto é auditável desde que alguém conte.

O tamanho decide sozinho: dos **8.355 fixtures** que passam pelo Motor, **28** têm lista de desfalque coletada antes do apito — **0,34%**. Fail-closed aqui apagaria o board inteiro por dois meses.

O trabalho real é **remover três `COALESCE` para zero** (`s_missing`, `n_wins_last5`, `h2h_total`); o contador é consequência. Dois só suprimem; o terceiro fabrica — `desfalque_adversario` é `o_missing >= 1 AND s_missing = 0`, e o zero forçado do nosso lado é *condição para acender*.

## ADR 0004 — O grão do de-vig é a janela

`int_futebol_odds_devig` resolvia cada linha para **uma** janela e descartava as outras duas. A janela passa a fazer parte da chave: `(fixture, market, outcome, line, janela)`, e quem escolhe qual vale é o consumidor. O board segue com **uma linha por linha**, na janela corrente, e ganha `janela_deteccao`.

A ADR também registra o que a mudança **não** compra: o multiplicador de 2,84 do ticket de origem não é ganho de amostra.

**Emenda de 2026-08-06** (commit `37cd35c`): os números 931 / 1.350 / 368 assumem `edge > 0` no gate, e a **A2 da task [A] remove o edge do gate**. Depois da A1+A2 as 368 viram outro conjunto — **remedir, não reaproveitar**.

## CONTEXT.md

Verbetes novos e afiados do lado do Motor, na linguagem das duas ADRs.

## Ordem de merge

Mergear **antes** do PR das ADRs 0005/0006 (branch `worktree-grill-taskA-a6-a7`): a 0006 cita a 0004. As duas branches tocam `dbt_futebol/CONTEXT.md` em hunks disjuntas — testei com `git merge-tree` e o merge é limpo, sem conflito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGVfqgzeeLjbEBJ4Z6ZxpS
