### PR TITLE
Rollout Primeira Liga (94) na camada dbt — fecha a Onda 2 (e expõe a imagem dbt parada em 05/08)

### DIFF
--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
@@ -137,7 +137,9 @@ flags AS (
         -- pontos corridos (Brasileirão, Série B, La Liga, Premier League e Serie A ITA — 20 times, mesma dinâmica
         -- G6/Z3 de Europa/rebaixamento, então rank<=6 / rank>=n-3 vale sem mudança; revisar na recalibração por
         -- liga) e S em zona de disputa (G6 ou Z4). Copa -> FALSE (rank é por grupo, proxy não vale).
-        -- Bundesliga e Ligue 1 -> TRUE, e são as duas de 18 times (as outras 5 têm 20). Entram
+        -- Bundesliga, Ligue 1 e Primeira Liga -> TRUE, e são as três de 18 times (as outras 5 têm
+        -- 20). A Primeira Liga é o caso mais LIMPO das três: o playoff dela tem 2 jogos nas duas
+        -- temporadas medidas (a da Ligue 1 varia, 2 em 24/25 e 4 em 25/26). Entram
         -- porque n_teams vem do standings por (liga, season), então `rank >= n_teams - 3` se ajusta
         -- sozinho (15-18) sem constante nova. RESSALVA IDÊNTICA NAS DUAS: ambas têm 3 vagas em risco
         -- (2 quedas diretas + 1 playoff contra a 2ª divisão — 2. Bundesliga e Ligue 2), então a faixa
@@ -156,7 +158,7 @@ flags AS (
         -- Champions League -> FALSE pelo mesmo motivo: fase de liga (36 times, 8 jogos) vira
         -- mata-mata em fevereiro e a tabela congela; G6/Z3 não modela a dinâmica top-8/9-24.
         -- TODO: refinar com rodada/congestionamento de calendário.
-        m.is_favorito AND m.competition IN ('brasileirao', 'serie_b', 'la_liga', 'premier_league', 'serie_a_ita', 'bundesliga', 'ligue_1')
+        m.is_favorito AND m.competition IN ('brasileirao', 'serie_b', 'la_liga', 'premier_league', 'serie_a_ita', 'bundesliga', 'ligue_1', 'primeira_liga')
             AND COALESCE(m.s_rank <= 6 OR m.s_rank >= m.n_teams - 3, FALSE)     AS sem_rodizio,
         -- Azarão (Σ30)
         m.is_azarao AND COALESCE(m.s_n_games >= 5 AND m.s_lost2 / m.s_n_games < 0.30, FALSE) AS raramente_perde_por_2,

--- a/dbt_futebol/models/marts/fact_fixtures.sql
+++ b/dbt_futebol/models/marts/fact_fixtures.sql
@@ -20,6 +20,7 @@ SELECT
         WHEN 135 THEN 'serie_a_ita'
         WHEN 78  THEN 'bundesliga'
         WHEN 61  THEN 'ligue_1'
+        WHEN 94  THEN 'primeira_liga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS competition_id,

--- a/dbt_futebol/models/marts/fact_injuries_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_injuries_snapshot.sql
@@ -23,6 +23,7 @@ SELECT
         WHEN 135 THEN 'serie_a_ita'
         WHEN 78  THEN 'bundesliga'
         WHEN 61  THEN 'ligue_1'
+        WHEN 94  THEN 'primeira_liga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS league_id,

--- a/dbt_futebol/models/marts/fact_odds_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_odds_snapshot.sql
@@ -23,6 +23,7 @@ SELECT
         WHEN 135 THEN 'serie_a_ita'
         WHEN 78  THEN 'bundesliga'
         WHEN 61  THEN 'ligue_1'
+        WHEN 94  THEN 'primeira_liga'
         ELSE 'unknown'
     END                                              AS competition,
     league_id,

--- a/dbt_futebol/models/marts/fact_predictions_api.sql
+++ b/dbt_futebol/models/marts/fact_predictions_api.sql
@@ -23,6 +23,7 @@ SELECT
         WHEN 135 THEN 'serie_a_ita'
         WHEN 78  THEN 'bundesliga'
         WHEN 61  THEN 'ligue_1'
+        WHEN 94  THEN 'primeira_liga'
         ELSE 'unknown'
     END                                              AS competition,
     league_id,

--- a/dbt_futebol/models/marts/fact_standings_snapshot.sql
+++ b/dbt_futebol/models/marts/fact_standings_snapshot.sql
@@ -23,6 +23,7 @@ SELECT
         WHEN 135 THEN 'serie_a_ita'
         WHEN 78  THEN 'bundesliga'
         WHEN 61  THEN 'ligue_1'
+        WHEN 94  THEN 'primeira_liga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS league_id,

--- a/dbt_futebol/models/marts/fact_team_season_stats.sql
+++ b/dbt_futebol/models/marts/fact_team_season_stats.sql
@@ -25,6 +25,7 @@ SELECT
         WHEN 135 THEN 'serie_a_ita'
         WHEN 78  THEN 'bundesliga'
         WHEN 61  THEN 'ligue_1'
+        WHEN 94  THEN 'primeira_liga'
         ELSE 'unknown'
     END                                          AS competition,
     requested_league_id                          AS competition_id,

--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -163,7 +163,7 @@ models:
         tests:
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1', 'primeira_liga']
               config:
                 tags: ['guarda']
       - name: competition_id
@@ -710,7 +710,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1', 'primeira_liga']
               config:
                 tags: ['guarda']
       - name: competition_id
@@ -863,7 +863,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1', 'primeira_liga']
               config:
                 tags: ['guarda']
       - name: league_id
@@ -990,7 +990,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1', 'primeira_liga']
               config:
                 tags: ['guarda']
       - name: league_id
@@ -1089,7 +1089,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1', 'primeira_liga']
               config:
                 tags: ['guarda']
       - name: league_id
@@ -1212,7 +1212,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1']
+                values: ['brasileirao', 'copa_mundo', 'serie_b', 'copa_do_brasil', 'libertadores', 'sudamericana', 'la_liga', 'premier_league', 'champions_league', 'serie_a_ita', 'bundesliga', 'ligue_1', 'primeira_liga']
               config:
                 tags: ['guarda']
       - name: league_id


### PR DESCRIPTION
Camada dbt da **Primeira Liga (94)** — 7ª europeia e **última liga da Onda 2**, que fecha a expansão. Par na ingestão: tech-lamjav/data-engineering#30.

## O que entra

Slug `primeira_liga` nos **6 `CASE`** e nos **6 `accepted_values`** (lista vai a **13 slugs**).

`'primeira_liga'` entra no `IN` do `sem_rodizio` — é a **terceira** liga de 18 times, e a mais limpa das três: o playoff dela tem **2 jogos nas duas** temporadas medidas, enquanto o da Ligue 1 varia (2 em 24/25, 4 em 25/26). A ressalva foi reescrita para cobrir as três em vez de duas.

## ⚠️ A suíte de guardas está VERMELHA, e não é por causa desta mudança

```
Done. PASS=10 WARN=0 ERROR=3 TOTAL=13
FAIL 1 · accepted_values de fact_fixtures, fact_injuries_snapshot, fact_standings_snapshot
```

O valor que falha é **`unknown` com `competition_id = 61`, 924 linhas** — a Ligue 1, materializada pelo run diário das 12:00 UTC de hoje.

**Causa:** a imagem Docker do job `dbt-futebol` é de **05/08 14:25** e nunca foi rebuildada depois do merge do slug `ligue_1` (#34). O job agendado roda o código antigo, então o 61 cai no `ELSE 'unknown'`.

**E isto é a guarda funcionando.** Rodando de código correto ela pega o bug em 3 dos 6 marts. Em produção não pegou pelo motivo estrutural que este episódio expôs:

> A fase `dbt test --select tag:guarda` roda da **mesma imagem** que os modelos. Uma imagem velha causa o bug **e remove o detector** — o log do job das 12:00 mostra `TOTAL=6`, não 13, porque o tagueamento dos 6 `accepted_values` (#28) também está preso na imagem velha.

O único sintoma que a guarda consegue emitir sobre si mesma é a **contagem**: se o `TOTAL` da linha `Done.` não for o esperado, a imagem está velha.

## O que o rebuild da imagem conserta, de uma vez

1. o slug `ligue_1` (924 linhas hoje em `unknown`);
2. o slug `primeira_liga` desta PR;
3. **o fix do de-vig** (`398b1d2`, spec #22 / task [D] — *"o de-vig para de anunciar certeza"*), commitado **05/08 14:26** contra uma imagem empurrada **05/08 14:25:16**: perdeu por **70 segundos** e está **fora de produção há 2 dias**, sem ninguém notar — pelo mesmo motivo, o detector estava desligado junto.

Depois do rebuild + re-execução do dbt, a guarda volta ao verde. Vai no mesmo passo deste rollout.

## Sondagem que sustenta o gabarito (2026-08-07)

| item | valor |
|---|---|
| abertura | **2026-08-07 19:15 UTC** (rodada 1 em 07–10/08) |
| fixtures | **306** (2026) · **308** (2024) · **308** (2025) — bracket estável de 2 jogos |
| times | 19 · 19 · 18 no catálogo → zero risco de órfão |
| standings | 18 linhas, grupo único |
| AWD | **nenhum** (≠ Ligue 1) |
| gols | 2,62 g/jogo · 51,5% Over 2.5 — desvio brando (+0,14 e +4,8pp vs Brasileirão) |

Entra **sem gate e sem recalibração**, como as outras seis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
