### PR TITLE
fix(futebol): aceita a janela 'daily' em collection_window

### DIFF
--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -1115,12 +1115,13 @@ models:
         tests:
           - not_null
       - name: collection_window
-        description: "Janela da coleta: 't24h' (abertura ~24h) | 't1h' (intermediária ~1h) | 't15m' (fechamento ~15min — habilita CLV real)"
+        description: "Janela da coleta: 'daily' (1 captura/dia de >24h até 7 dias do apito — o que tira o board do recorte de 24h; date-stampada na landing) | 't24h' (abertura ~24h) | 't1h' (intermediária ~1h) | 't15m' (fechamento ~15min — habilita CLV real). ⚠️ O dedup deste fato é por (fixture, casa, mercado, outcome, collection_window) SEM o dia, então as N capturas diárias de um jogo colapsam na mais recente aqui; o histórico completo fica na landing até o grão mudar (#37)."
         tests:
           - not_null
           - accepted_values:
               arguments:
-                values: ['t24h', 't1h', 't15m']
+                # 'daily' entrou em 2026-08-07 com tech-lamjav/data-engineering#34.
+                values: ['daily', 't24h', 't1h', 't15m']
       - name: collection_timestamp
         description: "TIMESTAMP (UTC) exato da coleta do snapshot"
         tests:


### PR DESCRIPTION
A janela diária de odds entrou em produção hoje com `tech-lamjav/data-engineering#34` — 1 captura por fixture por dia, de pouco além de 24h até 7 dias do apito. Verificado na primeira passada: 44 (fixture, janela) na banda, 40 com casas, Pinnacle presente num jogo além de 24h.

O `accepted_values` de `collection_window` ainda listava só as três bandas de fechamento, então a primeira linha `daily` reprova. Não derruba produção — o teste não é `tag:guarda`, e o workflow roda `dbt test --select tag:guarda` — mas quebra `dbt build` manual ou de desenvolvimento, que é justamente o que quem pegar a #37 vai rodar.

A `description` ganha junto o aviso de que o dedup deste fato é por `(fixture, casa, mercado, outcome, collection_window)` **sem o dia**: as N capturas diárias de um jogo colapsam na mais recente aqui, e o histórico completo de movimento de linha fica na landing até o grão mudar na #37.

Refs #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)