### PR TITLE
docs(futebol): glossário de escopo/recorte do PIT + ADRs 0007 e 0008

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -270,3 +270,45 @@ first from the second requires an out-of-sample control (ADR 0001).
 A fixture whose teams have played too few matches for a season aggregate to mean
 anything — structural in knockout competitions, and an established cause of fabricated
 signal.
+
+**Escopo do PIT**:
+Which competitions a PIT aggregate counts. Today it is *da competição*: only fixtures of the
+same competition as the one being rated.
+_Avoid_: "juntar os campeonatos" (silent about whether escopo, recorte, or both is changing)
+
+**Recorte do PIT**:
+Which stretch of past fixtures a PIT aggregate counts. Today it is season-to-date. A counting
+recorte ("the last N") crosses the season boundary by construction; a season recorte does not.
+_Avoid_: janela — that word is taken by the odds collection window, and the two are unrelated
+
+**Célula de medição**:
+One combination of escopo and recorte under which the whole premissa layer is rematerialised
+and remeasured. Two cells are comparable only if computed in the same run over the same frozen
+universe. The four are `base`, `escopo`, `recorte` and `ambos`, named for the axis each releases.
+_Avoid_: C1–C4 (C1, C2 and C3 already name subtasks of the [C] Coleta task)
+
+**min_jogos**:
+The smaller of the two teams' prior-fixture counts for a rated fixture, under the escopo and
+recorte in force. It is the number the piso de amostra cuts on, and what makes a fixture an
+amostra curta.
+_Avoid_: jogos disputados (ambiguous between the two teams)
+
+**min_jogos disponível / usado**:
+*Disponível* is how many prior fixtures exist in the escopo; *usado* is how many fed the average.
+They diverge only under a counting recorte, which saturates. The piso always cuts on disponível,
+so that it means the same thing in every célula.
+
+**Piso de amostra**:
+The minimum min_jogos for a line to enter a measurement. A parameter of the measurement, never
+of the Motor in production.
+
+**Premissa de tabela**:
+A premissa whose input is the team's standing — rank, ppg, or the size of the league. There are
+four. A league table exists inside one competition, so these have no juntado escopo and their
+numbers are identical across células by construction. See ADR 0008.
+
+**Família de competição**:
+How a competition labels its seasons: *ano-calendário* (Brasileirão, Série B, the cups, Copa do
+Mundo) or *split-year* (the European leagues and the Champions, where season N means N/N+1). A
+team belongs to one family, and the family decides whether releasing escopo without releasing
+recorte does anything for it.

--- a/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
+++ b/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+---
+
+# A medição de escopo roda em dataset próprio, atrás de uma var com default de produção
+
+A task [F] precisa saber o que cada premissa vira quando o PIT do time deixa de ser
+contado dentro da competição. Trocar só o `min_jogos` não responde isso: as flags das premissas
+saem dos 5 modelos de `intermediate/`, que fazem `ref('int_futebol_team_form_pit')` — e são elas
+que decidem em quais jogos a premissa acende. A medição exige, portanto, **re-materializar a
+camada de premissas inteira** sob outro escopo de PIT.
+
+Decidimos fazer isso com uma **var** nas fontes do PIT que são competição-scoped
+(`int_futebol_team_form_pit`, os `last5` locais de Gols e BTTS, o spine de xG), cujo **default
+reproduz exatamente o comportamento de hoje**, mais um **target `taskF` novo apontando para o
+dataset `futebol_taskF`**. É o mesmo padrão que a Task 0 usou para guardar o estado contaminado
+em `futebol_task0`.
+
+## Por que isto não é opcional
+
+No `profiles.yml`, `dev` **e** `prod` apontam para o mesmo dataset `futebol`, e `target: dev` é
+o default. Um `dbt run` sem `--target` escreve em produção. Sem um destino próprio, medir
+histórico juntado significa publicar histórico juntado no board — e o próximo run agendado
+reverteria por cima, deixando um intervalo em que o app serviu número de outra definição.
+
+Isto é um **dataset de medição**, análogo ao `futebol_task0`, e não um dataset por pessoa —
+proposta diferente, e recusada.
+
+## Considered options
+
+**Copiar os 5 modelos para versões de medição.** Rejeitada: são ~1000 linhas de premissa que
+passam a existir em duas cópias, e a cópia deriva da produção no primeiro commit seguinte. O
+modo de falha é silencioso — a medição continua rodando, medindo um catálogo que já não é o de
+produção.
+
+**Editar os modelos, medir e reverter.** Rejeitada: não deixa rastro reproduzível. Quem
+quiser refazer a medição daqui a três meses não tem como saber o que exatamente foi editado.
+
+## Consequences
+
+Fica uma var no código de produção que **produção nunca usa**. Um leitor futuro vai encontrá-la
+e não vai saber se pode remover. Por isso a var vem acompanhada de um teste que compara a saída
+com default contra a tabela publicada: enquanto ele passar, "o default preserva o comportamento"
+é fato verificado, e não promessa no comentário.

--- a/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
+++ b/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+---
+
+# Premissa de tabela não tem escopo juntado
+
+Quatro premissas do catálogo leem a **classificação** do time, não a performance dele:
+`superioridade_tabela` (1X2), `supremacia` e `sem_rodizio` (Handicap) e
+`x_superioridade_tabela` (Dupla Chance, reusada do 1X2). Os insumos são `rank`, `ppg` e — no
+caso do `sem_rodizio` — `n_teams`, o tamanho da liga.
+
+Decidimos que essas quatro **permanecem competição-scoped em todas as células de medição**, e
+que essa imobilidade é o resultado reportado, não uma lacuna a preencher.
+
+## Por quê
+
+Classificação existe dentro de uma competição. Não há posição de um time num PIT de escopo juntado,
+porque não há tabela juntada: `rank` exige o conjunto completo de adversários no mesmo recorte,
+e `sem_rodizio` compara o rank contra o tamanho da liga (`s_rank <= 6 OR s_rank >= n_teams - 3`)
+— um número que simplesmente não existe quando o PIT atravessa competições de tamanhos
+diferentes.
+
+Consequência prática: nas quatro células, o número dessas premissas é **idêntico por
+construção**. A linha delas na tabela do entregável não é um resultado nulo; é a resposta da
+coluna 3 ("dá para juntar, e o que impede se não der").
+
+## Considered options
+
+**Competição principal.** Cada time ganharia uma liga de referência (a nacional), e a tabela
+sairia sempre de lá, mesmo num jogo de copa. É a alternativa séria, e não foi descartada por ser
+ruim: foi adiada. Ela **muda a definição da premissa** — `supremacia` passaria a comparar
+posições de uma competição que não é a do jogo — e a [F] é uma task de medição, com instrução
+explícita de não mexer em premissa. Fica registrada como candidata para a [B], onde o
+`sem_rodizio` merece atenção por ser do Handicap, o mercado com ROI positivo.
+
+**Proxy sem tabela** (percentil de `ppg` entre todos os times da base). Rejeitada pelo mesmo
+motivo, com o agravante de que o percentil mistura ligas de níveis diferentes sem nada que
+sinalize isso no número.
+
+## Consequences
+
+O `min_jogos` **continua seguindo a célula**, inclusive nas linhas dessas quatro premissas. O
+piso de amostra é propriedade do jogo, não da premissa — um jogo com PIT juntado suficiente
+é o mesmo jogo, independentemente de qual premissa está sendo avaliada nele.


### PR DESCRIPTION
Rastro do grilling da task [F] (ClickUp `wdx6zevnhy`, spec #49). Só documentação — nenhum modelo,
nenhum teste, nenhum SQL.

## O que entra

**`CONTEXT.md`** ganha 8 termos, todos na seção de medição e sem tocar os 272 existentes: escopo
do PIT, recorte do PIT, célula de medição, `min_jogos` (e a distinção disponível/usado), piso de
amostra, premissa de tabela e família de competição.

Dois nomes saem com `_Avoid_` explícito, porque as duas colisões já custaram retrabalho:

- o eixo temporal chama-se **recorte**, nunca "janela" — janela é a janela de coleta de odds
  (daily/t24h/t1h/t15m) e as duas coisas não têm relação;
- as células chamam-se `base`/`escopo`/`recorte`/`ambos`, nunca C1–C4 — `C1`, `C2` e `C3` já
  nomeiam subtasks da task [C] (Coleta) no ClickUp, e a colisão atravessaria o tracker.

**ADR 0007** registra por que a medição roda em dataset próprio atrás de uma var com default de
produção: `dev` e `prod` apontam para o mesmo dataset e `dev` é o default, então medir sem destino
próprio publicaria PIT juntado no board.

**ADR 0008** registra por que as quatro premissas de tabela não têm escopo juntado, e deixa
escrita a alternativa adiada ("competição principal") para a [B] não a redescobrir daqui a seis
meses.

## Por que é um PR separado

O #50 (andaime da [F]) sai deste branch e implementa exatamente o que as duas ADRs decidem. Se os
dois viessem juntos, a revisão do código carregaria a decisão de projeto no mesmo diff — e é mais
fácil discordar de uma ADR antes de o código existir. **O PR do #50 tem este branch como base**,
então este entra primeiro.

Refs #49