### PR TITLE
docs(futebol): ADR 0005/0006 — a nota é absoluta e as portas classificam, não apagam

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -15,7 +15,20 @@ _Avoid_: model (reserved for statistical models)
 
 **Score de Confiabilidade**:
 The 0–100 rating of how trustworthy a value opportunity is: value points + premissa
-points + corroboration points, minus penalties, clamped.
+points + corroboration points, minus penalties, clamped. It is an **absolute** measure —
+how much evidence fired — and never a rank within its peer group. So a régua on it means
+"this much evidence", not "the best of this mercado"; markets legitimately publish at
+different rates, and that is a consequence, not a defect.
+_Avoid_: reading a score as a percentile or a quota
+
+**Teto alcançável**:
+The denominator the pontos de premissa are normalised against, per (mercado, lado): the
+observed p95, measured once over a **declared window** and **frozen**. Its job is to make
+100 mean the same thing on every lado — the top of the scale anchored at a common
+quantile. It is deliberately not the sum of the weights, which never occurs, and not
+recomputed at runtime: a denominator that moves makes the régua mean a different thing
+each day and kills every historical comparison.
+_Avoid_: teto (bare — ambiguous with the sum of the pesos)
 
 **Premissa**:
 A boolean context signal computed from the data, carrying a point weight. Fired
@@ -28,12 +41,26 @@ means the bet is not an opportunity at all. Dupla Chance has its own gate.
 
 **Faixa**:
 The confidence band over the score: Alta (>= 60), Média (40–59), Baixa (< 40).
-Thresholds differ from the NBA context.
+Thresholds differ from the NBA context. The band cuts and the **régua** are the same
+numbers wearing two hats — set the régua at a band floor and the band below it stops
+existing, leaving a column that is constant and therefore lying. So the cuts are never
+chosen apart from the régua, and never on a scale that is about to change: they come out
+of one measurement, on the scale that will actually ship.
+_Avoid_: treating the régua as independent of the bands
 
 **Value opportunity**:
 A fixture x market x outcome that passed the gate with positive edge — the product's
 unit of output.
 _Avoid_: pick, tip
+
+**Candidato**:
+A (fixture, mercado, saída, linha, janela) that **had a price in that janela** — the
+universe the gates act on, and the denominator of every funnel reading. A line nobody
+priced is not a rejected candidato, it is absence of market: that belongs to coleta, not
+to the funil. A candidato whose conjunto de saídas came in incomplete still counts —
+it exists, it just lost its fair probability.
+_Avoid_: counting every premissa row (they are generated for canonical lines with no
+market at all, and are unbounded)
 
 **Evidência**:
 A fired premissa surfaced to the user as a "why" bullet, ordered by weight.

--- a/dbt_futebol/docs/adr/0005-a-nota-e-absoluta-e-o-denominador-e-congelado.md
+++ b/dbt_futebol/docs/adr/0005-a-nota-e-absoluta-e-o-denominador-e-congelado.md
@@ -1,0 +1,95 @@
+---
+status: accepted
+---
+
+# A nota é absoluta, e o denominador é medido e congelado
+
+Quando o preço sai da nota, o Score passa a ser só pontos de premissa — e esses pontos vivem
+em escalas diferentes em cada `(mercado, lado)`. Hoje o `pts_valor` (0 a 30, idêntico em todos
+os mercados) é o que disfarça isso; ele some junto com o edge.
+
+Medido nos onze pares de mercado e lado, com os tetos lidos do código, a nota média vai de
+**16** no Resultado fora a **59** no azarão do Handicap — **3,8 vezes**. E a causa não são os
+pesos, é a interação: somar cresce reto conforme se adiciona premissa, acender junto cresce
+muito mais devagar. O Resultado tem 7 premissas e enche 21% do próprio teto; o azarão do
+Handicap tem 3 e enche 59%. **Quanto mais premissa um mercado tem, mais baixa é a nota dele** —
+o mercado onde se investiu mais modelagem é o mais punido.
+
+Isso também responde, sem nenhuma teoria sobre qualidade de aposta, a reclamação que originou a
+investigação inteira: o Score "nunca passa de 40 ou 50" porque estava sendo dividido por uma
+soma que nunca ocorre.
+
+Decidimos duas coisas. A nota é uma medida **absoluta** — quanta evidência acendeu — e nunca
+uma posição relativa dentro do lado. E o denominador é o **p95 observado** por `(mercado, lado)`,
+medido uma vez sobre uma **janela declarada** e **congelado** em seed versionado. O serviço dele
+é fazer o 100 significar a mesma coisa em todos os lados: o topo da escala ancorado no mesmo
+quantil.
+
+## Por que absoluta, e não relativa
+
+A alternativa era a nota ser o percentil dentro do lado. Ela entrega o objetivo declarado com
+exatidão — uma régua única passaria a significar literalmente "os melhores X% daquele lado",
+igual nos cinco mercados. Foi rejeitada por três motivos.
+
+Ela garante volume de publicação independente de qualidade: um lado sem nenhuma linha boa
+publica os X% melhores do lixo, e o produto não tem como dizer isso. Ela contradiz a degradação
+graciosa, que é a regra que sustenta a honestidade do motor — "a nota fica honestamente mais
+baixa" não quer dizer nada quando a nota só fala do grupo de comparação. E ela envenena o funil
+da ADR 0006: a rejeição passaria a ser exatamente X% por construção, e a pergunta que o funil
+existe para responder — quanto rendeu a faixa que a gente descartou — fica sem sentido.
+
+O preço de escolher absoluta é ter que dizer em voz alta que **os mercados publicam em taxas
+diferentes, e isso é consequência, não defeito**.
+
+## Por que medido, e não declarado
+
+A alternativa barata era um teto **estrutural**, função dos pesos — por exemplo a soma dos três
+maiores. Sai do código, não precisa de janela, não envelhece, é auditável sem query. Ela erra
+nos dois sentidos ao mesmo tempo:
+
+| lado | p95 observado | soma dos 3 maiores pesos | |
+| --- | --- | --- | --- |
+| Gols Over | 44 | 30 | linhas reais passariam de 100 |
+| Handicap favorito | 26 | 30 | teto nunca alcançado |
+
+Para funcionar, o teto declarado teria que ser calibrado lado a lado — que é medir com outro
+nome, e sem a janela escrita em lugar nenhum. Perde-se a única vantagem que ele tinha.
+
+## O que esta decisão NÃO compra
+
+**Não iguala a média.** O rescale leva a amplitude de 3,8× para 2,1×, mas o topo não se move: o
+azarão do Handicap fica cravado em 59, vinte pontos acima do segundo colocado. Uma régua única
+continua sendo réguas diferentes — só que menos diferentes. Quem quiser igualdade de taxa de
+publicação está pedindo a alternativa relativa, que foi rejeitada acima.
+
+**Não cria resolução.** O azarão do Handicap e o "Não" do Ambos Marcam têm 3 premissas cada, o
+que dá **8 notas possíveis no total**, e uma delas é o próprio teto. Rescalar não separa quem já
+está empatado. Isso é granularidade de catálogo e pertence à Limpeza do catálogo, não ao
+denominador.
+
+**Não cria sinal.** Nenhuma aposta fica melhor. O ganho é de coerência da régua e de parar de
+punir o mercado que tem mais premissa.
+
+## O empate
+
+O empate do 1X2 não tem lado apostado, então nenhuma premissa dispara: teto de premissa zero,
+p95 zero, denominador zero. O zero é **explícito antes da divisão**, e não um `SAFE_DIVIDE` — o
+`SAFE_DIVIDE` devolveria `NULL`, a comparação com a régua também seria `NULL`, e a linha sairia
+sem passar e sem ser marcada. Descarte silencioso é exatamente o que a ADR 0006 proíbe.
+
+## O custo, e a guarda
+
+Número congelado envelhece em silêncio. Toda mexida no catálogo, toda liga nova e toda remoção
+como a das premissas de movimento de linha desloca a distribuição, e o denominador continua lá,
+certo no dia em que foi medido e cada vez menos certo depois. Por isso a decisão vem com uma
+guarda que recalcula o p95 vivo e fica vermelha quando ele se afasta do congelado além de uma
+distância declarada.
+
+⚠️ O ponto cego dessa guarda é conhecido e não é nosso: **teste em dbt hoje não alarma**. O job
+devolve sucesso com teste vermelho, e o resumo diário não lê o status das guardas. Até a
+subtask C4 fechar, esta guarda é uma linha de log num job que retorna sucesso — o que faz desta
+decisão uma dependência da [A] na [C] que não estava registrada em lugar nenhum.
+
+E o denominador é medido **depois** da A1, não antes. A A1 tira as premissas de movimento de
+linha do Gols: o teto vai de 56/52 para 50/46 e o p95 anda junto. Qualquer p95 medido antes
+disso descreve uma escala que não vai existir.

--- a/dbt_futebol/docs/adr/0006-as-portas-classificam-nao-apagam.md
+++ b/dbt_futebol/docs/adr/0006-as-portas-classificam-nao-apagam.md
@@ -1,0 +1,100 @@
+---
+status: accepted
+---
+
+# As portas classificam, não apagam
+
+O mart guarda **só o que passa**. A `fact_value_opportunities` tem nota mínima 40 e zero linhas
+abaixo, e o histórico é uma foto da mesma tabela, então herda o mesmo recorte. Tudo que é
+rejeitado desaparece sem registro.
+
+A consequência é que toda decisão de régua é tomada sobre um backtest que recalcula o passado
+inteiro a cada execução — e cuja janela é "tudo que liquidou até hoje", que cresce. A mesma
+query, três dias depois e sem mudar um byte, moveu a faixa 20–40 de **−3,6% para +9,7%**. Não é
+bug. É que a régua está sendo escolhida sobre um número com validade de dias.
+
+Decidimos que **toda linha candidata é gravada**, com a nota, os componentes e o veredito de
+cada porta, e que o board lê só as que passam. As portas deixam de ser um `WHERE` que apaga e
+passam a ser colunas que classificam.
+
+É o mesmo conserto que já resolveu uma dor uma camada abaixo — o snapshot da oportunidade que
+não guardava histórico — aplicado agora ao funil, que continua sem memória de tudo que
+descartou.
+
+## O que é um candidato
+
+Um `(fixture, mercado, saída, linha, janela)` que **teve preço naquela janela**.
+
+A fronteira importa porque os modelos de premissa não têm filtro nenhum: rodam sobre a
+`fact_fixtures` inteira e geram linhas canônicas mesmo para jogo que nunca foi precificado — um
+piso de 21 linhas por fixture, sem recorte de data, crescendo para sempre. Gravar essas como
+"rejeitadas" seria registrar ausência de mercado como decisão nossa.
+
+"Ninguém precificou este jogo" é **coleta**, e a subtask C6 está construindo a sentinela de
+vazio exatamente para isso. Com a fronteira no preço, a divisão fica limpa: **a [C] responde
+"houve preço?", a [A] responde "o preço que houve passou nas portas?"** — e a pergunta "por que
+essa linha não publicou" deixa de ter duas respostas em dois lugares.
+
+Linha cujo conjunto de saídas veio incompleto **continua candidata**: pela ADR 0002 ela existe
+no de-vig, só perdeu a probabilidade justa. É a maior rejeição do funil — 4.735 linhas, 49% do
+universo — e sob qualquer fronteira mais larga esse número se diluiria até deixar de significar
+alguma coisa.
+
+Jogo encerrado também continua no universo, e tem que continuar: é ele que responde a pergunta
+que justifica esta decisão inteira — quanto rendeu a faixa que a gente descartou.
+
+## Por que o grão é a janela
+
+O mart reconstrói a cada 15 minutos. A leitura literal de "gravar todas as linhas candidatas"
+daria 96 fotos por dia do universo inteiro.
+
+O grão por janela colapsa isso em **três registros por candidato**, sem perder nada, e o motivo
+é uma consequência da A1 que não estava escrita: **depois que o preço sai da nota, a nota para
+de depender de preço**. Os modelos de premissa leem `fact_odds_snapshot` em três lugares, e só
+um deles é valor de premissa — `linha_subindo`/`linha_descendo`, que a A1 remove. Os outros dois
+apenas decidem **quais linhas existem**. Sobrando só esses, a nota vira função pura do contexto
+do jogo e muda no ritmo dele, não no do mercado.
+
+O que se move a cada 15 minutos, portanto, não é a nota: é o veredito das portas. E veredito
+muda quando a janela muda.
+
+Esse é também o grão que a subtask C5 está introduzindo no de-vig. Adotá-lo aqui transforma uma
+colisão entre duas frentes em convergência.
+
+## Por que um booleano por porta, e não um motivo
+
+Uma linha reprova em várias portas ao mesmo tempo. Um campo único de motivo é vitória do
+primeiro da fila, e destrói a distinção que dá valor à tabela: quantas linhas cada porta remove
+**sozinha**, e quantas ela ainda remove **depois** das anteriores. É a diferença entre a leitura
+isolada e a marginal — e é literalmente a análise para a qual esta tabela existe.
+
+Um `motivo_primario` derivado por cima dos booleanos é conveniência de leitura, não a fonte.
+
+## O empate carrega motivo próprio
+
+O empate é **um terço do universo de candidatos do 1X2 por construção** — os modelos emitem três
+linhas por fixture — e está estruturalmente em zero, porque sem lado apostado nenhuma premissa
+dispara.
+
+Sob o motivo genérico, esse terço apareceria como "nota abaixo da régua", e a porta de nota
+pareceria mais severa no 1X2 do que é. O número que já circula é a queda de **235 para 23
+linhas, −90%**, e parte dela é o empate sendo zero, não a régua agindo. Com motivo próprio, a
+linha de base separa as duas coisas sozinha.
+
+## O custo, e as duas armadilhas
+
+O custo é volume, e ele fica sem número por decisão: agora que a fronteira está no preço e o
+grão colapsa os rebuilds, dá para **medir** a retenção em vez de chutar seis meses. A política
+sai declarada junto com o primeiro número real.
+
+A tabela não vai para o Supabase. Fica no BigQuery: o app não lê funil, o sync é tabela a tabela
+e aborta em divergência de esquema, e já derrubou o workflow por falta de memória.
+
+⚠️ A linha de base refeita passa a ler **desta tabela** em vez de reimplementar os cinco ramos à
+mão, e por isso precisa **fixar uma janela por candidato antes de contar**. Contando as três,
+todo número infla até 3× — é o mesmo erro do "2,87× quase triplica a amostra", que já foi
+derrubado uma vez do outro lado do projeto.
+
+⚠️ E uma tabela que ninguém lê é uma tabela que ninguém percebe estar errada. O aceite de que a
+soma das rejeições mais as publicadas fecha com o universo de candidatos é o que impede isso —
+mas ele é uma guarda, e guarda em dbt hoje não alarma (ver ADR 0005 e a subtask C4).

--- a/dbt_futebol/docs/adr/0006-as-portas-classificam-nao-apagam.md
+++ b/dbt_futebol/docs/adr/0006-as-portas-classificam-nao-apagam.md
@@ -61,6 +61,28 @@ muda quando a janela muda.
 Esse é também o grão que a subtask C5 está introduzindo no de-vig. Adotá-lo aqui transforma uma
 colisão entre duas frentes em convergência.
 
+## O board não herda esse grão
+
+São três camadas, e só as duas de baixo são por janela: **de-vig por janela** (ADR 0004),
+**funil por janela** (esta), e o **board continua com uma linha por linha**, avaliada na janela
+corrente e carregando `janela_deteccao` — a janela mais cedo em que a linha passou.
+
+A ADR 0004 rejeitou o board por janela com razão: quebraria a `opportunity_key` do snapshot,
+triplicaria o que o sync materializa no Postgres e empurraria para o front uma decisão de
+produto, qual das três mostrar. Nada disso muda aqui. **O board lê o funil e colapsa para a
+janela corrente**; quem guarda as três é o funil, que é onde a pergunta de CLV vive.
+
+⚠️ E fica registrada uma interação entre as duas frentes que nenhuma das duas ADRs tinha: a ADR
+0004 escreve *"oportunidade que perdeu edge sai do board"*, e dimensiona o que a mudança compra
+com **931 / 1.350 / 368 linhas** recomputando o gate de valor por janela. Esses números — e a
+própria frase — assumem o gate de hoje, em que `edge > 0` elimina. **A A2 tira o edge do gate.**
+
+Depois da A1 e da A2 a nota não se move entre janelas, então uma linha não sai mais do board por
+perder evidência: sai por preço — a porta de odd, a liquidez, a completude do conjunto. As 368
+linhas que "passam em t24h e já não passam em t15m" continuam existindo como pergunta de CLV,
+mas passam a ser um conjunto **diferente**, definido por outras portas. Quem for medir aquilo
+depois da [A] precisa remedir, não reaproveitar o número.
+
 ## Por que um booleano por porta, e não um motivo
 
 Uma linha reprova em várias portas ao mesmo tempo. Um campo único de motivo é vitória do


### PR DESCRIPTION
Saída da grelha (`/grill-with-docs`) sobre o material novo da task **[A] Redesenho do Score** — as subtasks A6 e A7 criadas pelo Victor em 05/08, mais o pedido de refazer a linha de base. **Só documentação** — nenhum modelo de produção foi tocado.

As sete decisões estão fechadas e persistidas aqui. Entra pelo mesmo motivo do PR irmão: a spec da [A] (issue #15) e os tickets A1–A7 vão apontar para estas ADRs, e referência que só existe em branch não é encontrável por quem executa.

## ADR 0005 — A nota é absoluta, e o denominador é medido e congelado

Quando o preço sai da nota, o Score vira só pontos de premissa — e esses pontos vivem em escalas diferentes em cada `(mercado, lado)`. Hoje o `pts_valor` (0 a 30, idêntico em todos os mercados) é o que disfarça isso, e ele some junto com o edge.

Medido nos onze pares de mercado e lado, com os tetos lidos do código, a nota média vai de **16** no Resultado fora a **59** no azarão do Handicap — **3,8 vezes**. A causa não são os pesos, é a interação: somar cresce reto conforme se adiciona premissa, acender junto cresce muito mais devagar.

Daí a A6: denominador **medido e congelado** (p95), não recalculado a cada build.

## ADR 0006 — As portas classificam, não apagam

O mart guarda **só o que passa**. A `fact_value_opportunities` tem nota mínima 40 e zero linhas abaixo; o histórico é foto da mesma tabela e herda o recorte. Tudo que é rejeitado desaparece sem registro.

A consequência é que toda decisão de régua é tomada sobre um backtest que recalcula o passado inteiro a cada execução, numa janela que cresce. A mesma query, três dias depois e sem mudar um byte, moveu a faixa 20–40 de **−3,6% para +9,7%**. Não é bug — é régua escolhida sobre número com validade de dias.

Daí a A7: guardar o funil, para que o rejeitado deixe rastro.

## O grão não conflita com o da [C]

A 0006 ganhou a seção **"O board não herda esse grão"** (commit `09e3f99`), amarrando as três camadas: de-vig por janela (ADR 0004, da [C]), funil por janela (0006, daqui), board com uma linha por linha na janela corrente mais `janela_deteccao` (0004). Resolvido — não relitigar.

## Ordem de merge

Depende do PR da branch `docs/contexto-coleta-janelas` (ADRs 0003/0004) estar dentro: a 0006 cita a 0004. As duas branches tocam `dbt_futebol/CONTEXT.md` em hunks disjuntas e o merge é limpo — verificado com `git merge-tree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGVfqgzeeLjbEBJ4Z6ZxpS
