### PR TITLE
feat(deploy): carimbo de procedência da imagem dbt + detector fora dela

### DIFF
--- a/.github/workflows/deriva-imagem.yml
+++ b/.github/workflows/deriva-imagem.yml
@@ -1,0 +1,56 @@
+# Detector de deriva de imagem dbt.
+#
+# Pergunta, de hora em hora: a imagem que os Cloud Run Jobs estão rodando corresponde ao
+# código no master? Compara o carimbo de procedência gravado em cada job com o hash
+# recalculado deste checkout.
+#
+# POR QUE ESTE DETECTOR VIVE AQUI, e não numa guarda dbt:
+# a fase de guardas (`dbt test --select tag:guarda`) roda da MESMA imagem que os modelos que
+# protege. Imagem velha causa o bug E apaga o detector. Em 07/08/2026 a fase de guardas do
+# futebol passou com TOTAL=6 em vez de 13 — as 7 tags que faltavam estavam no master e não na
+# imagem, então a guarda que existia exatamente para pegar `competition='unknown'` nunca
+# rodou. Só um detector FORA da imagem enxerga essa classe de falha. Ver docs/adr/0001.
+#
+# POR QUE DE HORA EM HORA, e não uma vez por dia:
+# o job `dbt-futebol` roda ~96×/dia (workflow-futebol-odds é */15 e chama o job três vezes
+# por ciclo). Imagem velha não causa um dano diário, causa dano contínuo. Cadência horária
+# limita a ~4 execuções ruins. Não gera spam: o GitHub notifica na primeira falha de um
+# workflow agendado e na recuperação, não a cada execução. Repo público = Actions ilimitado.
+#
+# ⚠️ Em repositório público, workflow agendado é desativado após 60 dias sem atividade no
+# repo. Se este detector parar de rodar sem explicação, é a primeira coisa a conferir.
+
+name: Deriva de imagem dbt
+
+on:
+  schedule:
+    # Minuto 20 para não cair junto com os ciclos */15 dos workflows de odds.
+    - cron: '20 * * * *'
+  workflow_dispatch:
+
+jobs:
+  checa-deriva:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Autenticar no GCP
+        uses: google-github-actions/auth@v2
+        with:
+          # Mesmo secret que o deploy-dbt-docs.yml já usa (SA github-actions-dbt-docs@).
+          # Precisa de roles/run.viewer além dos papéis de BigQuery que já tinha — leitura
+          # apenas, e nunca toca o Artifact Registry: o carimbo mora no job.
+          credentials_json: ${{ secrets.BIGQUERY_SA_KEY }}
+
+      - name: Instalar gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: smartbetting-dados
+
+      - name: Checar deriva
+        run: ./scripts/checa_deriva.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,30 @@ All game times are stored in UTC and converted to Brasília (UTC-3) for display.
 
 GitHub Actions (`.github/workflows/deploy-dbt-docs.yml`) deploys static dbt docs to GitHub Pages on push to master when files under `dbt_nba/` change. Requires `BIGQUERY_SA_KEY` secret with a service account JSON.
 
+### ⚠️ Deploy dos modelos: mergear NÃO é deployar
+
+Os modelos rodam de uma **imagem Docker pré-buildada**, não do master. Depois de todo merge
+que toca as paths comportamentais de um projeto dbt:
+
+```bash
+./build-and-push.sh dbt_futebol   # ou dbt_nba
+```
+
+Esse comando agora faz build + push + `gcloud run jobs update` (digest **e** carimbo de
+procedência) num passo só. Não existe mais um segundo comando manual — foi o segundo passo
+esquecido que deixou o fix do de-vig 2 dias fora de produção e o `dbt_nba` 6 semanas atrás
+do master.
+
+**A fase de guardas dbt não pega isso**: ela roda da mesma imagem, então imagem velha causa o
+bug e apaga o detector. Quem pega é `.github/workflows/deriva-imagem.yml`, de hora em hora,
+de fora da imagem. Para conferir na hora:
+
+```bash
+./scripts/checa_deriva.sh
+```
+
+Ver `docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md`.
+
 ## Agent skills
 
 ### Issue tracker

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
-# Script para build e push da imagem Docker para Artifact Registry
+# Script para build, push e DEPLOY da imagem Docker do projeto dbt.
 # Uso:
 #   ./build-and-push.sh              # default: dbt_nba (compatibilidade)
 #   ./build-and-push.sh dbt_futebol  # build do projeto futebol
+#
+# ⚠️ Este script agora TAMBÉM atualiza o Cloud Run Job (`gcloud run jobs update`). Antes ele
+# parava no push, e o `jobs update` era um segundo comando manual — foi exatamente esse
+# segundo passo esquecido que deixou o de-vig 2 dias fora de produção (futebol, 05-07/08/2026)
+# e o dbt_nba 6 semanas atrás do master. O job fixa o DIGEST, não a tag: empurrar `:latest`
+# sem `jobs update` não muda nada em produção. Os dois passos são um só agora, de propósito.
+#
+# O mesmo comando grava o CARIMBO DE PROCEDÊNCIA (`scripts/procedencia.sh`) como env var do
+# job, para que build, digest e carimbo não possam divergir. Ver docs/adr/0001.
 
 set -e
 
@@ -38,6 +47,25 @@ fi
 # Construir o nome completo da imagem
 FULL_IMAGE_NAME="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPO}/${IMAGE_NAME}:${IMAGE_TAG}"
 
+# Nome do Cloud Run Job: mesma convenção da imagem (dbt_futebol -> dbt-futebol).
+JOB_NAME="$NORMALIZED_NAME"
+
+# Carimbo de procedência: hash do conteúdo EM DISCO das paths comportamentais — calculado
+# ANTES do build, da mesma árvore que o `docker build` vai copiar. O SHA do git vai junto só
+# para leitura humana (não é o que o detector compara).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROCEDENCIA_HASH="$("$SCRIPT_DIR/scripts/procedencia.sh" "$PROJECT_NAME")"
+PROCEDENCIA_SHA="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo "sem-git")"
+
+# Aviso — não bloqueio. Buildar de branch/worktree com alteração não commitada é legítimo
+# (hotfix, depuração) e o repo trabalha assim. O carimbo simplesmente vai refletir o disco,
+# então o detector vai acusar deriva até o código ser mergeado — que é a verdade, não um bug.
+if ! git -C "$SCRIPT_DIR" diff --quiet -- $("$SCRIPT_DIR/scripts/procedencia.sh" "$PROJECT_NAME" --paths) 2>/dev/null; then
+    echo "⚠️  AVISO: ha alteracao nao commitada nas paths comportamentais de ${PROJECT_NAME}."
+    echo "    O carimbo vai refletir o DISCO, entao o detector de deriva vai ficar VERMELHO"
+    echo "    ate esse codigo estar no master. Isso e o comportamento correto, nao um erro."
+fi
+
 echo "=========================================="
 echo "Build e Push da Imagem Docker"
 echo "=========================================="
@@ -48,6 +76,9 @@ echo "Região: ${GCP_REGION}"
 echo "Repositório: ${ARTIFACT_REGISTRY_REPO}"
 echo "Imagem: ${IMAGE_NAME}:${IMAGE_TAG}"
 echo "Nome completo: ${FULL_IMAGE_NAME}"
+echo "Cloud Run Job: ${JOB_NAME}"
+echo "Carimbo (procedência): ${PROCEDENCIA_HASH}"
+echo "Commit (leitura humana): ${PROCEDENCIA_SHA}"
 echo "=========================================="
 echo ""
 
@@ -65,11 +96,33 @@ echo ""
 echo "Fazendo push para Artifact Registry..."
 docker push ${FULL_IMAGE_NAME}
 
+# Deploy: repin do digest no job + gravação do carimbo, NO MESMO COMANDO.
+# O job resolve `:latest` para um digest no momento do update e as execuções herdam esse
+# digest — sem este passo, o push acima não muda absolutamente nada em produção.
+#
+# `--update-env-vars` e não `--set-env-vars`: o segundo substitui o mapa inteiro de env vars,
+# então qualquer variável que alguém venha a acrescentar ao job seria apagada em silêncio no
+# próximo build.
+echo ""
+echo "Atualizando Cloud Run Job ${JOB_NAME} (digest + carimbo)..."
+gcloud run jobs update "$JOB_NAME" \
+    --region="$GCP_REGION" \
+    --project="$GCP_PROJECT_ID" \
+    --image="$FULL_IMAGE_NAME" \
+    --update-env-vars="PROCEDENCIA_HASH=${PROCEDENCIA_HASH},PROCEDENCIA_SHA=${PROCEDENCIA_SHA}"
+
 echo ""
 echo "=========================================="
-echo "✅ Build e push concluídos com sucesso!"
+echo "✅ Build, push e deploy concluídos com sucesso!"
 echo "=========================================="
 echo "Imagem disponível em: ${FULL_IMAGE_NAME}"
+echo "Job ${JOB_NAME} carimbado com: ${PROCEDENCIA_HASH}"
+echo ""
+echo "Digest efetivamente fixado no job:"
+gcloud run jobs describe "$JOB_NAME" \
+    --region="$GCP_REGION" \
+    --project="$GCP_PROJECT_ID" \
+    --format="value(spec.template.spec.template.spec.containers[0].image)"
 echo ""
 echo "Para executar localmente:"
 echo "  docker run ${FULL_IMAGE_NAME}"

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -118,11 +118,14 @@ echo "=========================================="
 echo "Imagem disponível em: ${FULL_IMAGE_NAME}"
 echo "Job ${JOB_NAME} carimbado com: ${PROCEDENCIA_HASH}"
 echo ""
-echo "Digest efetivamente fixado no job:"
+echo "Carimbo agora gravado no job (o que o detector le):"
 gcloud run jobs describe "$JOB_NAME" \
     --region="$GCP_REGION" \
     --project="$GCP_PROJECT_ID" \
-    --format="value(spec.template.spec.template.spec.containers[0].image)"
+    --format="value(spec.template.spec.template.spec.containers[0].env)"
+# O spec do job guarda a TAG; o digest só aparece resolvido no spec de cada execução
+# (`gcloud run jobs executions list --format='value(spec.template.spec.containers[0].image)'`).
+# Por isso o carimbo, e não o digest, é o que o detector interroga.
 echo ""
 echo "Para executar localmente:"
 echo "  docker run ${FULL_IMAGE_NAME}"

--- a/docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md
+++ b/docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md
@@ -1,0 +1,99 @@
+# Carimbo de procedência da imagem dbt, detectado fora dela
+
+**Status:** accepted (2026-08-07)
+
+A fase de guardas dbt (`dbt test --select tag:guarda`) roda da **mesma imagem Docker** que os
+modelos que ela protege, então uma imagem velha causa o bug **e apaga o detector do bug** — a
+guarda é estruturalmente cega para o modo de falha "a imagem não foi rebuildada". Decidimos
+gravar um **carimbo de procedência** em cada Cloud Run Job (hash do conteúdo em disco das
+paths que carregam comportamento) e conferi-lo de hora em hora por um detector que roda no
+GitHub Actions, **fora da imagem**.
+
+Este ADR fica na raiz e não em `dbt_futebol/docs/adr/` porque a decisão atravessa os dois
+contextos (NBA e Futebol) e alcança o repo `data-engineering`.
+
+## Vocabulário
+
+Dois termos novos, deliberadamente **fora** de "guarda":
+
+- **Procedência** — o que uma imagem em produção declara sobre a própria origem.
+- **Deriva** — a condição de o que roda em produção não corresponder ao master.
+
+"Guarda" neste repo já significa teste de dado dbt (`tag:guarda`). A lição inteira do
+incidente é que **a guarda não consegue se vigiar**; reusar a palavra reimportaria a confusão
+que abriu o buraco. Os termos moram aqui e não no `CONTEXT.md`, que é glossário de domínio.
+
+## O que aconteceu (a evidência que motivou)
+
+| pipeline | imagem em produção | commit que ficou fora | margem | tempo fora |
+|---|---|---|---|---|
+| futebol | 05/08 14:25:16 | 05/08 14:26 (`398b1d2`, fix do de-vig) | **70 segundos** | 2 dias |
+| nba | 26/06 18:23:01 | 26/06 18:40 (`2f6263a`, DNP crítico + betting-math, 31 arquivos) | **17 minutos** | ~6 semanas |
+
+Nos dois casos **o deploy aconteceu** — apenas *antes* do último commit. No futebol, o efeito
+visível foi 924 linhas materializadas com `competition='unknown'` para a Ligue 1, e a fase de
+guardas passou com `TOTAL=6` em vez de 13: as 7 tags que teriam pego exatamente isso estavam
+no master e não na imagem. Sintoma e detector desligados pela mesma causa.
+
+## Decisões
+
+1. **O carimbo é o hash do conteúdo EM DISCO**, não `git rev-parse HEAD:<path>`. O
+   `docker build` copia o disco, não o HEAD; um build com alteração não commitada — ou de um
+   `.claude/worktrees/` numa branch, que é como este repo trabalha — carimbaria o master
+   enquanto a imagem carrega outra coisa, mentindo na direção perigosa ("está fresco").
+2. **Só as paths que carregam comportamento** (`models/`, `macros/`, `tests/`, `snapshots/`,
+   `seeds/`, `dbt_project.yml`, `packages.yml`, `package-lock.yml`, `requirements.txt`,
+   `profiles.yml`, Dockerfile). `analyses/`, `docs/` e `CONTEXT.md` vão para a imagem mas não
+   mudam comportamento: nos 30 dias anteriores foram 116 toques em `models` contra 28 nessas
+   três — hashear a pasta inteira renderia ~28 alarmes falsos/mês, e um detector que grita por
+   `CONTEXT.md` é ignorado em duas semanas.
+3. **O par `<path> <blob>` entra no hash, não só o blob.** No dbt o nome do arquivo É o nome
+   do modelo: renomear sem mudar uma linha muda a tabela materializada.
+4. **`LC_ALL=C` na ordenação.** O build roda em macOS e o detector em ubuntu-latest;
+   collation diferente daria ordem diferente, hash diferente e vermelho permanente parecendo
+   bug misterioso.
+5. **O carimbo mora no job (env var), não como LABEL da imagem.** O que apodrece é o *digest
+   fixado no job*, não a tag: o job resolve `:latest` para um digest no `jobs update` e as
+   execuções herdam. O carimbo interroga a coisa certa, e o detector precisa só de
+   `roles/run.viewer` — nunca lê o Artifact Registry.
+6. **`gcloud run jobs update` foi dobrado para dentro do `build-and-push.sh`**, com
+   `--update-env-vars` (não `--set-env-vars`, que apagaria variáveis futuras em silêncio).
+   Build, digest e carimbo passam a sair do mesmo comando e não podem divergir.
+7. **Fail-closed**: carimbo ausente ou ilegível é deriva. Um detector que fica quieto quando
+   não sabe é indistinguível de um detector desligado — o defeito original.
+8. **Sem janela de graça** entre merge e deploy. O modo de falha é "ninguém deploya"; graça é
+   o mecanismo que transforma "nunca" em "ainda não". Falso positivo se apaga sozinho no ciclo
+   seguinte.
+9. **Cadência horária.** O job `dbt-futebol` roda ~96×/dia (odds é `*/15` e chama o job 3× por
+   ciclo): o dano é contínuo, não diário. Horário limita a ~4 execuções ruins.
+10. **O alarme não bloqueia merge.** A deriva só passa a existir *depois* do merge, e reprovar
+    um PR por deriva pré-existente do master puniria o ator errado. O detector agendado falha
+    alto; o e-mail diário carrega o token `[DERIVA]` no assunto como rede de segurança.
+
+## Opções consideradas e rejeitadas
+
+- **Job dbt deployar `--source`, como os 13 serviços Cloud Run.** *Rejeitada.* Era a
+  recomendação inicial, e a medição a derrubou: nos dois incidentes **o deploy aconteceu**,
+  só que antes do último commit — `--source` numa linha teria produzido o mesmo resultado. Os
+  "2 dias" e "6 semanas" são latência de *detecção*, não atrito de *deploy*. Além disso os
+  serviços da NBA, que **são** `--source`, estavam 6 semanas defasados na mesma data. A
+  ergonomia que essa opção comprava veio de graça na decisão 6. **Não re-propor sem primeiro
+  refutar a tabela de margens acima.**
+- **Auto-deploy no merge.** *Rejeitada por ora.* Várias sessões mergeiam no master em
+  paralelo; produção passaria a seguir o master sem ninguém no circuito.
+- **Detector comparando `updateTime` do Artifact Registry com a hora do último commit.**
+  *Rejeitada.* É proxy de timestamp, e margens de 70 segundos e 17 minutos ficam exatamente na
+  resolução em que um proxy desses quebra. O carimbo compara conteúdo com conteúdo.
+- **Checar o `TOTAL` da linha `Done.` da fase de guardas contra um número esperado.**
+  *Rejeitada como detector.* Exige um esperado que apodrece a cada guarda nova; e o carimbo
+  já o subsume — carimbo batendo implica conjunto de tags certo. O `TOTAL` fica no e-mail
+  apenas como contexto descritivo.
+
+## Consequências
+
+- Enquanto um job não for rebuildado com o script novo, ele aparece **vermelho** — é o
+  fail-closed funcionando, não um defeito.
+- O `dbt_nba` **não tem nenhum teste `tag:guarda`** (os 10 são todos do futebol). O carimbo é
+  a única cobertura que a NBA tem contra esta classe.
+- Os serviços Cloud Run do `data-engineering` sofrem da mesma deriva e ainda **não** estão
+  cobertos; o detector já é uma tabela declarativa de alvos para recebê-los.

--- a/scripts/checa_deriva.sh
+++ b/scripts/checa_deriva.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Detector de DERIVA: o que roda em produção é o que está no master?
+#
+# Compara o carimbo de procedência gravado em cada Cloud Run Job com o hash recalculado da
+# árvore local. Divergência = a imagem em produção não corresponde ao código.
+#
+# Uso:
+#   scripts/checa_deriva.sh            # checa todos os alvos
+#   scripts/checa_deriva.sh dbt_nba    # checa um alvo
+#
+# POR QUE ESTE DETECTOR NÃO VIVE NA IMAGEM:
+# a fase de guardas (`dbt test --select tag:guarda`) roda da MESMA imagem que os modelos que
+# ela protege. Imagem velha causa o bug E apaga o detector — a guarda é estruturalmente cega
+# para "a imagem não foi rebuildada". Em 07/08/2026 a fase de guardas do futebol rodou com
+# TOTAL=6 em vez de 13 porque as 7 tags novas estavam no master e não na imagem. Este script
+# roda FORA da imagem, no GitHub Actions, e é o único que enxerga essa classe.
+#
+# Ver docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md
+
+set -uo pipefail
+
+GCP_PROJECT_ID="${GCP_PROJECT_ID:-smartbetting-dados}"
+GCP_REGION="${GCP_REGION:-us-east1}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Tabela declarativa de alvos. Acrescentar um alvo é acrescentar um nome aqui — desde que
+# `scripts/procedencia.sh` conheça as paths dele. Os serviços Cloud Run do repo
+# data-engineering entram por esta mesma porta quando chegarem (ver ADR 0001, Q4).
+if [ $# -gt 0 ]; then
+    ALVOS=("$@")
+else
+    ALVOS=(dbt_futebol dbt_nba)
+fi
+
+derivas=0
+erros=0
+
+for PROJECT_NAME in "${ALVOS[@]}"; do
+    JOB_NAME=$(echo "$PROJECT_NAME" | tr '_' '-')
+    echo "── ${PROJECT_NAME} (job ${JOB_NAME})"
+
+    ESPERADO=$("$SCRIPT_DIR/procedencia.sh" "$PROJECT_NAME") || {
+        echo "   ERRO: nao consegui calcular o hash local de ${PROJECT_NAME}"
+        erros=$((erros + 1))
+        continue
+    }
+
+    # Lê o carimbo direto do job. Só precisa de roles/run.viewer — nunca toca o Artifact
+    # Registry. O carimbo vive no job (e não como LABEL da imagem) porque o que apodrece é
+    # o DIGEST FIXADO NO JOB, não a tag da imagem: é essa a coisa a interrogar.
+    # `--format=json` inteiro, e não `--format="json(caminho)"`: quando o caminho não
+    # resolve, o segundo devolve o literal `null` em vez do esqueleto aninhado, e o parser
+    # quebra. Um detector que acusa deriva porque o próprio parser quebrou é um detector
+    # falso — por isso "erro de leitura" e "carimbo ausente" são casos separados abaixo.
+    JOB_JSON=$(gcloud run jobs describe "$JOB_NAME" \
+        --region="$GCP_REGION" \
+        --project="$GCP_PROJECT_ID" \
+        --format=json 2>&1) || {
+        echo "   ERRO: nao consegui ler o job ${JOB_NAME}:"
+        echo "$JOB_JSON" | sed 's/^/     /'
+        erros=$((erros + 1))
+        continue
+    }
+
+    ENCONTRADO=$(echo "$JOB_JSON" | python3 -c '
+import json, sys
+
+doc = json.load(sys.stdin)          # erro de parse aborta com stacktrace: e erro, nao deriva
+spec = doc["spec"]["template"]["spec"]["template"]["spec"]
+# `env` some do JSON quando o job nao tem nenhuma variavel — que e o estado inicial dos
+# dois jobs. Ausencia da chave e ausencia do carimbo, tratada como deriva pelo chamador.
+for var in spec["containers"][0].get("env") or []:
+    if var.get("name") == "PROCEDENCIA_HASH":
+        print(var.get("value") or "")
+        break
+') || {
+        echo "   ERRO: nao consegui interpretar a resposta do job ${JOB_NAME}"
+        erros=$((erros + 1))
+        continue
+    }
+
+    if [ -z "$ENCONTRADO" ]; then
+        # FAIL-CLOSED. Um detector que fica quieto quando não sabe é indistinguível de um
+        # detector desligado — que é exatamente o defeito que este script existe para
+        # corrigir. Carimbo ausente é deriva até prova em contrário.
+        echo "   ❌ DERIVA: o job nao tem carimbo (PROCEDENCIA_HASH ausente)."
+        echo "      Rode: ./build-and-push.sh ${PROJECT_NAME}"
+        derivas=$((derivas + 1))
+    elif [ "$ENCONTRADO" != "$ESPERADO" ]; then
+        echo "   ❌ DERIVA: a imagem em producao nao corresponde ao codigo."
+        echo "      no job:  ${ENCONTRADO}"
+        echo "      no repo: ${ESPERADO}"
+        echo "      Rode: ./build-and-push.sh ${PROJECT_NAME}"
+        derivas=$((derivas + 1))
+    else
+        echo "   ✅ em dia (${ESPERADO})"
+    fi
+done
+
+echo
+if [ "$derivas" -gt 0 ] || [ "$erros" -gt 0 ]; then
+    echo "RESULTADO: ${derivas} alvo(s) em deriva, ${erros} erro(s) de leitura."
+    echo
+    echo "Deriva significa que producao esta rodando codigo diferente do master — e que a"
+    echo "fase de guardas dbt NAO vai acusar isso, porque ela roda da mesma imagem derivada."
+    exit 1
+fi
+
+echo "RESULTADO: todos os alvos em dia."

--- a/scripts/procedencia.sh
+++ b/scripts/procedencia.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Carimbo de procedência de uma imagem dbt.
+#
+# Imprime um hash único do CONTEÚDO EM DISCO das paths que carregam comportamento de um
+# projeto dbt. O `build-and-push.sh` grava esse hash como env var no Cloud Run Job; o
+# detector (.github/workflows/deriva-imagem.yml) recalcula a mesma coisa num checkout limpo
+# do master e compara. Divergência = deriva: o que roda em produção não é o que está no
+# master.
+#
+# Uso:
+#   scripts/procedencia.sh dbt_futebol
+#   scripts/procedencia.sh dbt_nba --paths     # lista as paths declaradas e sai
+#
+# POR QUE CONTEÚDO EM DISCO, e não `git rev-parse HEAD:<path>`:
+# o `docker build` copia o disco, não o HEAD. Um build com alteração não commitada — ou
+# feito de um `.claude/worktrees/` numa branch, que é como este repo trabalha — carimbaria
+# o hash do master enquanto a imagem carrega outra coisa. O carimbo mentiria na direção
+# perigosa ("está fresco" quando não está). Hasheando o disco, um build sujo simplesmente
+# aparece como deriva até o código ser mergeado, que é a verdade.
+#
+# POR QUE ESTAS PATHS, e não a pasta inteira do projeto:
+# `analyses/`, `docs/` e `CONTEXT.md` vivem dentro do `COPY dbt_futebol/` e portanto mudam
+# a imagem sem mudar o comportamento. Nos 30 dias anteriores a 2026-08-07 houve 116 toques
+# em `models` mas também 28 nessas três — hashear a pasta inteira produziria ~28 alarmes
+# falsos por mês, e um detector que grita por CONTEXT.md é ignorado em duas semanas.
+
+set -euo pipefail
+
+# Ordenação e hash precisam ser idênticos entre o build (macOS) e o detector
+# (ubuntu-latest). Sem LC_ALL=C a collation difere entre os dois, a ordem das linhas muda,
+# o hash combinado muda e o detector fica permanentemente vermelho — parecendo bug
+# misterioso em vez de diferença de locale.
+export LC_ALL=C
+
+PROJECT_NAME="${1:-}"
+
+if [ -z "$PROJECT_NAME" ]; then
+    echo "ERROR: uso: $0 <dbt_futebol|dbt_nba> [--paths]" >&2
+    exit 2
+fi
+
+# Tabela declarativa: projeto -> paths que carregam comportamento.
+# Acrescentar um alvo é acrescentar um ramo aqui (ver Q14 do ADR 0001).
+# `requirements.txt`, `profiles.yml` e o Dockerfile entram porque também vão para a imagem
+# e mudam o que ela faz (versão do dbt, target do BigQuery, etapas do build).
+case "$PROJECT_NAME" in
+    dbt_futebol)
+        PATHS=(
+            dbt_futebol/models
+            dbt_futebol/macros
+            dbt_futebol/tests
+            dbt_futebol/snapshots
+            dbt_futebol/dbt_project.yml
+            dbt_futebol/packages.yml
+            dbt_futebol/package-lock.yml
+            requirements.txt
+            profiles.yml
+            Dockerfile.futebol
+        )
+        ;;
+    dbt_nba)
+        PATHS=(
+            dbt_nba/models
+            dbt_nba/macros
+            dbt_nba/tests
+            dbt_nba/snapshots
+            dbt_nba/seeds
+            dbt_nba/dbt_project.yml
+            dbt_nba/packages.yml
+            dbt_nba/package-lock.yml
+            requirements.txt
+            profiles.yml
+            Dockerfile
+        )
+        ;;
+    *)
+        echo "ERROR: projeto desconhecido: $PROJECT_NAME (esperado dbt_futebol ou dbt_nba)" >&2
+        exit 2
+        ;;
+esac
+
+if [ "${2:-}" = "--paths" ]; then
+    printf '%s\n' "${PATHS[@]}"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Fail-closed no inventário: como cada projeto declara a própria lista (futebol não tem
+# `seeds/`, nba tem), não sobrou caso legítimo de path ausente. Pular em silêncio deixaria
+# um erro de digitação na tabela enfraquecer o detector sem avisar — a mesma lógica do
+# fail-closed do carimbo ausente.
+for p in "${PATHS[@]}"; do
+    if [ ! -e "$p" ]; then
+        echo "ERROR: path declarada para $PROJECT_NAME nao existe: $p" >&2
+        exit 1
+    fi
+done
+
+# `-c` (rastreados) + `-o --exclude-standard` (não rastreados que o .gitignore não cobre):
+# juntos, é exatamente o conjunto que o `docker build` copiaria. Um arquivo de modelo novo
+# ainda não adicionado ao git entra na imagem e precisa entrar no hash.
+#
+# O par `<path> <blob>` — e não só o blob — porque nome de arquivo É comportamento no dbt:
+# o nome do modelo vem do nome do arquivo. Renomear `int_x.sql` para `int_y.sql` sem mudar
+# uma linha muda a tabela materializada, e uma lista de hashes soltos não veria isso.
+{
+    git ls-files -co --exclude-standard -- "${PATHS[@]}" | while IFS= read -r f; do
+        # Arquivo rastreado mas apagado do disco: o `docker build` também não o copiaria.
+        # Omiti-lo faz o hash refletir o disco, que é o invariante deste script.
+        [ -f "$f" ] || continue
+        printf '%s %s\n' "$f" "$(git hash-object "$f")"
+    done
+} | sort | git hash-object --stdin


### PR DESCRIPTION
Fecha a classe de falha descoberta em 07/08: **a guarda dbt viaja na mesma imagem que os modelos que ela protege**, então imagem velha causa o bug *e* apaga o detector.

## A evidência

| pipeline | imagem em produção | commit que ficou fora | margem | tempo fora |
|---|---|---|---|---|
| futebol | 05/08 14:25:16 | 05/08 14:26 (`398b1d2`, fix do de-vig) | **70 segundos** | 2 dias |
| nba | 26/06 18:23:01 | 26/06 18:40 (`2f6263a`, DNP crítico + betting-math) | **17 minutos** | ~6 semanas |

Nos dois casos **o deploy aconteceu** — só que antes do último commit. Os "2 dias" e "6 semanas" são latência de *detecção*, não atrito de *deploy*. No futebol o efeito foi 924 linhas com `competition='unknown'` e a fase de guardas passando com `TOTAL=6` em vez de 13: as 7 tags que pegariam exatamente isso estavam no master e não na imagem.

## O que entra

- **`scripts/procedencia.sh`** — hash do conteúdo **em disco** das paths que carregam comportamento. Disco e não `HEAD:` porque o `docker build` copia o disco; par `<path> <blob>` porque no dbt nome de arquivo é nome de modelo; `LC_ALL=C` porque build (macOS) e detector (ubuntu) precisam ordenar igual.
- **`build-and-push.sh`** — dobra o `gcloud run jobs update` para dentro do script e grava o carimbo no mesmo comando (`--update-env-vars`, não `--set-env-vars`). O job fixa o **digest**: push sem update não muda nada em produção.
- **`scripts/checa_deriva.sh` + `.github/workflows/deriva-imagem.yml`** — detector horário, **fora da imagem**. Fail-closed (carimbo ausente = deriva), sem janela de graça. Horário e não diário porque o `dbt-futebol` roda ~96×/dia.
- **`docs/adr/0001`** — decisões, vocabulário (*procedência* / *deriva*, deliberadamente fora de "guarda") e as alternativas rejeitadas.

## Rejeitado, e por quê

Deployar o job dbt com `--source` como os 13 serviços Cloud Run **era a recomendação inicial** e a medição a derrubou: nos dois incidentes o deploy aconteceu, `--source` numa linha teria dado o mesmo resultado. E os serviços da NBA, que *são* `--source`, estavam 6 semanas defasados na mesma data. Registrado no ADR para não ser re-proposto sem antes refutar a tabela de margens.

## Pré-requisito de infra

`roles/run.viewer` para `github-actions-dbt-docs@` — o detector lê o carimbo do **job** e nunca toca o Artifact Registry.

## Testes

8 testes de propriedade do hash passando: determinismo, sensível a conteúdo de modelo, sensível a rename com conteúdo idêntico, **insensível a `CONTEXT.md`**, sensível a modelo novo não commitado, fail-closed em alvo desconhecido, sem resíduo.

Detector já exercitado ao vivo contra os dois jobs — vermelho nos dois por carimbo ausente, que é o estado real hoje e o fail-closed funcionando como projetado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
