### PR TITLE
feat(futebol): o de-vig emite por janela, com o board inalterado (#37)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -4,6 +4,14 @@ Pre-match value betting for football (Brasileirão-first, plus cups and European
 leagues): a deterministic rules engine rates every fixture x market x outcome with a
 reliability score and explains why.
 
+> ⚠️ **Antes de mudar o grão ou as colunas de qualquer modelo sincronizado para o
+> Postgres, leia `docs/contrato-serving-rpcs.md`.** O `check_schema_parity` do sync
+> responde "o sync sobrevive?", não "os leitores sobrevivem?" — as RPCs
+> `public.get_futebol_*` assumem o grão de várias dessas tabelas, e mudá-lo passa o
+> parity inteiro e ainda entrega dado errado ao app. Isso já custou duas vezes, em
+> 07/08 e 10/08. O documento traz a matriz de quem lê o quê, com o estado de cada
+> ponto de leitura verificado no banco vivo.
+
 ## Language
 
 ### The score engine

--- a/dbt_futebol/analyses/taskA_linha_de_base.sql
+++ b/dbt_futebol/analyses/taskA_linha_de_base.sql
@@ -43,9 +43,14 @@ board AS (
     SELECT fixture_id, escopo FROM fixtures WHERE escopo IS NOT NULL
 ),
 
+{#- REDUZIDO À JANELA CORRENTE (#37): sem isso o funil conta a mesma candidata uma vez
+    por janela e infla em até 4×. É a armadilha que a própria A7 nomeia como a mais
+    importante do seu aceite — "fixar uma janela por candidato ANTES de contar qualquer
+    coisa". Reduzindo aqui, esta linha de base segue comparável com a que produziu o
+    dimensionamento de 50 -> 689 linhas. -#}
 devig AS (
     SELECT *, COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
-    FROM {{ ref('int_futebol_odds_devig') }}
+    FROM ({{ futebol_devig_janela_corrente() }})
 ),
 corro AS (
     SELECT *, COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key

--- a/dbt_futebol/docs/contrato-serving-rpcs.md
+++ b/dbt_futebol/docs/contrato-serving-rpcs.md
@@ -1,0 +1,90 @@
+# O contrato de serving: quem lê as tabelas sincronizadas, e com que suposição de grão
+
+**Levantado em 2026-08-10, lendo as funções do Postgres PRD vivo** (`pg_get_functiondef`), não o
+`prop-play-predictor/docs/futebol-prod-deploy.sql` — aquele arquivo não é migration, é registro, e
+já ficou obsoleto antes.
+
+## Por que este documento existe
+
+O sync BQ→Postgres tem uma verificação de esquema (`check_schema_parity`) que responde uma
+pergunta só: **o sync sobrevive?** Ele compara coluna a coluna e aborta as 21 tabelas se qualquer
+uma divergir.
+
+Ele não responde a pergunta que quebra o produto: **os leitores sobrevivem?** As RPCs
+`public.get_futebol_*` leem essas tabelas e várias assumem o GRÃO delas. Mudar o grão de uma
+tabela sincronizada **passa o parity inteiro e ainda entrega dado errado ao app.**
+
+Isso já custou duas vezes:
+
+| Quando | O quê |
+|---|---|
+| 2026-08-07 | A janela `daily` entra na coleta. O desempate de janela das duas RPCs de odds não a conhece, e `daily` empata com `t24h`. Ninguém notou por 3 dias |
+| 2026-08-10 | A #37 põe a janela no grão do de-vig. `get_futebol_fixture_value` não tem desempate de janela e passa a escolher arbitrariamente os avisos de penalidade. Chegou a produção e foi revertido no mesmo dia |
+
+Duas specs desta fila declararam esta camada verificada quando não estava: a **C1** afirma "a
+aplicação não os consulta" (falso, ver abaixo) e a **C5** não a mencionou.
+
+## A matriz
+
+20 das 22 tabelas da allowlist são lidas por alguma RPC. **`dim_leagues` e
+`fact_value_opportunities_hist` não são lidas por nenhuma** — mudança de grão nelas não alcança o
+app (o `hist` é consumido só por análise).
+
+| Tabela sincronizada | RPCs que leem | Suposição de grão | Estado |
+|---|---|---|---|
+| `fact_fixtures` | 9 (incl. `_futebol_team_form`) | 1 linha por `fixture_id` | ✅ |
+| `dim_teams` | 4 | `get_futebol_teams` faz `distinct on (team_id)` **sem desempate** | ✅ inofensivo — a tabela é única por `team_id` (591/591 medido) |
+| `fact_odds_snapshot` | 2 | `distinct on (…, bookmaker_name)` com desempate por janela | ⛔ **DEFEITO VIVO** — ver abaixo |
+| `fact_value_opportunities` | 2 | 1 linha por (fixture, market, outcome, line) | ✅ hoje; ⚠️ #40/#41/A1 mexem nas COLUNAS |
+| `int_futebol_odds_devig` | 1 (`get_futebol_fixture_value`) | `distinct on (fixture_id, outcome_side, line_value)` **sem desempate** | ⛔ bloqueia a #37 |
+| `fact_fixture_lineups` + `_players` | 1 (`get_futebol_fixture_extras`) | `jsonb_agg` de TODAS as linhas do fixture, sem filtro de fase | ⛔ bloqueia a #38 |
+| `fact_injuries_snapshot` | 1 | `distinct on (player_id)` + `order by snapshot_date desc` | ✅ desempate correto e semântico |
+| 5 × `int_futebol_premissas_*` | 2 cada | join por (fixture, outcome[, line]) | ✅ hoje; ⚠️ #41 pode adicionar coluna |
+| `fact_h2h`, `fact_predictions_api`, `fact_standings_snapshot`, `fact_team_season_stats`, `fact_fixture_stats`, `fact_fixture_events`, `fact_fixture_player_stats` | 1–2 cada | leitura direta, sem suposição de unicidade além da chave natural | ✅ |
+| `dim_leagues`, `fact_value_opportunities_hist` | **nenhuma** | — | ✅ fora do alcance do app |
+
+## ⛔ Defeito vivo: o desempate de janela das RPCs de odds não conhece a `daily`
+
+`get_futebol_fixture_odds` e `get_futebol_odds_board` escolhem a janela corrente assim:
+
+```sql
+case when collection_window = 't15m' then 3
+     when collection_window = 't1h'  then 2
+     else 1 end
+```
+
+**`t24h` e `daily` caem os dois no `else 1` e empatam.** Com empate, o `DISTINCT ON` do Postgres
+resolve arbitrariamente — e pode virar entre chamadas, sem nenhuma mudança de dado.
+
+Medido em 2026-08-10 no PRD: **27.066 chaves (fixture, casa, mercado, saída) empatadas, em 25
+fixtures** — as que já têm `daily` e `t24h` e ainda não têm `t1h`/`t15m`. Para elas, a tela de odds
+e o board de odds podem exibir uma odd de até 7 dias atrás em vez da de 24h.
+
+**Não foi causado pela #37.** Nasceu em 07/08 com `tech-lamjav/data-engineering#34`, quando a
+`daily` entrou na coleta e este `CASE` não acompanhou. É o mesmo formato do defeito da #37, três
+dias mais velho.
+
+Conserto: acrescentar `when collection_window = 't24h' then 2` deslocando os demais, ou melhor,
+derivar a prioridade de um lugar só. No dbt esse lugar já existe — o macro
+`futebol_janela_prioridade` — mas ele não atravessa para o Postgres, então aqui é duplicação
+inevitável e o que resta é **manter as duas listas juntas na mesma mudança**.
+
+## A regra que vale daqui pra frente
+
+Antes de mudar **grão** ou **colunas** de qualquer tabela da allowlist:
+
+1. `SELECT p.proname, pg_get_functiondef(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname LIKE '%futebol%'` — no banco vivo.
+2. Procure `distinct on`, `jsonb_agg`/`array_agg`, `limit 1` e joins por subconjunto da chave. São as quatro impressões digitais de "assumo uma linha por chave".
+3. **Coluna nova ou removida** → migration no Postgres ANTES do deploy da imagem, senão o parity aborta as 21 tabelas. Coluna que a RPC declara no `RETURNS TABLE` exige `DROP FUNCTION` e recriar (Postgres não faz `CREATE OR REPLACE` mudando assinatura).
+4. **Tabela nova** → ignorada pelo sync (a allowlist é explícita), então é livre.
+
+## O que isto diz sobre o trabalho na fila
+
+| Ticket | O que faz | Consequência nesta camada |
+|---|---|---|
+| **#37** (C5) | Janela no grão do de-vig | Precisa de desempate por `janela_usada` em `get_futebol_fixture_value` |
+| **#38** (C1) | Duas fases da escalação coexistem | `get_futebol_fixture_extras` duplicaria cada time e cada jogador; a projeção nem expõe `lineup_phase`. `lineup_phase` **já é coluna** nos dois fatos, então não há drift de esquema — só de grão |
+| **#40** (C5b) | Coluna `janela_deteccao` no mart | Coluna nova → migration antes do deploy |
+| **#41** (C3b) | Contador de premissas sem dado | Coluna nova → migration antes do deploy |
+| **A1** | Remove `pts_valor`/`pts_corroboracao`/`penalidades` do mart | Colunas removidas **e** declaradas no `RETURNS TABLE` das duas RPCs → `DROP FUNCTION` + recriar |
+| **A7** | Tabela nova de funil | Livre — fora da allowlist |

--- a/dbt_futebol/macros/devig_janela.sql
+++ b/dbt_futebol/macros/devig_janela.sql
@@ -13,9 +13,17 @@
   `ELSE 0` põe janela desconhecida ABAIXO de todas as conhecidas em vez de NULL: com
   NULL, uma linha cuja única janela fosse desconhecida teria MAX(prioridade) NULL, a
   comparação daria NULL e a linha desapareceria em silêncio — que é exatamente o modo
-  de falha que este repositório passa o tempo consertando. O ponto cego que sobra
-  (duas janelas desconhecidas empatando e abrindo fan-out) é coberto pelo
-  accepted_values de `janela_usada`, que fica vermelho antes disso acontecer.
+  de falha que este repositório passa o tempo consertando.
+
+  ⚠️ O ponto cego que SOBRA: duas janelas desconhecidas empatam no MAX e abrem fan-out.
+  O accepted_values de `janela_usada` reporta isso, mas **não previne** — e a diferença
+  importa. No `workflow_futebol.yml` a fase de `dbt run` é a 2 e a de `dbt test
+  --select tag:guarda` é a 4, sem gate (de propósito, para teste vermelho não derrubar
+  o board nem o sync). Ou seja: o fan-out seria construído, publicado e sincronizado, e
+  só depois o resumo diário reportaria. A guarda encurta o tempo até alguém saber; ela
+  não impede a linha duplicada de chegar ao board. Quem previne de verdade é o
+  accepted_values do MODELO A MONTANTE (`fact_odds_snapshot.collection_window`), porque
+  janela nova só existe aqui se antes existir lá.
 -#}
 {% macro futebol_janela_prioridade(coluna) -%}
     CASE {{ coluna }}

--- a/dbt_futebol/macros/devig_janela.sql
+++ b/dbt_futebol/macros/devig_janela.sql
@@ -1,0 +1,58 @@
+{#-
+  A ORDEM DAS JANELAS DE COLETA, declarada num lugar só (issue #37, ADR 0004).
+
+  Da mais cedo para a mais tarde: `daily` (até 7 dias do apito) < t24h < t1h < t15m.
+  Depois da #37 o de-vig emite uma avaliação POR JANELA e não escolhe nenhuma; quem
+  escolhe é o consumidor, e é esta ordem que ele usa.
+
+  ⚠️ São QUATRO janelas, não três. A `daily` entrou em produção em 07/08/2026
+  (`tech-lamjav/data-engineering#34`, horizonte de 7 dias) e o board já publica nela.
+  Qualquer coisa que assuma três janelas está desatualizada — a ADR 0004 rejeitou
+  "uma coluna por janela" justamente para que acrescentar a quinta não custe schema.
+
+  `ELSE 0` põe janela desconhecida ABAIXO de todas as conhecidas em vez de NULL: com
+  NULL, uma linha cuja única janela fosse desconhecida teria MAX(prioridade) NULL, a
+  comparação daria NULL e a linha desapareceria em silêncio — que é exatamente o modo
+  de falha que este repositório passa o tempo consertando. O ponto cego que sobra
+  (duas janelas desconhecidas empatando e abrindo fan-out) é coberto pelo
+  accepted_values de `janela_usada`, que fica vermelho antes disso acontecer.
+-#}
+{% macro futebol_janela_prioridade(coluna) -%}
+    CASE {{ coluna }}
+        WHEN 't15m'  THEN 4   -- fechamento
+        WHEN 't1h'   THEN 3
+        WHEN 't24h'  THEN 2
+        WHEN 'daily' THEN 1   -- varredura diária, até 7 dias do apito
+        ELSE 0
+    END
+{%- endmacro %}
+
+
+{#-
+  O DE-VIG REDUZIDO À JANELA CORRENTE — a forma como todo consumidor lê o de-vig.
+
+  O de-vig emite N linhas por (fixture, mercado, saída, linha), uma por janela
+  coletada. Consumidor que fizer join direto abre N vezes: o mart triplicaria (hoje
+  quadruplicaria) em silêncio, com a mesma oportunidade contada uma vez por janela.
+  Por isso a redução é um macro e não SQL copiado: a regra existe num lugar só, e
+  consumidor novo herda a redução em vez de redescobrir o problema.
+
+  A partição é (fixture, mercado, LINHA) e deliberadamente NÃO inclui a saída. A
+  linha inteira resolve para a MESMA janela, porque o de-vig normaliza sobre o
+  conjunto de saídas: se o Home viesse da t15m e o Away da t1h, o Σ(1/odd) somaria
+  preços de momentos diferentes. É a mesma partição que o `eval_odds` usava antes
+  da #37, e é o que faz a saída do mart sair idêntica à de antes da mudança de grão.
+-#}
+{% macro futebol_devig_janela_corrente() -%}
+    SELECT d.* EXCEPT (_janela_prioridade, _line_key)
+    FROM (
+        SELECT
+            *,
+            {{ futebol_janela_prioridade('janela_usada') }} AS _janela_prioridade,
+            COALESCE(CAST(line_value AS STRING), 'NONE')    AS _line_key
+        FROM {{ ref('int_futebol_odds_devig') }}
+    ) d
+    QUALIFY d._janela_prioridade = MAX(d._janela_prioridade) OVER (
+        PARTITION BY d.fixture_id, d.market_id, d._line_key
+    )
+{%- endmacro %}

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -229,7 +229,18 @@ odds AS (
         -- Mantido também para que a próxima análise VEJA que esta exclusão existe, em vez
         -- de herdá-la em silêncio.
         COALESCE(n_outcomes_valor < 2, TRUE) AS conjunto_incompleto
-    FROM {{ ref('int_futebol_odds_devig') }}
+    {#- ⚠️ REDUZIDO À JANELA CORRENTE (#37). O de-vig passou a emitir uma avaliação por
+        janela coletada; ler sem reduzir faria cada aposta entrar no backtest até 4 vezes,
+        uma por preço, todas liquidadas pelo mesmo placar. É EXATAMENTE o erro que a ADR
+        0001 e a ADR 0004 existem para impedir: o ROI esperado não se move e o intervalo de
+        confiança encolhe por √n sem entrar informação nenhuma — amostra falsa.
+
+        A redução reproduz byte-a-byte a base de antes da #37, porque a janela que ela
+        escolhe é a mesma que o de-vig escolhia sozinho. Quem quiser a base por janela —
+        a pergunta de CLV que a #37 destrava, "o edge de abertura prevê melhor que o de
+        fechamento?" — tem que optar por ela DELIBERADAMENTE, lendo o modelo direto e
+        declarando o que faz com a dependência entre as janelas da mesma aposta. -#}
+    FROM ({{ futebol_devig_janela_corrente() }})
 ),
 
 {#- Premissas em formato longo: uma linha por (aposta, premissa).

--- a/dbt_futebol/models/intermediate/_int_futebol__models.yml
+++ b/dbt_futebol/models/intermediate/_int_futebol__models.yml
@@ -4,9 +4,13 @@ models:
   - name: int_futebol_odds_devig
     description: >
       Fase 0 do Motor de Score — núcleo de VALOR (agnóstico de mercado). De-vig market-aware
-      da Pinnacle (bookmaker_id=4) na janela de fechamento (t15m>t1h>t24h) + edge + PTS_VALOR
-      (0-30) + best/avg/n_casas + penalidades globais + linha_sharp. 1 linha por (fixture_id,
-      market_id, outcome_side, line_value). DUPLA CHANCE (S5, market 12): a Pinnacle não precifica
+      da Pinnacle (bookmaker_id=4) + edge + PTS_VALOR (0-30) + best/avg/n_casas + penalidades
+      globais + linha_sharp. 1 linha por (fixture_id, market_id, outcome_side, line_value,
+      JANELA) desde a #37: cada janela coletada (daily/t24h/t1h/t15m) recebe a sua própria
+      avaliação, calculada só com as odds daquela janela, e o modelo NÃO escolhe janela —
+      quem escolhe é o consumidor, pelo macro futebol_devig_janela_corrente(). Exceção:
+      linha_sharp_confirma é medido sobre o conjunto completo de janelas (t24h->t15m), então
+      é propriedade da linha e vem igual em todas as janelas dela. Ver ADR 0004. DUPLA CHANCE (S5, market 12): a Pinnacle não precifica
       DC e as 3 saídas (1X/12/X2) NÃO são exaustivas (somam ~2) -> a prob_justa é DERIVADA do
       de-vig 1X2 da Pinnacle (dc_devig: P(1X)=P(Home)+P(Draw) etc.), valor_fonte=pinnacle,
       n_outcomes_valor=3. pinnacle_eval E consensus_devig EXCLUEM o market 12 (cai sempre no
@@ -36,8 +40,24 @@ models:
         description: "Casas distintas na janela (COUNT DISTINCT bookmaker_id)."
         tests: [not_null]
       - name: janela_usada
-        description: "Janela de avaliação efetiva (t15m>t1h>t24h, a mais recente disponível)."
-        tests: [not_null]
+        description: >
+          Janela de coleta desta avaliação, e parte do GRÃO desde a #37. O modelo emite uma
+          linha por janela coletada e NÃO escolhe nenhuma; quem escolhe é o consumidor, pelo
+          macro futebol_devig_janela_corrente(). São QUATRO janelas: daily (até 7 dias do
+          apito, em produção desde 07/08) < t24h < t1h < t15m.
+        tests:
+          - not_null
+          # A ordem das janelas vive no macro futebol_janela_prioridade, e janela fora da
+          # lista cai no ELSE 0 dele. Uma só desconhecida é inofensiva (fica abaixo das
+          # conhecidas); DUAS empatariam no MAX e abririam fan-out no consumidor, com a
+          # oportunidade publicada em duplicidade. Esta guarda fica vermelha primeiro —
+          # é a contrapartida de o ELSE não ser NULL.
+          - accepted_values:
+              arguments:
+                values: ['daily', 't24h', 't1h', 't15m']
+              config:
+                severity: error
+                tags: ['guarda']
       - name: valor_fonte
         description: "Fonte do de-vig: 'pinnacle' (1X2/O/U/AH + DC derivada) | 'consenso' (BTTS/HT-FT) | NULL (sem de-vig)."
         tests:
@@ -94,13 +114,26 @@ models:
       - name: pts_valor
         description: "0-30; NULL quando não há de-vig (Pinnacle ausente/incompleto)."
     tests:
+      # GRÃO NOVO (#37, ADR 0004): a janela entra na chave. Sem `janela_usada` aqui, o
+      # próprio efeito pretendido da mudança (N linhas por linha coletada) deixaria esta
+      # guarda permanentemente vermelha, e guarda sempre vermelha morre ignorada.
+      #
+      # TAG `guarda` de propósito: a versão anterior não tinha tag nenhuma, então nunca
+      # rodou no agendado — só no laptop de quem lembrasse. Fan-out acidental de grão é
+      # exatamente o modo de falha que infla número em silêncio, e o que faz este teste
+      # valer alguma coisa é ele rodar em produção.
       - dbt_utils.unique_combination_of_columns:
+          name: assert_devig_grao_por_janela
           arguments:
             combination_of_columns:
               - fixture_id
               - market_id
               - outcome_side
               - line_value
+              - janela_usada
+          config:
+            severity: error
+            tags: ['guarda']
 
   - name: int_futebol_corroboracao
     description: >
@@ -466,3 +499,83 @@ unit_tests:
         - {fixture_id: 6, market_id: 4,  outcome_side: 'Home',  n_outcomes_valor: 1, valor_fonte: null,       prob_justa_fechamento: null, edge: null}
         - {fixture_id: 7, market_id: 4,  outcome_side: 'Home',  n_outcomes_valor: 2, valor_fonte: 'pinnacle', prob_justa_fechamento: 0.5,  edge: 0.0}
         - {fixture_id: 7, market_id: 4,  outcome_side: 'Away',  n_outcomes_valor: 2, valor_fonte: 'pinnacle', prob_justa_fechamento: 0.5,  edge: 0.0}
+
+  # ==========================================================================
+  # UNIT TESTS — a JANELA entra no grão (issue #37, ADR 0004)
+  #
+  # Por que unit test e não data test: em produção o de-vig emitia UMA janela por
+  # linha, então "cada janela tem os seus agregados" não tinha nenhuma linha onde
+  # ser falsificado. Data test sobre produção ficaria verde por vacuidade — o
+  # mesmo motivo registrado no unit test da #22, acima.
+  #
+  # As odds são simétricas e potências de 2 (2/4/8/16) de propósito: a prob justa
+  # sai exatamente 0,5 em todas as janelas, então a única coisa que varia entre
+  # elas é o PREÇO — e é isso que a asserção precisa isolar. Odd assimétrica daria
+  # 1/3 e a asserção passaria a depender de arredondamento.
+  # ==========================================================================
+  - name: a_janela_entra_no_grao_e_os_agregados_nao_vazam
+    model: int_futebol_odds_devig
+    description: >
+      Linha com N janelas coletadas produz N linhas, cada uma com os agregados e o
+      valor calculados só com as odds daquela janela. O fixture 1 usa QUATRO janelas
+      (inclusive a `daily`, que entrou em produção em 07/08) — o número de janelas não
+      é 3 e o modelo não pode assumir que seja. O fixture 2 cobre a convivência entre
+      uma janela de conjunto incompleto, que não emite valor, e uma completa, que segue
+      emitindo normalmente.
+    given:
+      - input: ref('fact_odds_snapshot')
+        rows:
+          # (1) Mesma linha, quatro janelas, preço subindo. prob = 0,5 em todas;
+          #     best_odd / edge / pts_valor / pen_odd_longshot mudam por janela.
+          #     A t15m tem 2 casas -> n_casas também é por janela.
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 'daily', odd_decimal: 16.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 'daily', odd_decimal: 16.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't24h',  odd_decimal: 2.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't24h',  odd_decimal: 2.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't1h',   odd_decimal: 4.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't1h',   odd_decimal: 4.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't15m',  odd_decimal: 8.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 8, bookmaker_name: 'Bet365', collection_window: 't15m',  odd_decimal: 8.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't15m',  odd_decimal: 8.0}
+          - {fixture_id: 1, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 8, bookmaker_name: 'Bet365', collection_window: 't15m',  odd_decimal: 8.0}
+
+          # (2) t24h com o par completo, t15m com só o Over. Antes desta mudança a
+          #     t15m ganhava o QUALIFY e a avaliação completa da t24h desaparecia:
+          #     a linha inteira virava "não emite". Agora as duas coexistem.
+          - {fixture_id: 2, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't24h',  odd_decimal: 2.0}
+          - {fixture_id: 2, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't24h',  odd_decimal: 2.0}
+          - {fixture_id: 2, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 6, bookmaker_name: 'Bwin',   collection_window: 't15m',  odd_decimal: 2.0}
+    expect:
+      rows:
+        - {fixture_id: 1, outcome_side: 'Over',  janela_usada: 'daily', best_odd: 16.0, n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 7.0, pts_valor: 30, pen_odd_longshot: true}
+        - {fixture_id: 1, outcome_side: 'Under', janela_usada: 'daily', best_odd: 16.0, n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 7.0, pts_valor: 30, pen_odd_longshot: true}
+        - {fixture_id: 1, outcome_side: 'Over',  janela_usada: 't24h',  best_odd: 2.0,  n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 0.0, pts_valor: 0,  pen_odd_longshot: false}
+        - {fixture_id: 1, outcome_side: 'Under', janela_usada: 't24h',  best_odd: 2.0,  n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 0.0, pts_valor: 0,  pen_odd_longshot: false}
+        - {fixture_id: 1, outcome_side: 'Over',  janela_usada: 't1h',   best_odd: 4.0,  n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 1.0, pts_valor: 30, pen_odd_longshot: false}
+        - {fixture_id: 1, outcome_side: 'Under', janela_usada: 't1h',   best_odd: 4.0,  n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 1.0, pts_valor: 30, pen_odd_longshot: false}
+        - {fixture_id: 1, outcome_side: 'Over',  janela_usada: 't15m',  best_odd: 8.0,  n_casas: 2, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 3.0, pts_valor: 30, pen_odd_longshot: true}
+        - {fixture_id: 1, outcome_side: 'Under', janela_usada: 't15m',  best_odd: 8.0,  n_casas: 2, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 3.0, pts_valor: 30, pen_odd_longshot: true}
+        - {fixture_id: 2, outcome_side: 'Over',  janela_usada: 't24h',  best_odd: 2.0,  n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 0.0, pts_valor: 0,  pen_odd_longshot: false}
+        - {fixture_id: 2, outcome_side: 'Under', janela_usada: 't24h',  best_odd: 2.0,  n_casas: 1, n_outcomes_valor: 2, valor_fonte: 'consenso', prob_justa_fechamento: 0.5, edge: 0.0, pts_valor: 0,  pen_odd_longshot: false}
+        - {fixture_id: 2, outcome_side: 'Over',  janela_usada: 't15m',  best_odd: 2.0,  n_casas: 1, n_outcomes_valor: 1, valor_fonte: null,       prob_justa_fechamento: null, edge: null, pts_valor: null, pen_odd_longshot: false}
+
+  - name: o_sinal_sharp_e_invariante_entre_janelas
+    model: int_futebol_odds_devig
+    description: >
+      linha_sharp_confirma é propriedade da LINHA (movimento da Pinnacle t24h->t15m),
+      não da janela: a mesma linha carrega o mesmo sinal em todas as suas janelas. O
+      Over cai de 2,0 para 1,5 (sinal verdadeiro nas duas janelas) e o Under sobe de
+      2,0 para 3,0 (falso nas duas) — o sinal separa por LADO, nunca por janela.
+    given:
+      - input: ref('fact_odds_snapshot')
+        rows:
+          - {fixture_id: 3, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 4, bookmaker_name: 'Pinnacle', collection_window: 't24h', odd_decimal: 2.0}
+          - {fixture_id: 3, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 4, bookmaker_name: 'Pinnacle', collection_window: 't24h', odd_decimal: 2.0}
+          - {fixture_id: 3, market_id: 5, outcome_side: 'Over',  line_value: 2.5, bookmaker_id: 4, bookmaker_name: 'Pinnacle', collection_window: 't15m', odd_decimal: 1.5}
+          - {fixture_id: 3, market_id: 5, outcome_side: 'Under', line_value: 2.5, bookmaker_id: 4, bookmaker_name: 'Pinnacle', collection_window: 't15m', odd_decimal: 3.0}
+    expect:
+      rows:
+        - {fixture_id: 3, outcome_side: 'Over',  janela_usada: 't24h', linha_sharp_confirma: true}
+        - {fixture_id: 3, outcome_side: 'Over',  janela_usada: 't15m', linha_sharp_confirma: true}
+        - {fixture_id: 3, outcome_side: 'Under', janela_usada: 't24h', linha_sharp_confirma: false}
+        - {fixture_id: 3, outcome_side: 'Under', janela_usada: 't15m', linha_sharp_confirma: false}

--- a/dbt_futebol/models/intermediate/_int_futebol__models.yml
+++ b/dbt_futebol/models/intermediate/_int_futebol__models.yml
@@ -50,8 +50,11 @@ models:
           # A ordem das janelas vive no macro futebol_janela_prioridade, e janela fora da
           # lista cai no ELSE 0 dele. Uma só desconhecida é inofensiva (fica abaixo das
           # conhecidas); DUAS empatariam no MAX e abririam fan-out no consumidor, com a
-          # oportunidade publicada em duplicidade. Esta guarda fica vermelha primeiro —
-          # é a contrapartida de o ELSE não ser NULL.
+          # oportunidade publicada em duplicidade.
+          # ⚠️ Esta guarda REPORTA o empate, não o previne: no agendado o `dbt run` é a
+          # fase 2 e o `dbt test --select tag:guarda` é a 4, sem gate — a linha duplicada
+          # chega ao board e ao sync antes de qualquer teste rodar. Prevenção de verdade
+          # está no accepted_values de fact_odds_snapshot.collection_window, a montante.
           - accepted_values:
               arguments:
                 values: ['daily', 't24h', 't1h', 't15m']

--- a/dbt_futebol/models/intermediate/int_futebol_corroboracao.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_corroboracao.sql
@@ -3,9 +3,14 @@
     description='Fase 0 do Motor de Score — CORROBORAÇÃO externa (0-15), por (fixture_id, market_id, outcome_side, line_value). modelo_api_concorda (+7): o /predictions da própria API aponta o mesmo lado (hoje só implementado p/ 1X2; predictions ~vazio até a S6 coletar fixtures futuros -> majoritariamente FALSE, graceful). linha_sharp_confirma (+8): reusa o sinal já calculado no int_futebol_odds_devig (Pinnacle caiu t24h->t15m).'
 ) }}
 
+-- Reduzido à janela corrente (#37): o de-vig emite uma linha por janela, e sem a
+-- redução este modelo abriria uma linha de corroboração por janela — quebrando o
+-- próprio grão e, por tabela, o do mart. linha_sharp_confirma é invariante entre
+-- janelas (é movimento t24h->t15m da linha), então a redução não escolhe valor:
+-- só escolhe quantas vezes o mesmo valor aparece.
 WITH devig AS (
     SELECT fixture_id, market_id, outcome_side, line_value, linha_sharp_confirma
-    FROM {{ ref('int_futebol_odds_devig') }}
+    FROM ({{ futebol_devig_janela_corrente() }})
 ),
 
 preds AS (

--- a/dbt_futebol/models/intermediate/int_futebol_odds_devig.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_odds_devig.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='Fase 0 do Motor de Score — núcleo de VALOR (agnóstico de mercado). 1 linha por (fixture_id, market_id, outcome_side, line_value). Calcula, na janela de FECHAMENTO mais recente disponível (t15m>t1h>t24h): best_odd/avg_odd/n_casas entre TODAS as casas, o de-vig market-aware da Pinnacle (bookmaker_id=4) sobre o conjunto de outcomes do mercado, o edge e o PTS_VALOR (0-30), as 4 penalidades globais e o sinal linha_sharp (movimento Pinnacle t24h->t15m). NÃO aplica o gate (isso é no mart). De-vig correto p/ mercados exaustivos por (market,line): 1X2(3)/O/U(2)/BTTS(2)/Asian Handicap(4, 2). FALLBACK DE CONSENSO (S4, 2026-06-25): a Pinnacle NÃO precifica BTTS(8)/HT-FT(7)/Dupla Chance(12) — confirmado 0 fixtures. Nesses casos prob_justa_fechamento/booksum_fechamento/edge/PTS_VALOR caem na MEDIANA das casas (med_odd, de-vig de consenso), marcado por valor_fonte=consenso (vs pinnacle); n_outcomes_valor=COALESCE(pin_n_outcomes,cons_n_outcomes) p/ o ramo BTTS gatear. O COALESCE preserva 1X2/O/U/AH (Pinnacle presente -> usa Pinnacle). Consenso carrega a margem das casas -> rotular como estimativa no front. ✅ Confirmado 2026-06-24 (S3): no AH a API-Football traz line_value na ÓTICA DO MANDANTE, IGUAL p/ Home e Away — logo "Home -1.5"/"Away -1.5" são o par complementar e já caem na MESMA partição (fixture, market, line_key), de-vig soma ~1.03 com pin_n_outcomes=2 (sem pareamento extra). ✅ Double Chance(12) RESOLVIDO (S5, 2026-06-26): a Pinnacle não precifica DC, mas as 3 saídas (1X/12/X2) NÃO são exaustivas (somam ~2) — logo o consenso quebraria. Em vez disso a prob_justa da DC é DERIVADA do de-vig 1X2 da Pinnacle (P(1X)=P(Home)+P(Draw), P(12)=P(Home)+P(Away), P(X2)=P(Draw)+P(Away)) via dc_devig; valor_fonte=pinnacle (âncora sharp), n_outcomes_valor=3 (gate = conjunto 1X2 completo). TANTO o consenso QUANTO o de-vig da Pinnacle excluem o market 12 (a DC cai sempre no dc_devig derivado do 1X2, mesmo se a Pinnacle passar a precificá-lo). NOTA: a coluna booksum_fechamento é a SOMA Σ(1/odd) (=1+margem), NÃO a margem (margem = booksum_fechamento − 1). ⚠️ REGRA DE EMISSÃO (spec #22, 2026-08-05): o de-vig só emite valor quando o CONJUNTO DE SAÍDAS usado bate EXATAMENTE com o declarado em futebol_conjunto_saidas() (1:3, 4:2, 5:2, 6:2, 8:2, 12:3 — a entrada 12 é o conjunto 1X2 DE ORIGEM, não as 3 saídas da DC). Conjunto incompleto não gera estimativa pior, gera AUSÊNCIA de estimativa: prob_justa/booksum/edge/pts_valor/valor_fonte viram NULL e a linha sai da base de valor; n_outcomes_valor PERMANECE REAL (diagnóstico + tração da guarda). Antes disso, 403 linhas normalizavam sobre UMA saída e devolviam prob=1,0 e edge=odd−1 (odd 150 -> +14.900%), com 2 vitórias em 172 no recorte liquidado. A regra é escrita UMA VEZ na projeção final, sobre a coluna já consolidada -> cobre Pinnacle, DC derivada e consenso de uma vez (a Pinnacle nunca teve essa guarda). Mercado não declarado NÃO emite (fail-closed); o ponto cego disso é coberto por assert_devig_conjunto_declarado. Ver docs/adr/0002-conjunto-de-saidas-declarado-por-mercado.md.'
+    description='Fase 0 do Motor de Score — núcleo de VALOR (agnóstico de mercado). ⚠️ GRÃO (#37, ADR 0004): 1 linha por (fixture_id, market_id, outcome_side, line_value, JANELA) — cada janela coletada recebe a sua avaliação e o modelo NÃO escolhe janela; quem escolhe é o consumidor, pelo macro futebol_devig_janela_corrente(). São QUATRO janelas (daily<t24h<t1h<t15m), não três: a daily entrou em 07/08/2026. Calcula, DENTRO DE CADA JANELA, sem vazar de uma para outra: best_odd/avg_odd/n_casas entre TODAS as casas, o de-vig market-aware da Pinnacle (bookmaker_id=4) sobre o conjunto de outcomes do mercado, o edge e o PTS_VALOR (0-30), as 4 penalidades globais e o sinal linha_sharp (movimento Pinnacle t24h->t15m). NÃO aplica o gate (isso é no mart). De-vig correto p/ mercados exaustivos por (market,line): 1X2(3)/O/U(2)/BTTS(2)/Asian Handicap(4, 2). FALLBACK DE CONSENSO (S4, 2026-06-25): a Pinnacle NÃO precifica BTTS(8)/HT-FT(7)/Dupla Chance(12) — confirmado 0 fixtures. Nesses casos prob_justa_fechamento/booksum_fechamento/edge/PTS_VALOR caem na MEDIANA das casas (med_odd, de-vig de consenso), marcado por valor_fonte=consenso (vs pinnacle); n_outcomes_valor=COALESCE(pin_n_outcomes,cons_n_outcomes) p/ o ramo BTTS gatear. O COALESCE preserva 1X2/O/U/AH (Pinnacle presente -> usa Pinnacle). Consenso carrega a margem das casas -> rotular como estimativa no front. ✅ Confirmado 2026-06-24 (S3): no AH a API-Football traz line_value na ÓTICA DO MANDANTE, IGUAL p/ Home e Away — logo "Home -1.5"/"Away -1.5" são o par complementar e já caem na MESMA partição (fixture, market, line_key), de-vig soma ~1.03 com pin_n_outcomes=2 (sem pareamento extra). ✅ Double Chance(12) RESOLVIDO (S5, 2026-06-26): a Pinnacle não precifica DC, mas as 3 saídas (1X/12/X2) NÃO são exaustivas (somam ~2) — logo o consenso quebraria. Em vez disso a prob_justa da DC é DERIVADA do de-vig 1X2 da Pinnacle (P(1X)=P(Home)+P(Draw), P(12)=P(Home)+P(Away), P(X2)=P(Draw)+P(Away)) via dc_devig; valor_fonte=pinnacle (âncora sharp), n_outcomes_valor=3 (gate = conjunto 1X2 completo). TANTO o consenso QUANTO o de-vig da Pinnacle excluem o market 12 (a DC cai sempre no dc_devig derivado do 1X2, mesmo se a Pinnacle passar a precificá-lo). NOTA: a coluna booksum_fechamento é a SOMA Σ(1/odd) (=1+margem), NÃO a margem (margem = booksum_fechamento − 1). ⚠️ REGRA DE EMISSÃO (spec #22, 2026-08-05): o de-vig só emite valor quando o CONJUNTO DE SAÍDAS usado bate EXATAMENTE com o declarado em futebol_conjunto_saidas() (1:3, 4:2, 5:2, 6:2, 8:2, 12:3 — a entrada 12 é o conjunto 1X2 DE ORIGEM, não as 3 saídas da DC). Conjunto incompleto não gera estimativa pior, gera AUSÊNCIA de estimativa: prob_justa/booksum/edge/pts_valor/valor_fonte viram NULL e a linha sai da base de valor; n_outcomes_valor PERMANECE REAL (diagnóstico + tração da guarda). Antes disso, 403 linhas normalizavam sobre UMA saída e devolviam prob=1,0 e edge=odd−1 (odd 150 -> +14.900%), com 2 vitórias em 172 no recorte liquidado. A regra é escrita UMA VEZ na projeção final, sobre a coluna já consolidada -> cobre Pinnacle, DC derivada e consenso de uma vez (a Pinnacle nunca teve essa guarda). Mercado não declarado NÃO emite (fail-closed); o ponto cego disso é coberto por assert_devig_conjunto_declarado. Ver docs/adr/0002-conjunto-de-saidas-declarado-por-mercado.md.'
 ) }}
 
 WITH odds AS (
@@ -16,29 +16,18 @@ WITH odds AS (
         bookmaker_id,
         bookmaker_name,
         collection_window,
-        odd_decimal,
-        CASE collection_window
-            WHEN 't15m' THEN 3   -- fechamento (preferido)
-            WHEN 't1h'  THEN 2
-            WHEN 't24h' THEN 1
-            ELSE 0
-        END AS window_priority
+        odd_decimal
     FROM {{ ref('fact_odds_snapshot') }}
     -- descarta Exact Score (10) e labels sem lado pareável
     WHERE outcome_side IS NOT NULL
 ),
 
--- Janela de avaliação por (fixture, market, linha): a mais recente disponível.
--- Tudo abaixo (best_odd, n_casas, devig) é calculado NESSA mesma janela.
-eval_odds AS (
-    SELECT *
-    FROM odds
-    QUALIFY window_priority = MAX(window_priority) OVER (
-        PARTITION BY fixture_id, market_id, line_key
-    )
-),
-
--- Agregados por outcome (todas as casas na janela de avaliação).
+-- Agregados por outcome DENTRO DE CADA JANELA (todas as casas daquela janela).
+-- A janela entra no GROUP BY, então nenhum agregado mistura janelas (ADR 0004).
+-- Antes da #37 havia aqui um `eval_odds` que resolvia a linha para a janela mais
+-- recente via QUALIFY e descartava as outras — depois do jogo, a avaliação que
+-- existiu em t24h não existia em lugar nenhum. Quem escolhe a janela agora é o
+-- CONSUMIDOR, pelo macro futebol_devig_janela_corrente(); aqui só se emite.
 per_outcome AS (
     SELECT
         fixture_id,
@@ -48,7 +37,7 @@ per_outcome AS (
         outcome_side,
         line_value,
         line_key,
-        ANY_VALUE(collection_window)  AS janela_usada,
+        collection_window             AS janela_usada,
         MAX(odd_decimal)              AS best_odd,
         AVG(odd_decimal)              AS avg_odd,
         -- média DEIXANDO DE FORA a própria best_odd (leave-one-out): referência honesta p/ a
@@ -58,15 +47,17 @@ per_outcome AS (
         APPROX_QUANTILES(odd_decimal, 2)[OFFSET(1)] AS med_odd,
         COUNT(DISTINCT bookmaker_id)  AS n_casas,
         ARRAY_AGG(bookmaker_name ORDER BY odd_decimal DESC LIMIT 1)[OFFSET(0)] AS best_book
-    FROM eval_odds
-    GROUP BY fixture_id, market_id, outcome_side, line_value, line_key
+    FROM odds
+    GROUP BY fixture_id, market_id, outcome_side, line_value, line_key, collection_window
 ),
 
 -- De-vig market-aware da Pinnacle: prob_justa = (1/odd) / Σ(1/odd) sobre todos os
--- outcomes do (fixture, market, linha) na janela de avaliação (normalização multiplicativa).
+-- outcomes do (fixture, market, linha) DENTRO DA MESMA JANELA (normalização
+-- multiplicativa). A janela entra na partição: normalizar sobre odds de janelas
+-- diferentes somaria preços de momentos diferentes e o booksum perderia sentido.
 pinnacle_eval AS (
-    SELECT fixture_id, market_id, outcome_side, line_key, odd_decimal AS pin_odd
-    FROM eval_odds
+    SELECT fixture_id, market_id, outcome_side, line_key, collection_window, odd_decimal AS pin_odd
+    FROM odds
     WHERE bookmaker_id = 4
       -- EXCLUI a Dupla Chance(12) — espelha o consensus_devig: suas 3 saídas NÃO são exaustivas
       -- (somam ~2), normalizar p/ 1 daria prob ~metade da real. A DC é DERIVADA do de-vig 1X2 da
@@ -77,19 +68,19 @@ pinnacle_eval AS (
     -- contagem/fan-out caso dois labels distintos colapsem na mesma (lado, linha) ao parsear
     -- (ex.: '-1.5' vs '-1.50'). Mantém a melhor odd do lado (não muda nada hoje: 1 linha/lado).
     QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY fixture_id, market_id, outcome_side, line_key
+        PARTITION BY fixture_id, market_id, outcome_side, line_key, collection_window
         ORDER BY odd_decimal DESC
     ) = 1
 ),
 pinnacle_devig AS (
     SELECT
-        fixture_id, market_id, outcome_side, line_key,
+        fixture_id, market_id, outcome_side, line_key, collection_window,
         (1.0 / pin_odd) / SUM(1.0 / pin_odd) OVER (
-            PARTITION BY fixture_id, market_id, line_key
+            PARTITION BY fixture_id, market_id, line_key, collection_window
         )                                                         AS prob_justa_fechamento,
         -- booksum = Σ(1/odd) = normalizador = 1 + margem (NÃO é a margem; margem = booksum − 1).
-        SUM(1.0 / pin_odd)  OVER (PARTITION BY fixture_id, market_id, line_key) AS booksum_fechamento,
-        COUNT(*)            OVER (PARTITION BY fixture_id, market_id, line_key) AS pin_n_outcomes
+        SUM(1.0 / pin_odd)  OVER (PARTITION BY fixture_id, market_id, line_key, collection_window) AS booksum_fechamento,
+        COUNT(*)            OVER (PARTITION BY fixture_id, market_id, line_key, collection_window) AS pin_n_outcomes
     FROM pinnacle_eval
 ),
 
@@ -116,12 +107,12 @@ pinnacle_move AS (
 -- ramo BTTS usa n_outcomes_valor (consenso).
 consensus_devig AS (
     SELECT
-        fixture_id, market_id, outcome_side, line_key,
+        fixture_id, market_id, outcome_side, line_key, janela_usada,
         (1.0 / med_odd) / SUM(1.0 / med_odd) OVER (
-            PARTITION BY fixture_id, market_id, line_key
+            PARTITION BY fixture_id, market_id, line_key, janela_usada
         )                                                         AS cons_prob_justa,
-        SUM(1.0 / med_odd) OVER (PARTITION BY fixture_id, market_id, line_key) AS cons_booksum,
-        COUNT(*)           OVER (PARTITION BY fixture_id, market_id, line_key) AS cons_n_outcomes
+        SUM(1.0 / med_odd) OVER (PARTITION BY fixture_id, market_id, line_key, janela_usada) AS cons_booksum,
+        COUNT(*)           OVER (PARTITION BY fixture_id, market_id, line_key, janela_usada) AS cons_n_outcomes
     FROM per_outcome
     WHERE med_odd IS NOT NULL AND med_odd > 0
       AND market_id <> 12
@@ -132,20 +123,27 @@ consensus_devig AS (
 -- P(X2)=P(Draw)+P(Away). Âncora sharp (a Pinnacle precifica o 1X2) — melhor que o consenso, que
 -- nem se aplica aqui (saídas não-exaustivas). Exige o conjunto 1X2 inteiro (p_home/draw/away
 -- não-NULL); senão a DC fica sem prob_justa e é barrada no gate do mart.
+-- A JANELA entra na chave desta derivação (#37): a DC de uma janela deriva do 1X2
+-- DAQUELA janela, nunca de outra. Antes, com uma janela por linha, o join era só por
+-- fixture — e como o QUALIFY escolhia a janela POR MERCADO, a DC podia estar derivando
+-- de um 1X2 de janela diferente. Medido em 2026-08-10 antes de mudar: 265 fixtures têm
+-- 1X2 e DC e em ZERO deles a janela divergia (a chamada /odds traz todos os mercados
+-- juntos), então amarrar a janela não move nenhum valor de hoje — só fecha a porta.
 x2_pinnacle AS (
     SELECT
         fixture_id,
+        collection_window,
         MAX(IF(outcome_side = 'Home', prob_justa_fechamento, NULL)) AS p_home,
         MAX(IF(outcome_side = 'Draw', prob_justa_fechamento, NULL)) AS p_draw,
         MAX(IF(outcome_side = 'Away', prob_justa_fechamento, NULL)) AS p_away,
         ANY_VALUE(pin_n_outcomes)                                  AS n_1x2
     FROM pinnacle_devig
     WHERE market_id = 1
-    GROUP BY fixture_id
+    GROUP BY fixture_id, collection_window
 ),
 dc_devig AS (
     SELECT
-        po.fixture_id, po.market_id, po.outcome_side, po.line_key,
+        po.fixture_id, po.market_id, po.outcome_side, po.line_key, po.janela_usada,
         CASE po.outcome_side
             WHEN '1X' THEN x.p_home + x.p_draw
             WHEN '12' THEN x.p_home + x.p_away
@@ -153,7 +151,9 @@ dc_devig AS (
         END                                                       AS dc_prob_justa,
         x.n_1x2                                                   AS dc_n_1x2
     FROM per_outcome po
-    JOIN x2_pinnacle x ON po.fixture_id = x.fixture_id
+    JOIN x2_pinnacle x
+        ON  po.fixture_id   = x.fixture_id
+        AND po.janela_usada = x.collection_window
     WHERE po.market_id = 12
       AND x.p_home IS NOT NULL AND x.p_draw IS NOT NULL AND x.p_away IS NOT NULL
 ),
@@ -192,11 +192,19 @@ consolidado AS (
         END                                                                      AS conjunto_esperado,
         COALESCE(pm.pin_t15m < pm.pin_t24h, FALSE)                               AS linha_sharp_confirma
     FROM per_outcome po
+    -- As três fontes de valor casam PELA JANELA também: cada janela consome só o
+    -- de-vig dela. Sem isso o join abriria uma linha por janela da fonte × janela
+    -- do per_outcome, e o valor de uma janela vazaria para as outras.
     LEFT JOIN pinnacle_devig pd
         ON  po.fixture_id   = pd.fixture_id
         AND po.market_id    = pd.market_id
         AND po.outcome_side = pd.outcome_side
         AND po.line_key     = pd.line_key
+        AND po.janela_usada = pd.collection_window
+    -- EXCEÇÃO DELIBERADA: pinnacle_move NÃO entra pela janela. O movimento de linha
+    -- sharp é medido sobre o conjunto completo de janelas (t24h -> t15m), então é
+    -- propriedade da LINHA e a mesma linha carrega o mesmo sinal em todas as suas
+    -- janelas. Amarrar a janela aqui zeraria o sinal em toda janela que não a t15m.
     LEFT JOIN pinnacle_move pm
         ON  po.fixture_id   = pm.fixture_id
         AND po.market_id    = pm.market_id
@@ -207,11 +215,13 @@ consolidado AS (
         AND po.market_id    = dd.market_id
         AND po.outcome_side = dd.outcome_side
         AND po.line_key     = dd.line_key
+        AND po.janela_usada = dd.janela_usada
     LEFT JOIN consensus_devig cd
         ON  po.fixture_id   = cd.fixture_id
         AND po.market_id    = cd.market_id
         AND po.outcome_side = cd.outcome_side
         AND po.line_key     = cd.line_key
+        AND po.janela_usada = cd.janela_usada
 ),
 
 -- REGRA DE EMISSÃO (spec #22): o conjunto de saídas usado p/ o valor tem que bater EXATAMENTE

--- a/dbt_futebol/models/marts/fact_value_opportunities.sql
+++ b/dbt_futebol/models/marts/fact_value_opportunities.sql
@@ -25,9 +25,14 @@ prem_dc AS (
 ),
 
 -- line_key STRING (NULL-safe) p/ casar a linha entre modelos sem depender de igualdade FLOAT.
+-- REDUZIDO À JANELA CORRENTE (#37): o de-vig passou a emitir uma avaliação por janela
+-- coletada. Sem a redução, cada join deste mart abriria uma linha por janela e o board
+-- inflaria em silêncio — a mesma oportunidade publicada 4 vezes, uma por preço. A
+-- redução reproduz exatamente a janela que o de-vig escolhia sozinho antes da #37, e é
+-- por isso que a saída deste mart sai idêntica à de antes da mudança de grão.
 devig AS (
     SELECT *, COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
-    FROM {{ ref('int_futebol_odds_devig') }}
+    FROM ({{ futebol_devig_janela_corrente() }})
 ),
 
 corro AS (


### PR DESCRIPTION
Implementa a **subtask C5** da task [C] — a janela entra no grão do de-vig, com o board inalterado. Decisão de domínio na ADR 0004.

Closes #37

## O que muda

`int_futebol_odds_devig` passa a emitir **uma avaliação por janela coletada** em vez de resolver a linha para a janela mais recente e descartar as outras. Quem escolhe qual janela vale é o consumidor, pelo macro novo `futebol_devig_janela_corrente()`.

Todos os agregados por saída (best / avg / avg_ex_best / mediana / n_casas) e as três fontes de valor (Pinnacle, DC derivada do 1X2, consenso) passam a ser calculados **dentro** de cada janela, sem vazar. A regra de emissão da ADR 0002 continua valendo, agora por janela.

**Duas exceções deliberadas, ambas comentadas no modelo:**

- **`pinnacle_move` NÃO entra pela janela.** O movimento sharp é medido sobre o conjunto completo de janelas (t24h→t15m), então é propriedade da **linha** e vem igual em todas as janelas dela. Amarrar a janela ali zeraria o sinal em toda janela que não a t15m.
- **`dc_devig` PASSA a entrar pela janela.** A Dupla Chance de uma janela deriva do 1X2 daquela janela. Antes o join era só por fixture e, como o `QUALIFY` escolhia a janela **por mercado**, a DC podia derivar de outra janela. Medido antes de mudar: **265 fixtures com 1X2 e DC, zero com janela divergente** (a chamada `/odds` traz todos os mercados juntos) — amarrar não move nenhum valor de hoje, só fecha a porta.

A redução dos consumidores é um macro e não SQL copiado, para que consumidor novo herde a redução em vez de redescobrir o fan-out. A partição é `(fixture, mercado, LINHA)` e **não** inclui a saída, de propósito: a linha inteira resolve para a mesma janela, porque o de-vig normaliza sobre o conjunto de saídas — Home da t15m com Away da t1h somaria preços de momentos diferentes.

## Verificação

**O mart saiu byte-identical.** Foto do estado anterior em `futebol.baseline_fvo_20260810` (110 linhas, build 12:11:33 UTC), tirada antes de qualquer edição porque `fact_value_opportunities` é `table` e o primeiro build apaga o "antes":

| sumiram | apareceram | multiplicidade mudou | delta de linhas |
|---|---|---|---|
| 0 | 0 | 0 | 0 |

O isolamento é exato: `fact_odds_snapshot` é `table`, então rebuildar só os três modelos congela os inputs e a única diferença entre os dois builds é o código.

Dois cuidados na comparação, os dois descobertos ao rodá-la: `evidencias`/`avisos` são `ARRAY<STRING>` e o BigQuery rejeita ARRAY em `EXCEPT DISTINCT` (a linha vira `TO_JSON_STRING` com os arrays ordenados), e `dbt_loaded_at` é `CURRENT_TIMESTAMP()` e sai do fingerprint.

**Suíte completa: `PASS=265 WARN=10 ERROR=0`.** Os 10 warnings são os órfãos de `relationships` pré-existentes (injuries→dim_players, lineups_players→dim_players, standings→dim_teams etc.). Custo medido: **6,36 GiB, ~US$ 0,04 por execução** — responde de passagem o critério aberto de `tech-lamjav/data-engineering#19`, que pedia essa medição e não tinha número.

**Guardas novas, as duas com tag `guarda` para rodarem no agendado:**

- `assert_devig_grao_por_janela` — unicidade do grão novo. A versão anterior não tinha tag nenhuma, então nunca rodou em produção.
- `accepted_values` em `janela_usada` — contrapartida de o `ELSE` do macro de prioridade ser `0` e não `NULL`. Com `NULL`, linha cuja única janela fosse desconhecida desapareceria em silêncio; com `0`, uma desconhecida é inofensiva mas **duas** empatariam no `MAX` e abririam fan-out. Esta guarda fica vermelha primeiro.

**Unit tests:** 2 novos (o grão por janela com agregados próprios, e o sinal sharp invariante entre janelas), e o da #22 segue verde.

## Dois achados que a spec não previa

**1. São quatro janelas, não três.** A `daily` entrou em produção em 07/08 (`tech-lamjav/data-engineering#34`) e o board já publica nela. O grão ficou em **2,678 janelas por linha** (77.124 linhas, era 28.759) — não 3×. Os unit tests usam as quatro de propósito, para não fixar o número. Detalhe no [comentário da #37](https://github.com/tech-lamjav/analytics-engineering/issues/37#issuecomment-5240873375); a #40 e a A7 herdam a mesma correção.

**2. O `QUALIFY` antigo não descartava só janelas velhas — descartava saídas inteiras.** Saída que não foi precificada na janela mais nova desaparecia da base, não só da janela. São **41** hoje: o grão de negócio foi de 28.759 para 28.800, e a contagem de saídas ausentes da janela corrente dá exatamente 41. Elas agora existem no intermediate — é matéria-prima da pergunta de CLV que esta subtask destrava — e seguem fora do board pela redução, que é por que o mart saiu idêntico.

## Nota de deploy

⚠️ Rodei `dbt run --target prod`, então o BigQuery **já** tem o grão novo, mas o job agendado roda a imagem antiga e vai reverter as tabelas no próximo `workflow-futebol`. A reversão é inofensiva (o DAG velho é internamente consistente e o mart sai igual), mas a mudança só vale de verdade depois de `build-and-push.sh dbt_futebol` + `gcloud run jobs update`.

Sobre o sync BQ→Postgres: verificado e liberado. `janela_usada` já era coluna, então não há coluna nova e não há `aborted_schema_drift`; e as tabelas de destino não têm PK nem UNIQUE, com carga por TRUNCATE+COPY, então mais linhas passam. Sobra volume — vale olhar a duração do primeiro sync depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
