### PR TITLE
feat(futebol): declara o insumo de cada premissa num macro, com guarda (#39)

### DIFF
--- a/dbt_futebol/macros/premissas_insumos.sql
+++ b/dbt_futebol/macros/premissas_insumos.sql
@@ -1,0 +1,103 @@
+{#- FONTE ÚNICA do insumo de cada premissa do Motor de Score.
+
+    Uma premissa que não acende pode ser duas coisas muito diferentes: o sinal foi medido e
+    não estava lá, ou o sinal nunca pôde ser medido. Hoje as duas viram o mesmo score mais
+    baixo, e o leitor não tem como separar pouca informação de informação contrária. Contar a
+    segunda é o trabalho da ADR 0003 — e este macro é de onde a contagem sai.
+
+    Por que declarar num lugar só, e não contar NULL à mão em cada modelo: o contador escrito
+    à mão fica correto no dia em que é escrito e apodrece na premissa seguinte. Quem
+    acrescentar uma premissa nova precisa lembrar de somá-la, e esquecer é SILENCIOSO — o
+    contador segue verde, só que menor que a verdade. É o mesmo modo de falha do mercado órfão
+    que a ADR 0002 tratou com futebol_conjunto_saidas(), e a resposta aqui é a mesma: declarar
+    num lugar, e pôr uma guarda comparando o declarado com o que os modelos realmente
+    produzem (assert_premissas_insumo_declarado).
+
+    TRÊS TIPOS, porque nem toda coluna booleana de um modelo de premissas é uma premissa:
+
+      premissa   — entra no PTS_PREMISSAS e conta para premissas_sem_dado. São 39.
+      penalidade — subtrai pontos. Não conta para o contador (não é conhecimento faltando),
+                   mas declara insumo do mesmo jeito: desfalque_proprio depende de s_missing,
+                   e a ADR 0003 decidiu que cegueira deixa de EXIMIR a penalidade.
+      marcador   — nem soma nem subtrai; diz de que lado a linha está (is_favorito/is_azarao
+                   no Handicap). Declarado para que a guarda não o acuse de premissa não
+                   declarada, que é o ponto cego do fail-closed.
+
+    OS INSUMOS SÃO NOMES DA CTE `metrics` de cada modelo, não colunas da saída. É lá que a
+    nulidade tem de ser lida — a premissa já chega ao SELECT final como booleano, e nesse
+    ponto "não acendeu" e "não pôde ser avaliada" já colapsaram num FALSE só.
+
+    ⚠️ INSUMO NÃO-NULO NÃO É INSUMO PRESENTE, e é por isso que este mapa sozinho não faz o
+    contador funcionar. Um contador baseado em `IS NULL` nasce ZERADO por construção enquanto
+    os insumos chegarem preenchidos. São TRÊS classes, e a terceira é a pior:
+
+      (a) COALESCE para ZERO na própria `metrics` — s_missing e o_missing, n_wins_last5,
+          h2h_total. Nomeadas na ADR 0003; sair delas é o trabalho de #41 e #42.
+      (b) CONTAGEM sobre array vazio ou NULL — home_btts_cnt, home_over_cnt, home_under_cnt,
+          s_losses_last5 e irmãs, todas de UNNEST(last5_*). Devolvem 0 sem nenhum NULL para
+          detectar, e o zero é indistinguível de "cinco jogos, nenhum deles bateu".
+      (c) BOOLEANO JÁ COLAPSADO — x_forca_mismatch, x_superioridade_tabela e x_h2h_favoravel
+          (Dupla Chance, reusados do 1X2) e linha_caiu (Gols). Todos são COALESCE(..., FALSE),
+          ou seja, exatamente o colapso que a regra acima manda evitar, só que acontecendo uma
+          CTE antes. A Dupla Chance herda o FALSE de premissas do 1X2 que podem elas mesmas
+          não ter podido ser avaliadas, então a cegueira atravessa dois modelos sem deixar
+          rastro. E linha_caiu compara t15m contra t24h: numa janela distante o t15m ainda não
+          existe, então linha_subindo e linha_descendo ficam permanentemente cegas justamente
+          no horizonte novo, que é onde o contador mais precisa falar.
+
+    A guarda não pega nenhuma das três — ela valida nome e não-vazio, não a semântica do
+    insumo. Quem consumir este mapa tem de tratar as três, não só a (a).
+    Ver docs/adr/0003-dado-faltante-diagnostica-nao-elimina.md. -#}
+{% macro futebol_insumos_premissa() %}
+    {{ return([
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'forca_mismatch',       'tipo': 'premissa',   'insumos': ['s_gf_venue', 'o_ga_venue']},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'superioridade_xg',     'tipo': 'premissa',   'insumos': ['s_xg_for', 'o_xg_against']},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'mando',                'tipo': 'premissa',   'insumos': ['pct_pts_home', 'aprov_fora']},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'desfalque_adversario', 'tipo': 'premissa',   'insumos': ['s_missing', 'o_missing']},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'superioridade_tabela', 'tipo': 'premissa',   'insumos': ['s_rank', 'o_rank', 's_ppg', 'o_ppg']},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'forma',                'tipo': 'premissa',   'insumos': ['n_wins_last5']},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'h2h_favoravel',        'tipo': 'premissa',   'insumos': ['h2h_total', 's_wins']},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'pick_empate',          'tipo': 'penalidade', 'insumos': []},
+        {'modelo': 'int_futebol_premissas_1x2', 'nome': 'desfalque_proprio',    'tipo': 'penalidade', 'insumos': ['s_missing']},
+
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'is_favorito',            'tipo': 'marcador',   'insumos': []},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'is_azarao',              'tipo': 'marcador',   'insumos': []},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'supremacia',             'tipo': 'premissa',   'insumos': ['s_rank', 'o_rank', 's_ppg', 'o_ppg']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'tende_golear',           'tipo': 'premissa',   'insumos': ['s_gf_venue', 's_ga_venue']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'adversario_fragil_fora', 'tipo': 'premissa',   'insumos': ['o_ga_venue']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'mando_forte',            'tipo': 'premissa',   'insumos': ['pct_pts_home']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'sem_rodizio',            'tipo': 'premissa',   'insumos': ['s_rank', 'n_teams']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'raramente_perde_por_2',  'tipo': 'premissa',   'insumos': ['s_n_games', 's_lost2']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'defesa_fora_solida',     'tipo': 'premissa',   'insumos': ['s_ga_venue']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'favorito_irregular',     'tipo': 'premissa',   'insumos': ['o_n_games', 'o_won2']},
+        {'modelo': 'int_futebol_premissas_ah',  'nome': 'handicap_alto',          'tipo': 'penalidade', 'insumos': []},
+
+        {'modelo': 'int_futebol_premissas_btts', 'nome': 'ambos_marcam',     'tipo': 'premissa', 'insumos': ['home_fts_pct', 'away_fts_pct']},
+        {'modelo': 'int_futebol_premissas_btts', 'nome': 'ataque_dos_dois',  'tipo': 'premissa', 'insumos': ['home_gf', 'away_gf']},
+        {'modelo': 'int_futebol_premissas_btts', 'nome': 'defesas_vazaveis', 'tipo': 'premissa', 'insumos': ['home_cs_pct', 'away_cs_pct']},
+        {'modelo': 'int_futebol_premissas_btts', 'nome': 'historico_btts',   'tipo': 'premissa', 'insumos': ['home_btts_cnt', 'away_btts_cnt']},
+        {'modelo': 'int_futebol_premissas_btts', 'nome': 'defesa_forte',     'tipo': 'premissa', 'insumos': ['home_cs_pct', 'away_cs_pct']},
+        {'modelo': 'int_futebol_premissas_btts', 'nome': 'ataque_trava',     'tipo': 'premissa', 'insumos': ['home_fts_pct', 'away_fts_pct']},
+        {'modelo': 'int_futebol_premissas_btts', 'nome': 'historico_seco',   'tipo': 'premissa', 'insumos': ['home_no_btts_cnt', 'away_no_btts_cnt']},
+
+        {'modelo': 'int_futebol_premissas_dc', 'nome': 'lado_coberto_forte',   'tipo': 'premissa', 'insumos': ['x_forca_mismatch', 'x_superioridade_tabela']},
+        {'modelo': 'int_futebol_premissas_dc', 'nome': 'equilibrio_defensivo', 'tipo': 'premissa', 'insumos': ['s_ga_total', 'o_ga_total', 's_thrash_rate', 'o_thrash_rate']},
+        {'modelo': 'int_futebol_premissas_dc', 'nome': 'adversario_limitado',  'tipo': 'premissa', 'insumos': ['o_aproveitamento', 'x_h2h_favoravel']},
+        {'modelo': 'int_futebol_premissas_dc', 'nome': 'invicto_recente',      'tipo': 'premissa', 'insumos': ['s_games_last5', 's_losses_last5']},
+
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'ataque_combinado',   'tipo': 'premissa',   'insumos': ['gf_comb']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'defesas_vazaveis',   'tipo': 'premissa',   'insumos': ['ga_comb']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'xg_combinado_alto',  'tipo': 'premissa',   'insumos': ['xg_comb']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'ritmo_alto',         'tipo': 'premissa',   'insumos': ['pace_both', 'pace_median']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'ambos_vazam',        'tipo': 'premissa',   'insumos': ['home_cs_pct', 'away_cs_pct']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'historico_over',     'tipo': 'premissa',   'insumos': ['home_over_cnt', 'away_over_cnt']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'linha_subindo',      'tipo': 'premissa',   'insumos': ['linha_caiu']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'defesas_firmes',     'tipo': 'premissa',   'insumos': ['ga_comb']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'clean_sheets_altos', 'tipo': 'premissa',   'insumos': ['home_cs_pct', 'away_cs_pct']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'xg_baixo_combinado', 'tipo': 'premissa',   'insumos': ['xg_comb']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'ataques_fracos',     'tipo': 'premissa',   'insumos': ['home_fts_pct', 'away_fts_pct']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'historico_under',    'tipo': 'premissa',   'insumos': ['home_under_cnt', 'away_under_cnt']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'linha_descendo',     'tipo': 'premissa',   'insumos': ['linha_caiu']},
+        {'modelo': 'int_futebol_premissas_ou', 'nome': 'linha_extrema',      'tipo': 'penalidade', 'insumos': []}
+    ]) }}
+{% endmacro %}

--- a/dbt_futebol/tests/assert_premissas_insumo_declarado.sql
+++ b/dbt_futebol/tests/assert_premissas_insumo_declarado.sql
@@ -1,0 +1,77 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DO MAPA DE INSUMOS (#39): o declarado em futebol_insumos_premissa() tem que
+-- corresponder às colunas booleanas que os modelos de premissas realmente produzem.
+--
+-- Cobre TRÊS pontos cegos. Os dois primeiros são simétricos; o terceiro é interno ao mapa:
+--
+-- 1. PREMISSA NÃO DECLARADA — coluna booleana nova num modelo, ausente do mapa. Sem esta
+--    guarda ela nasceria MUDA: o contador de premissas_sem_dado a ignoraria, e "não contada"
+--    é indistinguível de "não faltou". É o modo de falha que a ADR 0002 já pagou uma vez, no
+--    mercado órfão.
+-- 2. MAPA ENVELHECIDO — o mapa declara premissa que o modelo não produz mais (renomeada ou
+--    removida). O contador passaria a somar sobre coluna inexistente, ou a errar o total em
+--    silêncio.
+-- 3. PREMISSA SEM INSUMO DECLARADO — está no mapa, com a lista de insumos vazia. É a podridão
+--    por dentro: a premissa existe, a guarda das duas direções acima fica verde, e mesmo
+--    assim o contador nunca a incrementa, porque não há nulidade nenhuma para ler. Vale só
+--    para tipo='premissa' — penalidade e marcador legitimamente não têm insumo (pick_empate
+--    depende do outcome, handicap_alto e linha_extrema da própria linha, e os dois marcadores
+--    do sinal do handicap; todos sempre presentes).
+--
+-- Compara contra o CATÁLOGO (INFORMATION_SCHEMA), não contra os dados. Não há como uma
+-- consulta a dados revelar uma coluna cujo nome não se conhece de antemão, e é exatamente
+-- essa a direção 1. O LIKE cobre modelo de premissas NOVO sem precisar editar esta guarda —
+-- mercado novo entra e as premissas dele já são exigidas no mapa.
+--
+-- ⚠️ VERDE POR VACUIDADE hoje, igual à assert_devig_conjunto_declarado: o mapa nasce
+-- casando com a realidade, e a guarda é infalsificável em produção até o dia em que alguém
+-- mexer num modelo — que é exatamente o dia em que precisamos confiar nela. Por isso foi
+-- dirigida ao vermelho NAS DUAS DIREÇÕES durante a implementação (#39): retirando uma
+-- premissa do mapa (acusou as 36 restantes) e declarando uma inexistente (acusou a órfã).
+
+WITH declarado AS (
+    SELECT * FROM UNNEST([
+        {%- for p in futebol_insumos_premissa() %}
+        STRUCT('{{ p.modelo }}' AS modelo, '{{ p.nome }}' AS nome, '{{ p.tipo }}' AS tipo, {{ p.insumos | length }} AS n_insumos){{ "," if not loop.last }}
+        {%- endfor %}
+    ])
+),
+
+-- Colunas booleanas dos modelos de premissas, direto do catálogo do dataset.
+--
+-- O LIKE lê o catálogo, e o catálogo não é o DAG: sem as arestas abaixo esta guarda só
+-- dependeria do 1X2, e num target novo poderia rodar antes de os outros quatro existirem —
+-- acusando ~30 premissas como "o modelo não produz mais" quando o modelo apenas ainda não
+-- foi construído. Guarda cujo primeiro disparo é falso positivo morre ignorada.
+-- depends_on: {{ ref('int_futebol_premissas_ah') }}
+-- depends_on: {{ ref('int_futebol_premissas_btts') }}
+-- depends_on: {{ ref('int_futebol_premissas_dc') }}
+-- depends_on: {{ ref('int_futebol_premissas_ou') }}
+observado AS (
+    SELECT
+        table_name  AS modelo,
+        column_name AS nome
+    FROM `{{ ref('int_futebol_premissas_1x2').database }}.{{ ref('int_futebol_premissas_1x2').schema }}.INFORMATION_SCHEMA.COLUMNS`
+    WHERE table_name LIKE 'int\\_futebol\\_premissas\\_%'
+      AND data_type = 'BOOL'
+)
+
+SELECT
+    COALESCE(o.modelo, d.modelo) AS modelo,
+    COALESCE(o.nome, d.nome)     AS nome,
+    d.tipo                       AS tipo_declarado,
+    CASE
+        WHEN d.nome IS NULL
+            THEN 'coluna booleana no modelo e ausente do mapa — declarar em futebol_insumos_premissa() como premissa, penalidade ou marcador'
+        WHEN o.nome IS NULL
+            THEN 'o mapa declara o que o modelo não produz mais — remover do mapa ou restaurar no modelo'
+        ELSE 'premissa declarada sem insumo — o contador nunca a incrementaria; declarar as colunas da CTE metrics de que ela depende'
+    END AS diagnostico
+FROM observado o
+FULL OUTER JOIN declarado d
+    ON  o.modelo = d.modelo
+    AND o.nome   = d.nome
+WHERE d.nome IS NULL
+   OR o.nome IS NULL
+   OR (d.tipo = 'premissa' AND d.n_insumos = 0)
+ORDER BY modelo, nome


### PR DESCRIPTION
Closes #39. Prefactor do contador de `premissas_sem_dado` (ADR 0003). **Nenhum modelo foi tocado** — o board não pode ter mudado, e `git status` é a prova, mais forte que uma comparação antes/depois.

## O que entra

**`macros/premissas_insumos.sql`** — fonte única de qual coluna da CTE `metrics` cada premissa lê. 45 entradas: as **39 premissas** dos cinco mercados, mais 4 penalidades e 2 marcadores de lado, tipados.

Penalidade e marcador entram no mapa porque a guarda compara contra *toda* coluna booleana do modelo — sem declará-los, o fail-closed acusaria falso positivo. E `desfalque_proprio`, que é penalidade, tem insumo de verdade (`s_missing`): a ADR 0003 decidiu que cegueira deixa de **eximi-la**.

Os insumos são nomes da `metrics`, não colunas da saída. É lá que a nulidade ainda existe — no `SELECT` final, "não acendeu" e "não pôde ser avaliada" já colapsaram num `FALSE` só.

**`tests/assert_premissas_insumo_declarado.sql`** — compara o mapa com o **catálogo** (`INFORMATION_SCHEMA`), não com os dados. Nenhuma consulta a dados revela uma coluna cujo nome não se conhece de antemão, e é exatamente essa a direção que importa. O `LIKE` cobre modelo de premissas novo sem editar a guarda; quatro `depends_on` garantem que os cinco modelos existam antes de ela julgar.

## Dirigida ao vermelho nas três direções

Em produção a guarda nasce verde por vacuidade e infalsificável, então foi quebrada de propósito durante a implementação:

| direção | cenário | resultado |
|---|---|---|
| 1 | mapa só com o 1X2 | **FAIL 36** — as demais colunas booleanas |
| 2 | premissa declarada inexistente | **FAIL 1**, diagnóstico de mapa envelhecido |
| 3 | premissa com `insumos: []` | **FAIL 1**, a podridão por dentro do mapa |

A direção 3 não estava no ticket e é a mais traiçoeira: as outras duas ficam verdes e o contador mesmo assim nunca incrementa aquela premissa.

## O que a revisão pegou

**Faltava uma classe inteira de insumo cego** — o achado que mais importa, porque #41 e #42 vão ler o bloco de alerta do macro como o escopo delas. Quatro insumos declarados são `COALESCE(..., FALSE)`: `x_forca_mismatch`, `x_superioridade_tabela` e `x_h2h_favoravel` (Dupla Chance) e `linha_caiu` (Gols). São booleanos **já colapsados** — o mesmo colapso que a regra do macro manda evitar, uma CTE antes.

Pior na Dupla Chance, que herda `FALSE` de premissas do 1X2 que podem elas mesmas não ter sido avaliadas: a cegueira atravessa dois modelos sem deixar rastro. E `linha_caiu` compara t15m contra t24h, então `linha_subindo`/`linha_descendo` ficam cegas justamente no horizonte de 7 dias que acabou de abrir — onde o contador mais precisa falar. O macro agora nomeia as **três** classes.

**A guarda não tinha aresta no DAG** para quatro dos cinco modelos. Num target novo rodaria antes de eles existirem e acusaria ~30 falsos positivos — guarda cujo primeiro disparo é falso positivo morre ignorada. Corrigido e conferido com `dbt ls`.

## Verificação

`dbt test` completo: **PASS=260 WARN=12 ERROR=0** (total 272). Os 12 warnings são testes de `relationships` pré-existentes, configurados para avisar, em modelos que este PR não toca.

## Um critério de aceite cumprido por outro meio

O ticket pedia **unit test de dbt**. Não foi escrito. Unit test só existe para *modelo*, e esta guarda é singular test lendo `INFORMATION_SCHEMA` — mas seria possível quebrar a comparação em dois modelos e mockar o lado observado, então "não tem onde encaixar" seria exagero.

Não foi feito porque custaria dois modelos materializados no DAG e no sync para testar um `FULL OUTER JOIN`, enquanto o risco real — o mapa divergir da realidade — só a guarda contra o catálogo verdadeiro pega. **A perda fica registrada:** os três vermelhos acima foram manuais e não deixam artefato repetível.

⚠️ Lembrete herdado da spec: a camada `tag:guarda` roda no pipeline agendado mas **não alarma** (o job devolve exit 0 com teste vermelho e o resumo diário não lê o status). Até a C4 fechar, esta guarda protege quem roda local ou no CI, e ninguém mais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGVfqgzeeLjbEBJ4Z6ZxpS
