### PR TITLE
feat(futebol): andaime da medição da task [F] — dataset, vars e Costura A

### DIFF
--- a/dbt_futebol/analyses/taskf_congela_baseline.sql
+++ b/dbt_futebol/analyses/taskf_congela_baseline.sql
@@ -1,0 +1,61 @@
+/*
+    [F-1] Congela o BASELINE da Costura A — a saída do int_futebol_team_form_pit ANTES de a var
+    de escopo/recorte entrar no modelo.
+
+    Por que existe: a ADR 0007 deixa no código de produção uma var que produção nunca usa. A
+    promessa que a acompanha é "o default preserva o comportamento de hoje". Este congelamento é
+    o lado esquerdo da igualdade que transforma essa promessa em fato verificável — o direito é
+    tests/assert_taskf_pit_default_igual_baseline.sql.
+
+    ⚠️ RODA UMA VEZ SÓ, e ANTES de a var entrar no modelo. Re-congelar depois da var apaga a
+    guarda: o baseline passaria a sair do mesmo código que ele deveria auditar, e a Costura A
+    ficaria verde por construção. Se um dia for preciso re-congelar (mudança legítima de
+    comportamento do modelo), isso é decisão de quem revisa, não passo de rotina.
+
+    JÁ FOI RODADO: 2026-08-12 12:22 UTC, commit a3b954e, 21.054 linhas e 37 partições.
+
+    Três tabelas, todas FORA do dbt de propósito — nenhuma é modelo, então nenhum `dbt run` as
+    reconstrói:
+
+      baseline_int_futebol_team_form_pit  a saída congelada, sem dbt_loaded_at (que muda a cada
+                                          build por construção e não é comportamento).
+      baseline_pit_fingerprint            impressão digital do INSUMO por (competition_id,
+                                          season), emitida pela macro taskf_fingerprint_insumo_pit
+                                          — a MESMA que o teste usa. O contrato congelado dela
+                                          está no cabeçalho da macro; as duas pontas leem de lá
+                                          justamente para não haver duas cópias que precisam ficar
+                                          idênticas para sempre.
+      baseline_pit_meta                   quando, de qual commit, quantas linhas.
+
+    Como rodar (do dbt_futebol/). O passo 1 é o que povoa o dataset de medição: com --target
+    taskF todo `ref()` resolve para futebol_taskF, então a ancestria (staging + fact_fixtures +
+    fact_standings_snapshot) tem de existir lá antes — o `+` no seletor é o que a constrói, lendo
+    as sources cruas, que são fixas no dataset de origem e não seguem o target:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt run --target taskF \
+        --select +int_futebol_team_form_pit
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+        --select taskf_congela_baseline --vars '{freeze_git_sha: '"$(git rev-parse --short HEAD)"'}'
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_congela_baseline.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+*/
+
+CREATE OR REPLACE TABLE `smartbetting-dados.futebol_taskF.baseline_int_futebol_team_form_pit` AS
+SELECT * EXCEPT (dbt_loaded_at)
+FROM {{ ref('int_futebol_team_form_pit') }};
+
+
+CREATE OR REPLACE TABLE `smartbetting-dados.futebol_taskF.baseline_pit_fingerprint` AS
+WITH {{ taskf_fingerprint_insumo_pit() }}
+SELECT * FROM fp_insumo_pit;
+
+
+CREATE OR REPLACE TABLE `smartbetting-dados.futebol_taskF.baseline_pit_meta` AS
+SELECT
+    CURRENT_TIMESTAMP()                          AS congelado_em,
+    '{{ var("freeze_git_sha", "desconhecido") }}' AS git_sha,
+    (SELECT COUNT(*) FROM {{ source('futebol_taskF', 'baseline_int_futebol_team_form_pit') }}) AS n_linhas,
+    (SELECT COUNT(*) FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }})           AS n_particoes;

--- a/dbt_futebol/macros/taskf_fingerprint_insumo_pit.sql
+++ b/dbt_futebol/macros/taskf_fingerprint_insumo_pit.sql
@@ -1,0 +1,83 @@
+{#
+    Impressão digital do INSUMO do int_futebol_team_form_pit, por (competition_id, season).
+
+    Existe para que a Costura A (task [F], issue #49, ADR 0007) possa ser exata sem ser frágil.
+    O insumo do modelo é vivo — fixture novo, resultado que entra, jogo remarcado —, e nada disso
+    é regressão, mas tudo isso muda a saída. A guarda então compara só as partições cujo insumo é
+    idêntico ao do congelamento, e nelas exige igualdade linha a linha, sem folga.
+
+    O recorte por (competition_id, season) é sólido porque no caminho DEFAULT a linha de uma
+    âncora em (C,S) é função só dos fixtures de (C,S) e das standings de (C,S): os dois joins do
+    modelo são escopados pelos dois campos. Sob pit_escopo=todas isso deixa de valer — e é aí que
+    a guarda deve mesmo falhar, porque a var saiu do default.
+
+    ⚠️ ESTA DEFINIÇÃO É CONTRATO CONGELADO. Ela é usada nos dois lados da comparação: uma vez em
+    analyses/taskf_congela_baseline.sql, que gravou futebol_taskF.baseline_pit_fingerprint, e a
+    cada execução em tests/assert_taskf_pit_default_igual_baseline.sql. Mudar o que entra no
+    FARM_FINGERPRINT muda os valores e faz NENHUMA partição casar contra o baseline já gravado —
+    a guarda não fica vermelha, fica VAZIA, que é pior. Por isso as duas pontas leem daqui e não
+    de cópias: cópia que precisa ficar idêntica para sempre não fica. Se um dia for mesmo preciso
+    mudar, o baseline tem de ser recongelado no mesmo commit — decisão de quem revisa, não passo
+    de rotina.
+
+    Emite UMA CTE no escopo do chamador, `fp_insumo_pit`, com uma linha por (competition_id,
+    season) e as colunas n_fixtures / fp_fixtures / n_grupos / fp_standings. Uma CTE do chamador
+    com esse nome a sombreia em silêncio.
+
+    Uso:
+
+        WITH {{ taskf_fingerprint_insumo_pit() }},
+        casadas AS (SELECT ... FROM fp_insumo_pit JOIN baseline_pit_fingerprint USING (...))
+#}
+
+{% macro taskf_fingerprint_insumo_pit() %}
+
+fp_fixtures_pit AS (
+    SELECT
+        competition_id,
+        season,
+        COUNT(*) AS n_fixtures,
+        BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(
+            fixture_id, competition, home_team_id, away_team_id,
+            kickoff_utc, status_short, goals_home, goals_away
+        )))) AS fp_fixtures
+    FROM {{ ref('fact_fixtures') }}
+    GROUP BY competition_id, season
+),
+
+-- Mesmo QUALIFY do modelo: o insumo que ele de fato lê, e não a tabela crua. O snapshot ganha
+-- uma linha por dia por time, então digitalizar o cru mudaria todo dia e jogaria todas as
+-- competições fora da comparação — a guarda passaria em branco.
+fp_team_group_pit AS (
+    SELECT league_id AS competition_id, season, team_id, group_name
+    FROM {{ ref('fact_standings_snapshot') }}
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY league_id, season, team_id
+        ORDER BY CASE WHEN group_name LIKE '%third-placed%' THEN 1 ELSE 0 END,
+                 snapshot_date DESC
+    ) = 1
+),
+
+fp_standings_pit AS (
+    SELECT
+        competition_id,
+        season,
+        COUNT(*) AS n_grupos,
+        BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(team_id, group_name)))) AS fp_standings
+    FROM fp_team_group_pit
+    GROUP BY competition_id, season
+),
+
+fp_insumo_pit AS (
+    SELECT
+        f.competition_id,
+        f.season,
+        f.n_fixtures,
+        f.fp_fixtures,
+        COALESCE(s.n_grupos, 0) AS n_grupos,
+        s.fp_standings
+    FROM fp_fixtures_pit f
+    LEFT JOIN fp_standings_pit s USING (competition_id, season)
+)
+
+{% endmacro %}

--- a/dbt_futebol/models/intermediate/_int_futebol__models.yml
+++ b/dbt_futebol/models/intermediate/_int_futebol__models.yml
@@ -145,6 +145,14 @@ models:
       erro médio de 0,27 posição — as diferenças são o snapshot diário estar defasado do kickoff.
       Em jogos FUTUROS o resultado é ~idêntico ao antigo (diferença média de 0,003 gol/jogo), ou
       seja, a correção muda o backtest e não mexe em produção.
+      ⚠️ MEDIÇÃO (task [F], ADR 0007): o modelo aceita as vars pit_escopo (da_competicao|todas) e
+      pit_recorte (temporada|ultimos_10), cujos DEFAULTS reproduzem exatamente o comportamento
+      descrito acima — no default o SQL compilado é idêntico ao de antes de as vars existirem, e
+      tests/assert_taskf_pit_default_igual_baseline prova a igualdade contra um baseline congelado
+      antes delas. Produção nunca as passa; elas servem às células de medição, materializadas no
+      dataset futebol_taskF (target `taskF`). A tabela do campeonato (rank/points/ppg/n_teams/
+      goal_diff) NÃO segue os eixos: classificação existe dentro de uma competição, então ela
+      permanece competição+temporada em todas as células, por construção (ADR 0008).
     columns:
       - name: fixture_id
         tests: [not_null]

--- a/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
@@ -1,8 +1,88 @@
 {{ config(
     materialized='table',
     cluster_by=['fixture_id', 'team_id'],
-    description='Correção da Task 0 (look-ahead) — agregados de forma POINT-IN-TIME por (fixture_id, team_id): tudo é calculado SÓ com jogos FINALIZADOS da MESMA competição/season e com kickoff ANTERIOR ao do jogo-alvo. Substitui as duas fontes contaminadas dos 5 modelos de premissas: (A) fact_team_season_stats, que tem 1 único snapshot por (time, liga, season) — p/ 2024/2025 é a temporada FECHADA (played_total=38 aplicado à rodada 1, ~51% de cada média sendo futuro e 100% dos jogos com o próprio resultado dentro da média); e (B2) o standings_latest (MAX(snapshot_date) sem âncora no kickoff), cujo histórico só começa em 11/06/2026 e que p/ 24/25 é a tabela final. Reconstrói do fact_fixtures o mesmo conjunto de colunas consumido pelos modelos (gols pró/contra casa/fora/total, clean sheet, failed to score, played/wins/draws) MAIS a tabela do campeonato no instante do jogo (rank/points/ppg/n_wins_last5). O rank sai DENTRO do grupo (group_name das standings = estrutura do chaveamento, conhecida antes dos jogos — não é medição): liga de pontos corridos = 1 grupo, logo rank global 1-20 (Brasileirão/Série B/La Liga/PL/Serie A ITA) ou 1-36 (Champions, fase de liga); Libertadores/Sudamericana/Copa do Mundo = rank por grupo (1-4 / 1-12), igual à API; Copa do Brasil não tem standings -> sem grupo -> rank NULL, como já era. Degradação graciosa por construção: no início de temporada played_total=0 -> médias NULL -> premissa FALSE (honesto: na rodada 1 não existe passado). played_* fica exposto p/ que a recalibragem possa decidir um piso de amostra.'
+    description='Correção da Task 0 (look-ahead) — agregados de forma POINT-IN-TIME por (fixture_id, team_id): tudo é calculado SÓ com jogos FINALIZADOS da MESMA competição/season e com kickoff ANTERIOR ao do jogo-alvo. Substitui as duas fontes contaminadas dos 5 modelos de premissas: (A) fact_team_season_stats, que tem 1 único snapshot por (time, liga, season) — p/ 2024/2025 é a temporada FECHADA (played_total=38 aplicado à rodada 1, ~51% de cada média sendo futuro e 100% dos jogos com o próprio resultado dentro da média); e (B2) o standings_latest (MAX(snapshot_date) sem âncora no kickoff), cujo histórico só começa em 11/06/2026 e que p/ 24/25 é a tabela final. Reconstrói do fact_fixtures o mesmo conjunto de colunas consumido pelos modelos (gols pró/contra casa/fora/total, clean sheet, failed to score, played/wins/draws) MAIS a tabela do campeonato no instante do jogo (rank/points/ppg/n_wins_last5). O rank sai DENTRO do grupo (group_name das standings = estrutura do chaveamento, conhecida antes dos jogos — não é medição): liga de pontos corridos = 1 grupo, logo rank global 1-20 (Brasileirão/Série B/La Liga/PL/Serie A ITA) ou 1-36 (Champions, fase de liga); Libertadores/Sudamericana/Copa do Mundo = rank por grupo (1-4 / 1-12), igual à API; Copa do Brasil não tem standings -> sem grupo -> rank NULL, como já era. Degradação graciosa por construção: no início de temporada played_total=0 -> médias NULL -> premissa FALSE (honesto: na rodada 1 não existe passado). played_* fica exposto p/ que a recalibragem possa decidir um piso de amostra. ⚠️ MEDIÇÃO (task [F], ADR 0007): aceita as vars pit_escopo (da_competicao|todas) e pit_recorte (temporada|ultimos_10), cujos DEFAULTS reproduzem exatamente o descrito acima — no default o SQL compilado é idêntico ao de antes das vars existirem. Produção nunca as passa; elas servem às células de medição, materializadas no dataset futebol_taskF. A tabela do campeonato (rank/points/ppg/n_teams/goal_diff) NÃO segue os eixos: classificação existe dentro de uma competição, então ela permanece competição+temporada em todas as células, por construção (ADR 0008).'
 ) }}
+{#-
+    EIXOS DE MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — não usados em produção.
+
+    `pit_escopo`  = quais COMPETIÇÕES contam no histórico do time.
+                    da_competicao (default) = só a competição do jogo, o que roda hoje.
+                    todas                   = qualquer competição do time.
+
+    `pit_recorte` = qual TRECHO do passado conta.
+                    temporada (default) = a temporada corrente, o que roda hoje.
+                    ultimos_10          = os 10 jogos anteriores, contagem móvel que atravessa
+                                          a virada de temporada por construção.
+
+    ⚠️ `recorte`, nunca `janela`: janela é a janela de coleta de odds (daily/t24h/t1h/t15m) e as
+    duas coisas não têm relação. Ver o glossário no CONTEXT.md.
+
+    Os dois defaults reproduzem o comportamento de hoje, e a igualdade é fato verificado, não
+    promessa: tests/assert_taskf_pit_default_igual_baseline.sql compara a saída no default contra
+    o baseline congelado antes de esta var existir. No default o SQL compilado é IDÊNTICO ao de
+    antes da var — nenhum ramo novo é emitido.
+
+    Produção nunca passa estas vars. Quem mede escolhe a célula na linha de comando, contra o
+    target `taskF` (dataset de medição), nunca contra dev/prod — que apontam para o dataset do
+    board:
+
+      dbt run --target taskF --select int_futebol_team_form_pit \
+        --vars '{pit_escopo: todas, pit_recorte: ultimos_10}'
+-#}
+{%- set pit_escopo  = var('pit_escopo',  'da_competicao') -%}
+{%- set pit_recorte = var('pit_recorte', 'temporada') -%}
+{%- if pit_escopo not in ['da_competicao', 'todas'] -%}
+    {{ exceptions.raise_compiler_error(
+        "pit_escopo inválido: '" ~ pit_escopo ~ "'. Valores aceitos: da_competicao | todas.") }}
+{%- endif -%}
+{%- if pit_recorte not in ['temporada', 'ultimos_10'] -%}
+    {{ exceptions.raise_compiler_error(
+        "pit_recorte inválido: '" ~ pit_recorte ~ "'. Valores aceitos: temporada | ultimos_10.") }}
+{%- endif -%}
+{#- Fora do default, a tabela do campeonato precisa do próprio agregado, competição-scoped
+    (ADR 0008) — e o rank/ppg passam a sair dele, não do agregado da célula. -#}
+{%- set tabela_propria = (pit_escopo != 'da_competicao') or (pit_recorte != 'temporada') -%}
+{%- set tab = 'tb' if tabela_propria else 'p' -%}
+{#- A lista de agregados existe UMA vez e é renderizada nas duas formas do CTE pit (junção direta
+    no default, pares ranqueados sob recorte de contagem) — para as duas formas não derivarem. -#}
+{%- set agregados_pit %}
+        -- jogos / resultados
+        COUNTIF(l.is_home)                          AS played_home,
+        COUNTIF(NOT l.is_home)                      AS played_away,
+        COUNT(l.team_id)                            AS played_total,
+        COUNTIF(l.is_home       AND l.gf > l.ga)    AS wins_home,
+        COUNTIF(l.is_home       AND l.gf = l.ga)    AS draws_home,
+        COUNTIF(NOT l.is_home   AND l.gf > l.ga)    AS wins_away,
+        COUNTIF(NOT l.is_home   AND l.gf = l.ga)    AS draws_away,
+        COUNTIF(l.gf > l.ga)                        AS wins_total,
+        COUNTIF(l.gf = l.ga)                        AS draws_total,
+
+        -- gols marcados / sofridos (médias por venue e no total)
+        SAFE_DIVIDE(SUM(IF(l.is_home,     l.gf, 0)), COUNTIF(l.is_home))     AS goals_for_avg_home,
+        SAFE_DIVIDE(SUM(IF(NOT l.is_home, l.gf, 0)), COUNTIF(NOT l.is_home)) AS goals_for_avg_away,
+        SAFE_DIVIDE(SUM(l.gf),                       COUNT(l.team_id))       AS goals_for_avg_total,
+        SAFE_DIVIDE(SUM(IF(l.is_home,     l.ga, 0)), COUNTIF(l.is_home))     AS goals_against_avg_home,
+        SAFE_DIVIDE(SUM(IF(NOT l.is_home, l.ga, 0)), COUNTIF(NOT l.is_home)) AS goals_against_avg_away,
+        SAFE_DIVIDE(SUM(l.ga),                       COUNT(l.team_id))       AS goals_against_avg_total,
+
+        -- defesa / ataque agregados
+        COUNTIF(l.ga = 0)                           AS clean_sheet_total,
+        COUNTIF(l.gf = 0)                           AS failed_to_score_total,
+
+        -- insumos da tabela do campeonato
+        COUNTIF(l.gf > l.ga) * 3 + COUNTIF(l.gf = l.ga)  AS points,
+        COALESCE(SUM(l.gf), 0)                           AS goals_for_total,
+        COALESCE(SUM(l.gf) - SUM(l.ga), 0)               AS goal_diff,
+
+        -- forma: os últimos 5 resultados ANTES do jogo (substitui o parse de standings.form)
+        ARRAY_AGG(
+            CASE WHEN l.gf > l.ga THEN 'W'
+                 WHEN l.gf = l.ga THEN 'D'
+                 WHEN l.gf < l.ga THEN 'L' END
+            IGNORE NULLS ORDER BY l.kickoff_utc DESC LIMIT 5
+        ) AS last5_desc
+{%- endset %}
 
 WITH fixtures AS (
     SELECT
@@ -67,49 +147,85 @@ team_group AS (
 anchors AS (
     SELECT fixture_id, competition_id, season, kickoff_utc FROM fixtures
 ),
+{% if pit_recorte == 'ultimos_10' %}
+-- MEDIÇÃO — recorte de CONTAGEM. O par (âncora, time) × jogo anterior vira linha, e só os 10
+-- kickoffs mais recentes sobrevivem. Atravessa temporada por construção: é isso que separa a
+-- coluna direita da esquerda do 2x2. O LEFT JOIN sem correspondência devolve kickoff NULL, que
+-- o ROW_NUMBER mantém em 1 — o time sem passado segue com played_total = 0.
+pares AS (
+    SELECT
+        a.fixture_id,
+        lt.team_id AS anchor_team_id,
+        a.competition_id,
+        a.season,
+        l.team_id,
+        l.is_home,
+        l.gf,
+        l.ga,
+        l.kickoff_utc
+    FROM anchors a
+    JOIN league_teams lt
+        ON  lt.competition_id = a.competition_id
+        AND lt.season         = a.season
+    LEFT JOIN team_log l
+        ON  l.team_id        = lt.team_id
+        {%- if pit_escopo == 'da_competicao' %}
+        AND l.competition_id = a.competition_id
+        {%- endif %}
+        AND l.kickoff_utc    < a.kickoff_utc
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY a.fixture_id, lt.team_id
+        ORDER BY l.kickoff_utc DESC
+    ) <= 10
+),
 
+pit AS (
+    SELECT
+        l.fixture_id,
+        l.anchor_team_id AS team_id,
+        l.competition_id,
+        l.season,
+{{ agregados_pit }}
+    FROM pares l
+    GROUP BY l.fixture_id, l.anchor_team_id, l.competition_id, l.season
+),
+{% else %}
 pit AS (
     SELECT
         a.fixture_id,
         lt.team_id,
         a.competition_id,
         a.season,
-
-        -- jogos / resultados
-        COUNTIF(l.is_home)                          AS played_home,
-        COUNTIF(NOT l.is_home)                      AS played_away,
-        COUNT(l.team_id)                            AS played_total,
-        COUNTIF(l.is_home       AND l.gf > l.ga)    AS wins_home,
-        COUNTIF(l.is_home       AND l.gf = l.ga)    AS draws_home,
-        COUNTIF(NOT l.is_home   AND l.gf > l.ga)    AS wins_away,
-        COUNTIF(NOT l.is_home   AND l.gf = l.ga)    AS draws_away,
-        COUNTIF(l.gf > l.ga)                        AS wins_total,
-        COUNTIF(l.gf = l.ga)                        AS draws_total,
-
-        -- gols marcados / sofridos (médias por venue e no total)
-        SAFE_DIVIDE(SUM(IF(l.is_home,     l.gf, 0)), COUNTIF(l.is_home))     AS goals_for_avg_home,
-        SAFE_DIVIDE(SUM(IF(NOT l.is_home, l.gf, 0)), COUNTIF(NOT l.is_home)) AS goals_for_avg_away,
-        SAFE_DIVIDE(SUM(l.gf),                       COUNT(l.team_id))       AS goals_for_avg_total,
-        SAFE_DIVIDE(SUM(IF(l.is_home,     l.ga, 0)), COUNTIF(l.is_home))     AS goals_against_avg_home,
-        SAFE_DIVIDE(SUM(IF(NOT l.is_home, l.ga, 0)), COUNTIF(NOT l.is_home)) AS goals_against_avg_away,
-        SAFE_DIVIDE(SUM(l.ga),                       COUNT(l.team_id))       AS goals_against_avg_total,
-
-        -- defesa / ataque agregados
-        COUNTIF(l.ga = 0)                           AS clean_sheet_total,
-        COUNTIF(l.gf = 0)                           AS failed_to_score_total,
-
-        -- insumos da tabela do campeonato
+{{ agregados_pit }}
+    FROM anchors a
+    JOIN league_teams lt
+        ON  lt.competition_id = a.competition_id
+        AND lt.season         = a.season
+    LEFT JOIN team_log l
+        ON  l.team_id        = lt.team_id
+        {%- if pit_escopo == 'da_competicao' %}
+        AND l.competition_id = a.competition_id
+        {%- endif %}
+        AND l.season         = a.season
+        AND l.kickoff_utc    < a.kickoff_utc
+    GROUP BY a.fixture_id, lt.team_id, a.competition_id, a.season
+),
+{% endif %}
+{%- if tabela_propria %}
+-- MEDIÇÃO — a tabela do campeonato NÃO segue a célula (ADR 0008). Classificação existe dentro de
+-- uma competição: não há rank num histórico que atravessa competições, e o sem_rodizio chega a
+-- comparar o rank contra o tamanho da liga. Este agregado é o de hoje, competição + temporada,
+-- e é dele que saem rank e ppg em qualquer célula — por isso as quatro premissas de tabela dão
+-- número idêntico nas quatro, por construção.
+tabela AS (
+    SELECT
+        a.fixture_id,
+        lt.team_id,
+        COUNT(l.team_id)                                 AS played_total,
         COUNTIF(l.gf > l.ga) * 3 + COUNTIF(l.gf = l.ga)  AS points,
+        COUNTIF(l.gf > l.ga)                             AS wins_total,
         COALESCE(SUM(l.gf), 0)                           AS goals_for_total,
-        COALESCE(SUM(l.gf) - SUM(l.ga), 0)               AS goal_diff,
-
-        -- forma: os últimos 5 resultados ANTES do jogo (substitui o parse de standings.form)
-        ARRAY_AGG(
-            CASE WHEN l.gf > l.ga THEN 'W'
-                 WHEN l.gf = l.ga THEN 'D'
-                 WHEN l.gf < l.ga THEN 'L' END
-            IGNORE NULLS ORDER BY l.kickoff_utc DESC LIMIT 5
-        ) AS last5_desc
+        COALESCE(SUM(l.gf) - SUM(l.ga), 0)               AS goal_diff
     FROM anchors a
     JOIN league_teams lt
         ON  lt.competition_id = a.competition_id
@@ -119,9 +235,9 @@ pit AS (
         AND l.competition_id = a.competition_id
         AND l.season         = a.season
         AND l.kickoff_utc    < a.kickoff_utc
-    GROUP BY a.fixture_id, lt.team_id, a.competition_id, a.season
+    GROUP BY a.fixture_id, lt.team_id
 ),
-
+{% endif %}
 -- Tabela do campeonato no instante do jogo. Critério de desempate = pontos > vitórias > saldo >
 -- gols pró (o do Brasileirão), + team_id p/ ser determinístico. ROW_NUMBER e não RANK porque o
 -- rank da API é estrito (não repete posição), e o modelo compara diferenças de rank.
@@ -129,16 +245,24 @@ pit AS (
 -- todo mundo empataria em 0 -> `s_rank <= 6` do sem_rodizio dispararia p/ a liga inteira.
 ranked AS (
     SELECT
-        p.*,
+        p.*{% if tabela_propria %} EXCEPT (points, goals_for_total, goal_diff),
+        tb.points,
+        tb.goal_diff,
+        tb.played_total AS played_total_tabela{% endif %},
         tg.group_name,
-        IF(tg.group_name IS NULL OR p.played_total = 0, NULL,
+        IF(tg.group_name IS NULL OR {{ tab }}.played_total = 0, NULL,
            ROW_NUMBER() OVER (
                PARTITION BY p.fixture_id, tg.group_name
-               ORDER BY p.points DESC, p.wins_total DESC, p.goal_diff DESC,
-                        p.goals_for_total DESC, p.team_id
+               ORDER BY {{ tab }}.points DESC, {{ tab }}.wins_total DESC, {{ tab }}.goal_diff DESC,
+                        {{ tab }}.goals_for_total DESC, p.team_id
            )
         ) AS rank
     FROM pit p
+    {%- if tabela_propria %}
+    JOIN tabela tb
+        ON  tb.fixture_id = p.fixture_id
+        AND tb.team_id    = p.team_id
+    {%- endif %}
     LEFT JOIN team_group tg
         ON  tg.competition_id = p.competition_id
         AND tg.season         = p.season
@@ -178,7 +302,7 @@ SELECT
     r.rank,
     r.points,
     r.goal_diff,
-    SAFE_DIVIDE(r.points, r.played_total) AS ppg,
+    SAFE_DIVIDE(r.points, r.played_total{% if tabela_propria %}_tabela{% endif %}) AS ppg,
     ls.n_teams,
     r.group_name,
 

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -503,3 +503,55 @@ sources:
               STRUCT com 7 métricas de comparação home vs away {form, att, def,
               poisson_distribution, h2h, goals, total}, cada uma STRUCT<home STRING, away STRING>
               (percentuais "45%"). Cast em stg. (def é keyword SQL — crases no stg.)
+
+  # Artefatos CONGELADOS da medição da task [F] (issue #49, ADR 0007). Não são modelos e nenhum
+  # `dbt run` os reconstrói: foram criados uma vez pelo analyses/taskf_congela_baseline.sql, ANTES
+  # de as vars pit_escopo/pit_recorte entrarem no int_futebol_team_form_pit, e é essa anterioridade
+  # que dá valor a eles. O schema é fixo em `futebol_taskF` de propósito — o baseline não segue o
+  # target, senão a Costura A compararia produção contra ela mesma rodada com --target dev/prod.
+  # Exceção consciente ao "só modelo de staging lê source": o consumidor é o teste singular da
+  # Costura A, e `source()` é o único handle do dbt para uma tabela congelada que não é modelo.
+  - name: futebol_taskF
+    description: >
+      Dataset de medição da task [F] (ADR 0007). Guarda o baseline de equivalência da Costura A.
+    database: smartbetting-dados
+    schema: futebol_taskF
+    tables:
+      - name: baseline_int_futebol_team_form_pit
+        description: >
+          A saída do int_futebol_team_form_pit no código anterior às vars de escopo/recorte,
+          sem dbt_loaded_at (que muda a cada build por construção e não é comportamento).
+          Lado esquerdo da igualdade de assert_taskf_pit_default_igual_baseline.
+
+      - name: baseline_pit_fingerprint
+        description: >
+          Impressão digital do INSUMO do modelo por (competition_id, season) no instante do
+          congelamento — contagem e BIT_XOR(FARM_FINGERPRINT) dos fixtures e do team_group já
+          resolvido. É o que deixa a Costura A ser exata sem ser frágil: fixture novo, resultado
+          que entra e jogo remarcado mudam legitimamente a saída de uma competição, e a guarda
+          compara só as partições cujo insumo é idêntico ao congelado. Produzida pela macro
+          taskf_fingerprint_insumo_pit(), a MESMA que o teste usa — se as duas divergirem, nenhuma
+          partição casa.
+        columns:
+          - name: competition_id
+            description: "ID da competição (a mesma chave de escopo do join do modelo)"
+          - name: season
+            description: "Rótulo de temporada"
+          - name: n_fixtures
+            description: "Quantos fixtures a partição tinha no congelamento"
+          - name: fp_fixtures
+            description: >
+              BIT_XOR(FARM_FINGERPRINT(...)) sobre os campos de fixture que o modelo lê
+              (fixture_id, competition, times, kickoff, status, gols). Independente de ordem.
+          - name: n_grupos
+            description: "Quantos times tinham grupo resolvido na partição"
+          - name: fp_standings
+            description: >
+              BIT_XOR(FARM_FINGERPRINT(...)) sobre (team_id, group_name) do team_group JÁ
+              RESOLVIDO — não do snapshot cru, que ganha uma linha por dia e jogaria todas as
+              competições fora da comparação.
+
+      - name: baseline_pit_meta
+        description: >
+          Quando o baseline foi congelado, de qual commit, e com quantas linhas/partições.
+          Uma linha só.

--- a/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
+++ b/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
@@ -1,0 +1,131 @@
+{{ config(tags=['taskf']) }}
+-- COSTURA A da task [F] (issue #49, ADR 0007) — o default das vars reproduz produção.
+--
+-- A ADR 0007 deixa no código de produção uma var que produção nunca usa, e promete que o default
+-- dela preserva o comportamento. Este teste é o que transforma a promessa em fato verificado:
+-- enquanto ele passar, "o default preserva o comportamento" é verificação, e não comentário.
+-- Falha = o andaime da medição vazou para o caminho que o board serve.
+--
+-- QUEM RODA. Não é o agendado: a tag é `taskf` e não `guarda`, de propósito — o pipeline horário
+-- executa `dbt test --select tag:guarda` e o ticket que criou este teste (#50) promete que nada
+-- do agendado mudou. Quem roda é a própria medição, que materializa a camada de premissas com
+-- `dbt build` a cada célula (#51 a #54); a #52 chega a exigir por escrito que "a Costura A segue
+-- verde". O teste é executado, portanto, exatamente quando a var pode ter vazado — que é quando
+-- a pergunta dele importa. Fora disso: `dbt build --target taskF --select
+-- int_futebol_team_form_pit`.
+--
+-- Igualdade EXATA, sem tolerância: o modelo lê só fact_fixtures e fact_standings_snapshot — é
+-- determinístico, não encosta em odds, e por isso não há deriva legítima para acomodar. A
+-- comparação é linha a linha, nos dois sentidos (EXCEPT DISTINCT dos dois lados), sobre lista
+-- EXPLÍCITA de colunas: coluna nova acrescentada por um ticket seguinte não invalida o baseline
+-- silenciosamente, e dbt_loaded_at fica de fora porque muda a cada build por construção.
+--
+-- ⚠️ O que é restringido é QUAIS LINHAS são comparáveis, nunca QUANTO elas podem diferir. O
+-- porquê, e o contrato congelado da impressão digital, estão na macro
+-- taskf_fingerprint_insumo_pit — a MESMA que gravou o baseline. Se as duas pontas divergirem,
+-- nenhuma partição casa.
+--
+-- PISO DE COBERTURA. Restringir linhas comparáveis tem um modo de falha próprio: a cobertura
+-- encolhe sozinha conforme o insumo anda, e uma guarda que compara 3 linhas continua verde
+-- dizendo o mesmo que uma que compara 21 mil. Por isso a cobertura é medida e tem piso declarado
+-- (`taskf_cobertura_minima`, hoje 0,5 das linhas do baseline): abaixo dele o teste FALHA, com os
+-- números na saída. O piso não é alto de propósito — durante a [F] as competições da temporada
+-- corrente saem da comparação legitimamente, uma a uma, conforme os jogos acontecem. Ele pega a
+-- erosão estrutural, não a natural. Quando ele disparar, as duas saídas honestas são recongelar
+-- o baseline de propósito (no mesmo commit da mudança que o justifica) ou baixar o piso de
+-- propósito — as duas explícitas, nenhuma silenciosa.
+--
+-- Falsificada uma vez com `--vars '{pit_escopo: todas}'`, que a deixa vermelha (12.868
+-- divergências). Consequência disso: nas células juntadas esta guarda é VERMELHA POR DESENHO,
+-- porque a saída ali de fato não é a de produção. Quem roda as células exclui as duas guardas que
+-- afirmam coisa de célula `base` — esta e o `assert_pit_first_game_has_no_history`, cuja
+-- invariante é competição-scoped por definição (ver #53):
+--
+--   dbt build --target taskF --select int_futebol_team_form_pit \
+--     --vars '{pit_escopo: todas}' \
+--     --exclude assert_taskf_pit_default_igual_baseline assert_pit_first_game_has_no_history
+
+{% set colunas = [
+    'fixture_id', 'team_id', 'competition', 'competition_id', 'season', 'kickoff_utc',
+    'played_home', 'played_away', 'played_total',
+    'wins_home', 'draws_home', 'wins_away', 'draws_away', 'wins_total', 'draws_total',
+    'goals_for_avg_home', 'goals_for_avg_away', 'goals_for_avg_total',
+    'goals_against_avg_home', 'goals_against_avg_away', 'goals_against_avg_total',
+    'clean_sheet_total', 'failed_to_score_total',
+    'rank', 'points', 'goal_diff', 'ppg', 'n_teams', 'group_name',
+    'n_wins_last5', 'n_games_last5', 'form_last5'
+] %}
+
+WITH {{ taskf_fingerprint_insumo_pit() }},
+
+-- As partições em que o insumo não se mexeu desde o congelamento. IS NOT DISTINCT FROM porque
+-- fp_standings é NULL em competição sem tabela (Copa do Brasil) — NULL = NULL tem de casar.
+particoes_casadas AS (
+    SELECT b.competition_id, b.season
+    FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }} b
+    JOIN fp_insumo_pit a
+        ON  a.competition_id = b.competition_id
+        AND a.season         = b.season
+    WHERE a.n_fixtures    = b.n_fixtures
+      AND a.fp_fixtures   = b.fp_fixtures
+      AND a.n_grupos      = b.n_grupos
+      AND a.fp_standings IS NOT DISTINCT FROM b.fp_standings
+),
+
+atual AS (
+    SELECT {{ colunas | join(', ') }}
+    FROM {{ ref('int_futebol_team_form_pit') }}
+    JOIN particoes_casadas USING (competition_id, season)
+),
+
+baseline_completo AS (
+    SELECT {{ colunas | join(', ') }}
+    FROM {{ source('futebol_taskF', 'baseline_int_futebol_team_form_pit') }}
+),
+
+baseline AS (
+    SELECT {{ colunas | join(', ') }}
+    FROM baseline_completo
+    JOIN particoes_casadas USING (competition_id, season)
+),
+
+divergencias AS (
+    SELECT 'so_no_baseline' AS motivo, TO_JSON_STRING(d) AS linha
+    FROM (SELECT * FROM baseline EXCEPT DISTINCT SELECT * FROM atual) d
+
+    UNION ALL
+
+    SELECT 'so_no_atual' AS motivo, TO_JSON_STRING(d) AS linha
+    FROM (SELECT * FROM atual EXCEPT DISTINCT SELECT * FROM baseline) d
+)
+
+SELECT motivo, linha FROM divergencias
+
+UNION ALL
+
+-- Piso de cobertura, que também é a guarda de vacuidade: zero linhas comparadas está abaixo de
+-- qualquer piso positivo, então passar em branco deixa de ser possível.
+SELECT
+    'cobertura_abaixo_do_piso' AS motivo,
+    TO_JSON_STRING(STRUCT(
+        linhas_comparadas, linhas_no_baseline, cobertura, piso,
+        particoes_casadas_n, particoes_no_baseline
+    )) AS linha
+FROM (
+    SELECT
+        linhas_comparadas,
+        linhas_no_baseline,
+        particoes_casadas_n,
+        particoes_no_baseline,
+        {{ var('taskf_cobertura_minima', 0.5) }} AS piso,
+        SAFE_DIVIDE(linhas_comparadas, linhas_no_baseline) AS cobertura
+    FROM (
+        SELECT
+            (SELECT COUNT(*) FROM atual)               AS linhas_comparadas,
+            (SELECT COUNT(*) FROM baseline_completo)   AS linhas_no_baseline,
+            (SELECT COUNT(*) FROM particoes_casadas)   AS particoes_casadas_n,
+            (SELECT COUNT(*) FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }})
+                                                       AS particoes_no_baseline
+    )
+)
+WHERE cobertura IS NULL OR cobertura < piso

--- a/profiles.yml
+++ b/profiles.yml
@@ -40,4 +40,18 @@ dbt_futebol:
       threads: 4
       location: us-east1
 
+    # Dataset de MEDICAO da task [F] (issue #49). Existe porque dev e prod apontam ambos para o
+    # dataset de producao `futebol` e dev e o default: um `dbt run` sem --target publicaria
+    # historico juntado no board. Nada agendado usa este target. Ver ADR 0007.
+    taskF:
+      type: bigquery
+      method: oauth
+      project: smartbetting-dados
+      dataset: futebol_taskF
+      threads: 4
+      location: us-east1
+      job_execution_timeout_seconds: 900
+      job_retries: 1
+      priority: interactive
+
   target: dev


### PR DESCRIPTION
Fecha o #50 (F-1). Depois deste PR, **medir uma célula do 2×2 é escolher um valor de var** — não
reescrever modelo.

> ⚠️ **Empilhado**: a base deste PR é `taskf-glossario-e-adrs` (#60), que carrega as ADRs 0007/0008
> e o glossário que este código implementa. Mergear o #60 primeiro; o base deste vira `master`
> sozinho. Nada aqui depende de mergear os dois juntos.

## O que entra

**Target `taskF`** (`profiles.yml`) → dataset `futebol_taskF`. Não é luxo: `dev` **e** `prod`
apontam para o mesmo dataset `futebol` e `dev` é o default, então um `dbt run` sem `--target`
publicaria PIT juntado no board (ADR 0007). Nada agendado usa o target novo.

**Dois eixos** no `int_futebol_team_form_pit`:

| var | default (= produção) | célula |
|---|---|---|
| `pit_escopo` | `da_competicao` | `todas` |
| `pit_recorte` | `temporada` | `ultimos_10` |

Os dois valores de cada eixo estão implementados (os quatro compilados validados no BigQuery com
`--dry_run`), e valor desconhecido levanta erro de compilação em vez de medir `base` calado.

**A tabela do campeonato não segue os eixos.** Fora do default o modelo emite um agregado próprio,
competição+temporada, e é dele que saem `rank` e `ppg`. Classificação existe dentro de uma
competição (ADR 0008) — então as quatro premissas de tabela dão número idêntico nas quatro células
por construção, e não por disciplina de quem mede.

## As provas, não as promessas

**No default o SQL compilado é byte-idêntico** ao de antes das vars — `diff` do compilado
antes/depois sai vazio. Nenhum ramo novo é emitido no caminho que produção usa.

**Costura A** (`tests/assert_taskf_pit_default_igual_baseline.sql`). O baseline foi congelado
**antes** de a var entrar (commit `a3b954e`, 21.054 linhas), e o teste compara a saída no default
contra ele: igualdade exata, linha a linha, nos dois sentidos, sobre lista explícita de colunas.

O insumo do modelo é vivo — fixture novo, resultado que entra, jogo remarcado —, então junto do
baseline vai uma impressão digital do insumo por (`competition_id`, `season`) e a comparação roda
só nas partições cujo insumo não mudou. **É restrição de quais linhas são comparáveis, nunca de
quanto elas podem diferir**: dentro da partição casada não há folga. Hoje casam **37/37 partições
e 21.054/21.054 linhas**.

A digital sai de **uma macro única**, lida pelas duas pontas — a que gravou o baseline e a que o
confere. Duas cópias que precisam ficar idênticas para sempre não ficam, e a falha seria muda:
nenhuma partição casaria e a guarda ficaria *vazia*, não vermelha. Contra a mesma falha, a
cobertura tem **piso declarado** (`taskf_cobertura_minima`, 0,5) — encolher em silêncio até
comparar 3 linhas é modo de falha real, e agora ele falha.

**As duas guardas foram falsificadas, não só vistas passar:**

| falsificação | resultado |
|---|---|
| `--vars '{pit_escopo: todas}'` | Costura A acusa **12.868 divergências** |
| `--vars '{taskf_cobertura_minima: 1.01}'` | acusa cobertura insuficiente |

**Sanidade das outras três células** (leitura, sem materializar): grão intacto nas quatro
(21.054 linhas = 21.054 pares, zero fan-out), `escopo` acrescenta histórico sobre a `base`
(289.920 vs 237.630 jogos anteriores), as de recorte de contagem cortam porque saturam em 10, e a
cobertura de `rank` é **idêntica nas quatro** (15.277) — a ADR 0008 valendo por construção.

## Nada do pipeline agendado mudou

Nenhum workflow YAML, nenhum script de deploy, nenhum `--select`, nenhuma imagem. O agendado roda
`dbt test --select tag:guarda` (`workflow_futebol.yml:782`) e o teste novo é `tag: taskf`, fora
dele. As **14 guardas rodadas contra produção** depois da mudança: PASS=14, ERROR=0. A tabela de
produção não foi reescrita — última modificação = o run agendado das 12:11 UTC.

`dbt build --target taskF --select int_futebol_team_form_pit` verde, **10/10**, incluindo o teste
de grão (fan-out é o risco número um de soltar `competition_id` de um join) e o guard da Task 0.

## Dois avisos para quem revisa

1. **O `assert_pit_first_game_has_no_history` fica vermelho (224 linhas) nas células de escopo
   juntado** — é o guard estando *certo* sobre uma invariante que é competição-scoped por
   definição. Não foi tocado aqui de propósito: ele é `tag:guarda` e roda de hora em hora, então
   mexer nele violaria a última promessa deste ticket. Repassado à #53 com as duas saídas, e o
   comando de exclusão para builds de célula está no cabeçalho do teste.
2. **Depois do merge o `deriva-imagem` vai acusar** até alguém rodar `build-and-push.sh
   dbt_futebol`. O rebuild é seguro: no default o compilado é byte-idêntico e a Costura A prova a
   equivalência. Não foi rodado aqui porque nada agendado pode mudar neste ticket.

Revisado nos dois eixos (Standards e Spec) antes de abrir; os achados dos dois estão corrigidos
neste diff — em particular a extração da macro de digital e o piso de cobertura.

Closes #50
Refs #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)