### PR TITLE
[F-2] Célula base ponta a ponta: universo congelado e reconciliação com a [0.1]

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -291,10 +291,13 @@ _Avoid_: C1–C4 (C1, C2 and C3 already name subtasks of the [C] Coleta task)
 The fixed set of fixtures every célula is measured over — the [0.1]'s published window, 169
 fixtures. Its ceiling is an **instant**, not a date: the [0.1] ran mid-day with no frozen cutoff,
 so `DATE(kickoff) <= '2026-08-04'` returns 178 and only `kickoff < 04/08 12:00 UTC` returns the
-published 169. Written once in `taskf_janela()`; see `docs/TASKF_RESULTADOS.md`.
-_Avoid_: janela — that word already names the odds collection window and its two derivatives, and
-this is a third unrelated thing. Say "universo congelado", or "o corte", never "a janela da
-medição".
+published 169. Written once in `taskf_universo()`; see `docs/TASKF_RESULTADOS.md`.
+_Avoid_: janela in prose — that word already names the odds collection window and its two
+derivatives, and this is a third unrelated thing. Say "universo congelado" or "o corte".
+The `janela_ini` / `janela_fim` **columns** are the one exception, and deliberate: they are the
+[0.1]'s own column names, carried over so the measured output lines up with the published table
+field for field. Renaming them would buy vocabulary hygiene at the cost of the reconciliation
+being eyeball-checkable against the doc.
 
 **min_jogos**:
 The smaller of the two teams' prior-fixture counts for a rated fixture, under the escopo and

--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -287,6 +287,15 @@ and remeasured. Two cells are comparable only if computed in the same run over t
 universe. The four are `base`, `escopo`, `recorte` and `ambos`, named for the axis each releases.
 _Avoid_: C1–C4 (C1, C2 and C3 already name subtasks of the [C] Coleta task)
 
+**Universo congelado**:
+The fixed set of fixtures every célula is measured over — the [0.1]'s published window, 169
+fixtures. Its ceiling is an **instant**, not a date: the [0.1] ran mid-day with no frozen cutoff,
+so `DATE(kickoff) <= '2026-08-04'` returns 178 and only `kickoff < 04/08 12:00 UTC` returns the
+published 169. Written once in `taskf_janela()`; see `docs/TASKF_RESULTADOS.md`.
+_Avoid_: janela — that word already names the odds collection window and its two derivatives, and
+this is a third unrelated thing. Say "universo congelado", or "o corte", never "a janela da
+medição".
+
 **min_jogos**:
 The smaller of the two teams' prior-fixture counts for a rated fixture, under the escopo and
 recorte in force. It is the number the piso de amostra cuts on, and what makes a fixture an

--- a/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_01.sql
@@ -37,6 +37,28 @@
     A régua está em `taskf_tolerancia_pp` (default 0,5 pp), aplicada só sobre a origem 1. O valor
     é declarado e justificado por escrito em `docs/TASKF_RESULTADOS.md` — aqui ele é só o número.
 
+    ⚠️ O QUE A PRIMEIRA EXECUÇÃO MOSTROU, e que muda como esta saída deve ser lida (12/08/2026):
+
+    - A origem 2 tem footprint ZERO nas 39 linhas publicadas, e isso foi medido, não suposto. Na
+      janela congelada, 1X2, BTTS e Dupla Chance não têm NENHUMA linha de conjunto incompleto; as
+      237 que existem estão em Handicap (58) e Gols (179) e são TODAS de consenso puro — nenhuma
+      delas tem preço da Pinnacle em nenhuma janela, conferido contra um controle que casa 3.370
+      de 6.566 linhas normais, então o join não é vácuo. Como o benchmark preferido de Handicap e
+      Gols é o sharp, a correção não alcança nenhuma linha comparada. O `correcao_22` continua na
+      classificação porque a próxima janela de medição pode não ter essa sorte.
+
+    - A origem 1 NÃO TEM MECANISMO NESTA JANELA. A coleta de odds é forward-only e para no
+      apito: para os 169 jogos congelados, ZERO capturas com data posterior a 04/08 em qualquer
+      das três janelas de fechamento. O insumo de `linha_caiu` (média das probabilidades
+      implícitas de todas as casas, t24h → t15m) é, portanto, imóvel. "As odds viram sozinhas
+      entre builds" é verdade no board vivo e FALSA num universo congelado do passado — e essa
+      distinção não estava escrita em lugar nenhum antes desta medição.
+
+    Consequência: `DENTRO_DA_TOLERANCIA` aqui significa "passou na régua declarada", e NÃO
+    "explicado". A régua foi declarada antes de medir, e continua valendo como bar; o que a
+    medição acrescenta é que a única linha que a usou não tem a causa que a justificaria. O
+    resíduo está documentado em `docs/TASKF_RESULTADOS.md`, aberto e delimitado.
+
     ────────────────────────────────────────────────────────────────────────────────
     O QUE É COMPARÁVEL, POR LINHA
 
@@ -96,13 +118,17 @@ juntado AS (
         m.mercado  IS NULL AS so_no_publicado,
         p.mercado  IS NULL AS so_no_medido,
 
-        m.n_p0          AS n_p0_medido,          p.n_p0          AS n_p0_pub,
-        m.diferenca_p0  AS dif_p0_medido,        p.diferenca_p0  AS dif_p0_pub,
-        m.a_odd_dava_p0 AS a_odd_dava_p0_medido, p.a_odd_dava_p0 AS a_odd_dava_p0_pub,
-        m.aconteceu_p0  AS aconteceu_p0_medido,  p.aconteceu_p0  AS aconteceu_p0_pub,
-        m.n_p5          AS n_p5_medido,          p.n_p5          AS n_p5_pub,
-        m.diferenca_p5  AS dif_p5_medido,        p.diferenca_p5  AS dif_p5_pub,
-        m.diferenca_p10 AS dif_p10_medido,       p.diferenca_p10 AS dif_p10_pub
+        m.n_p0              AS n_p0_medido,          p.n_p0              AS n_p0_pub,
+        m.diferenca_p0      AS dif_p0_medido,        p.diferenca_p0      AS dif_p0_pub,
+        m.a_odd_dava_p0     AS a_odd_dava_p0_medido, p.a_odd_dava_p0     AS a_odd_dava_p0_pub,
+        m.aconteceu_p0      AS aconteceu_p0_medido,  p.aconteceu_p0      AS aconteceu_p0_pub,
+        m.jogos_medios      AS jogos_medios_medido,  p.jogos_medios      AS jogos_medios_pub,
+        m.pct_amostra_curta AS pct_curta_medido,     p.pct_amostra_curta AS pct_curta_pub,
+        m.peso_p0           AS peso_p0_medido,       p.peso_p0           AS peso_p0_pub,
+        m.peso_p0_k0        AS peso_p0_k0_medido,    p.peso_p0_k0        AS peso_p0_k0_pub,
+        m.n_p5              AS n_p5_medido,          p.n_p5              AS n_p5_pub,
+        m.diferenca_p5      AS dif_p5_medido,        p.diferenca_p5      AS dif_p5_pub,
+        m.diferenca_p10     AS dif_p10_medido,       p.diferenca_p10     AS dif_p10_pub
     FROM medido AS m
     FULL OUTER JOIN publicado_01 AS p
       ON  p.mercado  = m.mercado
@@ -126,7 +152,22 @@ classificado AS (
        + IF(n_p0_pub          IS NOT NULL, 1, 0)
        + IF(n_p5_pub          IS NOT NULL, 1, 0)
        + IF(a_odd_dava_p0_pub IS NOT NULL, 1, 0)
-       + IF(aconteceu_p0_pub  IS NOT NULL, 1, 0)) AS campos_comparados,
+       + IF(aconteceu_p0_pub  IS NOT NULL, 1, 0)
+       + IF(jogos_medios_pub  IS NOT NULL, 1, 0)
+       + IF(pct_curta_pub     IS NOT NULL, 1, 0)
+       + IF(peso_p0_pub       IS NOT NULL, 1, 0)
+       + IF(peso_p0_k0_pub    IS NOT NULL, 1, 0)) AS campos_comparados,
+
+        {#- Campos publicados que NÃO estão em pontos percentuais (contagem de jogos, fração,
+            peso) não entram no `maior_delta_pp`, que é uma régua em pp. Entram aqui, como
+            contagem de campos que bateram — divergência neles é achado do mesmo jeito, só não
+            é comparável com a régua. -#}
+        (IF(jogos_medios_pub IS NOT NULL AND jogos_medios_medido IS DISTINCT FROM jogos_medios_pub, 1, 0)
+       + IF(pct_curta_pub    IS NOT NULL AND pct_curta_medido    IS DISTINCT FROM pct_curta_pub,    1, 0)
+       + IF(peso_p0_pub      IS NOT NULL AND peso_p0_medido      IS DISTINCT FROM peso_p0_pub,      1, 0)
+       + IF(peso_p0_k0_pub   IS NOT NULL AND peso_p0_k0_medido   IS DISTINCT FROM peso_p0_k0_pub,   1, 0)
+       + IF(n_p0_pub         IS NOT NULL AND n_p0_medido         IS DISTINCT FROM n_p0_pub,         1, 0)
+       + IF(n_p5_pub         IS NOT NULL AND n_p5_medido         IS DISTINCT FROM n_p5_pub,         1, 0)) AS campos_divergentes_nao_pp,
 
         CASE
             WHEN premissa IN ({{ premissas_de_odds | map('tojson') | join(', ') }})
@@ -153,12 +194,18 @@ SELECT
     n_p5_pub, n_p5_medido, n_p5_medido - n_p5_pub AS delta_n_p5,
     a_odd_dava_p0_pub, a_odd_dava_p0_medido,
     aconteceu_p0_pub,  aconteceu_p0_medido,
+    jogos_medios_pub,  jogos_medios_medido,
+    pct_curta_pub,     pct_curta_medido,
+    peso_p0_pub,       peso_p0_medido,
+    peso_p0_k0_pub,    peso_p0_k0_medido,
+    campos_divergentes_nao_pp,
     ROUND(maior_delta_pp, 1) AS maior_delta_pp,
     {{ tol }} AS tolerancia_pp,
     CASE
         WHEN so_no_medido OR so_no_publicado    THEN 'SEM_CONTRAPARTE'
         WHEN campos_comparados = 0              THEN 'NADA_A_COMPARAR'
-        WHEN maior_delta_pp = 0                 THEN 'EXATO'
+        WHEN maior_delta_pp = 0
+             AND campos_divergentes_nao_pp = 0  THEN 'EXATO'
         WHEN origem = 'deriva_de_odds'
              AND maior_delta_pp <= {{ tol }}    THEN 'DENTRO_DA_TOLERANCIA'
         WHEN origem = 'deriva_de_odds'          THEN 'DERIVA_ACIMA_DA_TOLERANCIA'

--- a/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_01.sql
@@ -1,0 +1,172 @@
+{#
+    [F-2] RECONCILIAÇÃO: a célula `base` contra o Teste 2 publicado da Task [0.1].
+
+    `base` é a célula que não muda nada — escopo na competição do jogo, recorte na temporada
+    corrente, que é o que roda hoje. Se ela não reproduz o número publicado, o caminho inteiro da
+    medição (var → target → dataset → Teste 2 → comparação) está errado em algum ponto, e as
+    outras três células não têm como significar coisa alguma. É o tracer bullet: o caso em que a
+    resposta já é conhecida.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A TOLERÂNCIA COBRE UMA ORIGEM DE DIVERGÊNCIA, E SÓ UMA
+
+    A [0.1] rodou em 04/08 e esta medição roda depois. Entre as duas execuções o número de uma
+    premissa pode andar por motivos diferentes, e tratá-los como um só é o que transformaria a
+    tolerância em desculpa. São três, e a saída os separa em `origem`:
+
+    1. `deriva_de_odds` — a ÚNICA que a tolerância cobre. `linha_subindo` e `linha_descendo` leem
+       odds ao vivo: elas acendem comparando o preço de abertura com o de fechamento, e o
+       fechamento é a última janela de coleta disponível NO MOMENTO DO BUILD. Uma janela t15m que
+       chegou depois de 04/08 muda quais linhas acendem, então tanto a `diferença` quanto o `n`
+       andam sozinhos, sem bug. Já medido no repositório: o mercado de Gols não é reproduzível
+       entre builds, e a mesma query devolve −7,4 e −7,6 em dias diferentes.
+
+    2. `correcao_22` — divergência de OUTRA origem, que a tolerância NÃO cobre e que a saída
+       marca para ser explicada. A spec #22 corrigiu o de-vig em 05/08, DEPOIS da publicação: o
+       conjunto de saídas incompleto deixou de emitir valor. Os números publicados incluíam 172
+       linhas dessas no Teste 2 (2 vitórias em 172, ROI −35,5%) — TODAS de consenso. Elas não
+       existem mais. Então a reprodução exata do que foi publicado no benchmark de consenso é
+       impossível por construção, e o BTTS é o mercado atingido no lugar que dói, porque o
+       benchmark preferido dele é justamente o consenso. Isto não é deriva; é uma correção
+       conhecida, e o lugar dela é a coluna de origem e o doc de resultados, não a folga.
+
+    3. `investigar` — o resto. Premissa que não lê odds, em mercado ancorado na Pinnacle, medida
+       sobre o mesmo universo congelado: deveria ser DETERMINÍSTICA. Diferença aqui não tem
+       explicação pronta e é achado até que se prove o contrário.
+
+    A régua está em `taskf_tolerancia_pp` (default 0,5 pp), aplicada só sobre a origem 1. O valor
+    é declarado e justificado por escrito em `docs/TASKF_RESULTADOS.md` — aqui ele é só o número.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O QUE É COMPARÁVEL, POR LINHA
+
+    O doc publica três recortes diferentes (ver macros/taskf_publicado_01.sql), então nem toda
+    linha tem todo campo. `campos_comparados` diz quantos de fato foram conferidos, e
+    `sem_contraparte` marca a linha medida que não tem número publicado nenhum. Sem isso,
+    "bateu" fica indistinguível de "não havia o que comparar" — que é o modo de falha silencioso
+    de qualquer reconciliação.
+
+    Só o benchmark PREFERIDO de cada mercado entra: é o recorte que o doc publica. As linhas de
+    consenso do Handicap e do Gols (`usado_para_peso = false`) não têm contraparte e ficam de
+    fora da comparação de propósito.
+
+    Rodar com (depois de taskf_teste2 ter materializado a célula `base`):
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+        --select taskf_reconciliacao_01
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+#}
+
+{%- set tol = var('taskf_tolerancia_pp', 0.5) -%}
+
+{#- As duas premissas que leem odds ao vivo. Não é uma lista de exceções conveniente: é o
+    conjunto exato das que comparam preço com preço, e ele sai do catálogo do Motor. Qualquer
+    outra premissa lê fixture, estatística ou tabela — tudo determinístico sobre o mesmo
+    universo congelado. -#}
+{%- set premissas_de_odds = ['linha_subindo', 'linha_descendo'] -%}
+
+WITH {{ taskf_publicado_01() }},
+
+medido AS (
+    SELECT
+        mercado, premissa, benchmark, usado_para_peso,
+        jogos_no_universo, medido_em, git_sha,
+        n_p0, a_odd_dava_p0, aconteceu_p0, diferenca_p0,
+        jogos_medios, pct_amostra_curta, peso_p0, peso_p0_k0,
+        n_p5, diferenca_p5, diferenca_p10
+    FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    WHERE celula = 'base'
+      AND usado_para_peso
+),
+
+{#- FULL OUTER para que a linha publicada sem contraparte medida apareça — 39 de cada lado é o
+    esperado, e um FULL OUTER é o que denuncia quando não é. -#}
+juntado AS (
+    SELECT
+        COALESCE(m.mercado,  p.mercado)  AS mercado,
+        COALESCE(m.premissa, p.premissa) AS premissa,
+        m.jogos_no_universo,
+        m.medido_em,
+        m.git_sha,
+        m.mercado  IS NULL AS so_no_publicado,
+        p.mercado  IS NULL AS so_no_medido,
+
+        m.n_p0          AS n_p0_medido,          p.n_p0          AS n_p0_pub,
+        m.diferenca_p0  AS dif_p0_medido,        p.diferenca_p0  AS dif_p0_pub,
+        m.a_odd_dava_p0 AS a_odd_dava_p0_medido, p.a_odd_dava_p0 AS a_odd_dava_p0_pub,
+        m.aconteceu_p0  AS aconteceu_p0_medido,  p.aconteceu_p0  AS aconteceu_p0_pub,
+        m.n_p5          AS n_p5_medido,          p.n_p5          AS n_p5_pub,
+        m.diferenca_p5  AS dif_p5_medido,        p.diferenca_p5  AS dif_p5_pub,
+        m.diferenca_p10 AS dif_p10_medido,       p.diferenca_p10 AS dif_p10_pub
+    FROM medido AS m
+    FULL OUTER JOIN publicado_01 AS p
+      ON  p.mercado  = m.mercado
+      AND p.premissa = m.premissa
+),
+
+classificado AS (
+    SELECT
+        *,
+        {#- A maior divergência entre os pisos publicados é o que decide o veredito da linha: uma
+            premissa que bate no piso 0 e erra 9 pp no piso 5 não "bateu". -#}
+        GREATEST(
+            COALESCE(ABS(dif_p0_medido  - dif_p0_pub),  0),
+            COALESCE(ABS(dif_p5_medido  - dif_p5_pub),  0),
+            COALESCE(ABS(dif_p10_medido - dif_p10_pub), 0)
+        ) AS maior_delta_pp,
+
+        (IF(dif_p0_pub        IS NOT NULL, 1, 0)
+       + IF(dif_p5_pub        IS NOT NULL, 1, 0)
+       + IF(dif_p10_pub       IS NOT NULL, 1, 0)
+       + IF(n_p0_pub          IS NOT NULL, 1, 0)
+       + IF(n_p5_pub          IS NOT NULL, 1, 0)
+       + IF(a_odd_dava_p0_pub IS NOT NULL, 1, 0)
+       + IF(aconteceu_p0_pub  IS NOT NULL, 1, 0)) AS campos_comparados,
+
+        CASE
+            WHEN premissa IN ({{ premissas_de_odds | map('tojson') | join(', ') }})
+                THEN 'deriva_de_odds'
+            {#- O consenso é o benchmark preferido do BTTS, e é onde as 172 linhas degeneradas da
+                spec #22 viviam. Toda linha de BTTS carrega essa origem por construção. -#}
+            WHEN mercado = 'BTTS' THEN 'correcao_22'
+            ELSE 'investigar'
+        END AS origem
+    FROM juntado
+)
+
+SELECT
+    mercado,
+    premissa,
+    origem,
+    campos_comparados,
+    so_no_medido,
+    so_no_publicado,
+    n_p0_pub,  n_p0_medido,  n_p0_medido  - n_p0_pub  AS delta_n_p0,
+    dif_p0_pub,  dif_p0_medido,  ROUND(dif_p0_medido  - dif_p0_pub,  1) AS delta_p0,
+    dif_p5_pub,  dif_p5_medido,  ROUND(dif_p5_medido  - dif_p5_pub,  1) AS delta_p5,
+    dif_p10_pub, dif_p10_medido, ROUND(dif_p10_medido - dif_p10_pub, 1) AS delta_p10,
+    n_p5_pub, n_p5_medido, n_p5_medido - n_p5_pub AS delta_n_p5,
+    a_odd_dava_p0_pub, a_odd_dava_p0_medido,
+    aconteceu_p0_pub,  aconteceu_p0_medido,
+    ROUND(maior_delta_pp, 1) AS maior_delta_pp,
+    {{ tol }} AS tolerancia_pp,
+    CASE
+        WHEN so_no_medido OR so_no_publicado    THEN 'SEM_CONTRAPARTE'
+        WHEN campos_comparados = 0              THEN 'NADA_A_COMPARAR'
+        WHEN maior_delta_pp = 0                 THEN 'EXATO'
+        WHEN origem = 'deriva_de_odds'
+             AND maior_delta_pp <= {{ tol }}    THEN 'DENTRO_DA_TOLERANCIA'
+        WHEN origem = 'deriva_de_odds'          THEN 'DERIVA_ACIMA_DA_TOLERANCIA'
+        WHEN origem = 'correcao_22'             THEN 'EXPLICADA_PELA_CORRECAO_22'
+        ELSE                                         'INVESTIGAR'
+    END AS veredito,
+    jogos_no_universo,
+    medido_em,
+    git_sha
+FROM classificado
+ORDER BY maior_delta_pp DESC, mercado, premissa

--- a/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_01.sql
@@ -54,10 +54,15 @@
       entre builds" é verdade no board vivo e FALSA num universo congelado do passado — e essa
       distinção não estava escrita em lugar nenhum antes desta medição.
 
-    Consequência: `DENTRO_DA_TOLERANCIA` aqui significa "passou na régua declarada", e NÃO
-    "explicado". A régua foi declarada antes de medir, e continua valendo como bar; o que a
-    medição acrescenta é que a única linha que a usou não tem a causa que a justificaria. O
-    resíduo está documentado em `docs/TASKF_RESULTADOS.md`, aberto e delimitado.
+    Consequência: nesta janela NENHUMA linha se classifica como `deriva_de_odds`, porque o
+    mecanismo não existe — `linha_descendo` cai em `INVESTIGAR`, que é o veredito honesto, e o
+    resíduo está documentado em `docs/TASKF_RESULTADOS.md`, aberto e delimitado. A régua de 0,5 pp
+    continua declarada e continua valendo: ela volta a ter mordida no universo estendido da spec,
+    que alcança o presente e onde `capturas_apos_o_teto` deixa de ser zero.
+
+    É por isso que os dois mecanismos são MEDIDOS e vão na saída (`capturas_apos_o_teto`,
+    `linhas_da_22_no_preferido`): quem lê não precisa acreditar no rótulo, ele vem com o número
+    que o produziu.
 
     ────────────────────────────────────────────────────────────────────────────────
     O QUE É COMPARÁVEL, POR LINHA
@@ -85,6 +90,7 @@
 #}
 
 {%- set tol = var('taskf_tolerancia_pp', 0.5) -%}
+{%- set j   = taskf_universo() -%}
 
 {#- As duas premissas que leem odds ao vivo. Não é uma lista de exceções conveniente: é o
     conjunto exato das que comparam preço com preço, e ele sai do catálogo do Motor. Qualquer
@@ -93,6 +99,81 @@
 {%- set premissas_de_odds = ['linha_subindo', 'linha_descendo'] -%}
 
 WITH {{ taskf_publicado_01() }},
+
+jogos_congelados AS (
+    SELECT fixture_id
+    FROM {{ ref('fact_fixtures') }}
+    WHERE status_short = 'FT'
+      AND goals_home IS NOT NULL
+      AND {{ taskf_universo_filtro() }}
+),
+
+{#- ─────────────────────────────────────────────────────────────────────────────────────
+    OS DOIS MECANISMOS SÃO MEDIDOS, NÃO SUPOSTOS.
+
+    A primeira versão desta análise rotulava a origem por dedução de mesa: "é premissa de odds,
+    logo é deriva" e "é BTTS, logo é a #22". Rótulo deduzido vira desculpa automática — um BTTS
+    que divergisse por qualquer motivo sairia carimbado como explicado, sem ninguém olhar, e a
+    #55 consumiria esse veredito como predicado. Os dois viraram medição.
+    ───────────────────────────────────────────────────────────────────────────────────── -#}
+
+{#- MECANISMO 1 — a deriva de odds é possível NESTA janela? Só é se tiver chegado captura depois
+    do teto do universo. A coleta é forward-only e para no apito, então para uma janela do passado
+    isto é zero, e "as odds viraram sozinhas" deixa de ser explicação disponível. Numa janela que
+    alcance o presente (o universo estendido da spec) deixa de ser zero, e aí o rótulo volta a
+    valer sozinho. -#}
+deriva AS (
+    SELECT COUNTIF(o.collection_date > DATE('{{ j.teto_utc }}')) AS capturas_apos_o_teto
+    FROM {{ ref('fact_odds_snapshot') }} AS o
+    JOIN jogos_congelados USING (fixture_id)
+),
+
+{#- MECANISMO 2 — a correção da spec #22 alcança o benchmark PREFERIDO de qual mercado?
+
+    Uma linha que o de-vig deixou de emitir só move um número comparado se ela estivesse no
+    benchmark preferido daquele mercado. E isso depende do mercado:
+
+      BTTS (8)                    preferido = consenso  -> QUALQUER linha nulada o alcança.
+      1X2 (1), Handicap (4),      preferido = sharp     -> só alcança se a Pinnacle precificava
+      Gols (5)                                             aquela linha; sem Pinnacle a linha
+                                                           nulada era de consenso e o consenso
+                                                           não pesa nesses mercados.
+      Dupla Chance (12)           preferido = derivada do de-vig 1X2 da Pinnacle -> mesma regra. -#}
+pinnacle_nas_linhas AS (
+    SELECT DISTINCT
+        fixture_id,
+        market_id,
+        COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
+    FROM {{ ref('fact_odds_snapshot') }}
+    WHERE bookmaker_id = 4
+),
+
+nuladas_pela_22 AS (
+    SELECT
+        d.market_id,
+        p.fixture_id IS NOT NULL AS tinha_pinnacle
+    FROM {{ ref('int_futebol_odds_devig') }} AS d
+    JOIN jogos_congelados USING (fixture_id)
+    LEFT JOIN pinnacle_nas_linhas AS p
+           ON  p.fixture_id = d.fixture_id
+           AND p.market_id  = d.market_id
+           AND p.line_key   = COALESCE(CAST(d.line_value AS STRING), 'NONE')
+    WHERE d.market_id IN ({{ task01_markets().keys() | join(', ') }})
+      AND COALESCE(d.n_outcomes_valor < 2, TRUE)
+),
+
+alcance_22 AS (
+    SELECT
+        CASE market_id
+            {%- for mid, m in task01_markets().items() %}
+            WHEN {{ mid }} THEN '{{ m.nome }}'
+            {%- endfor %}
+        END AS mercado,
+        COUNT(*)                                        AS linhas_nuladas,
+        IF(market_id = 8, COUNT(*), COUNTIF(tinha_pinnacle)) AS alcanca_o_preferido
+    FROM nuladas_pela_22
+    GROUP BY market_id
+),
 
 medido AS (
     SELECT
@@ -136,8 +217,10 @@ juntado AS (
 ),
 
 classificado AS (
+    {#- `jt.*` e não `*`: os dois CTEs de mecanismo entram por CROSS/LEFT JOIN e um `*` traria as
+        colunas deles duas vezes (a projeção abaixo já as nomeia). -#}
     SELECT
-        *,
+        jt.*,
         {#- A maior divergência entre os pisos publicados é o que decide o veredito da linha: uma
             premissa que bate no piso 0 e erra 9 pp no piso 5 não "bateu". -#}
         GREATEST(
@@ -162,22 +245,30 @@ classificado AS (
             peso) não entram no `maior_delta_pp`, que é uma régua em pp. Entram aqui, como
             contagem de campos que bateram — divergência neles é achado do mesmo jeito, só não
             é comparável com a régua. -#}
-        (IF(jogos_medios_pub IS NOT NULL AND jogos_medios_medido IS DISTINCT FROM jogos_medios_pub, 1, 0)
-       + IF(pct_curta_pub    IS NOT NULL AND pct_curta_medido    IS DISTINCT FROM pct_curta_pub,    1, 0)
-       + IF(peso_p0_pub      IS NOT NULL AND peso_p0_medido      IS DISTINCT FROM peso_p0_pub,      1, 0)
-       + IF(peso_p0_k0_pub   IS NOT NULL AND peso_p0_k0_medido   IS DISTINCT FROM peso_p0_k0_pub,   1, 0)
-       + IF(n_p0_pub         IS NOT NULL AND n_p0_medido         IS DISTINCT FROM n_p0_pub,         1, 0)
-       + IF(n_p5_pub         IS NOT NULL AND n_p5_medido         IS DISTINCT FROM n_p5_pub,         1, 0)) AS campos_divergentes_nao_pp,
+        (IF(jogos_medios_pub  IS NOT NULL AND jogos_medios_medido  IS DISTINCT FROM jogos_medios_pub,  1, 0)
+       + IF(pct_curta_pub     IS NOT NULL AND pct_curta_medido     IS DISTINCT FROM pct_curta_pub,     1, 0)
+       + IF(peso_p0_pub       IS NOT NULL AND peso_p0_medido       IS DISTINCT FROM peso_p0_pub,       1, 0)
+       + IF(peso_p0_k0_pub    IS NOT NULL AND peso_p0_k0_medido    IS DISTINCT FROM peso_p0_k0_pub,    1, 0)
+       + IF(n_p0_pub          IS NOT NULL AND n_p0_medido          IS DISTINCT FROM n_p0_pub,          1, 0)
+       + IF(n_p5_pub          IS NOT NULL AND n_p5_medido          IS DISTINCT FROM n_p5_pub,          1, 0)
+       + IF(a_odd_dava_p0_pub IS NOT NULL AND a_odd_dava_p0_medido IS DISTINCT FROM a_odd_dava_p0_pub, 1, 0)
+       + IF(aconteceu_p0_pub  IS NOT NULL AND aconteceu_p0_medido  IS DISTINCT FROM aconteceu_p0_pub,  1, 0))
+                                                                        AS campos_divergentes_fora_da_regua,
 
+        d.capturas_apos_o_teto,
+        COALESCE(a.alcanca_o_preferido, 0) AS linhas_da_22_no_preferido,
+
+        {#- A ordem importa: uma premissa de odds num mercado que a #22 alcança é classificada
+            como deriva, que é a origem mais específica dela. -#}
         CASE
             WHEN premissa IN ({{ premissas_de_odds | map('tojson') | join(', ') }})
-                THEN 'deriva_de_odds'
-            {#- O consenso é o benchmark preferido do BTTS, e é onde as 172 linhas degeneradas da
-                spec #22 viviam. Toda linha de BTTS carrega essa origem por construção. -#}
-            WHEN mercado = 'BTTS' THEN 'correcao_22'
+                 AND d.capturas_apos_o_teto > 0            THEN 'deriva_de_odds'
+            WHEN COALESCE(a.alcanca_o_preferido, 0) > 0    THEN 'correcao_22'
             ELSE 'investigar'
         END AS origem
-    FROM juntado
+    FROM juntado AS jt
+    CROSS JOIN deriva AS d
+    LEFT JOIN alcance_22 AS a ON a.mercado = jt.mercado
 )
 
 SELECT
@@ -198,18 +289,26 @@ SELECT
     pct_curta_pub,     pct_curta_medido,
     peso_p0_pub,       peso_p0_medido,
     peso_p0_k0_pub,    peso_p0_k0_medido,
-    campos_divergentes_nao_pp,
+    campos_divergentes_fora_da_regua,
+    capturas_apos_o_teto,
+    linhas_da_22_no_preferido,
     ROUND(maior_delta_pp, 1) AS maior_delta_pp,
     {{ tol }} AS tolerancia_pp,
+    {#- A régua é em pp e cobre a DIFERENÇA. `EXATO` exige também que os campos publicados fora
+        dela (n, jogos médios, % amostra curta, prob justa, acerto, pesos) tenham batido — senão
+        "exato" significaria "exato no que a régua olha", que não é o que a palavra diz.
+        `DENTRO_DA_TOLERANCIA` NÃO promete isso: leia `campos_divergentes_fora_da_regua` ao lado.
+        E `CORRECAO_22_ALCANCA` não é veredito de aprovação — é o aviso de que aquele mercado tem
+        linha nulada no benchmark preferido e, portanto, que a comparação ali não é limpa. -#}
     CASE
         WHEN so_no_medido OR so_no_publicado    THEN 'SEM_CONTRAPARTE'
         WHEN campos_comparados = 0              THEN 'NADA_A_COMPARAR'
         WHEN maior_delta_pp = 0
-             AND campos_divergentes_nao_pp = 0  THEN 'EXATO'
+             AND campos_divergentes_fora_da_regua = 0 THEN 'EXATO'
         WHEN origem = 'deriva_de_odds'
              AND maior_delta_pp <= {{ tol }}    THEN 'DENTRO_DA_TOLERANCIA'
         WHEN origem = 'deriva_de_odds'          THEN 'DERIVA_ACIMA_DA_TOLERANCIA'
-        WHEN origem = 'correcao_22'             THEN 'EXPLICADA_PELA_CORRECAO_22'
+        WHEN origem = 'correcao_22'             THEN 'CORRECAO_22_ALCANCA'
         ELSE                                         'INVESTIGAR'
     END AS veredito,
     jogos_no_universo,

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -29,8 +29,8 @@
     ────────────────────────────────────────────────────────────────────────────────
     O QUE MUDA EM RELAÇÃO AO ORIGINAL — três coisas, e só três:
 
-    1. UNIVERSO CONGELADO. `apostas` é recortada por taskf_janela_filtro(). O original rodou sem
-       corte (a janela dele é o instante da execução). Ver macros/taskf_janela.sql: o teto é um
+    1. UNIVERSO CONGELADO. `apostas` é recortada por taskf_universo_filtro(). O original rodou sem
+       corte (a janela dele é o instante da execução). Ver macros/taskf_universo.sql: o teto é um
        INSTANTE, não um dia, e é isso que devolve os 169 publicados em vez de 178.
     2. COLUNA DE CÉLULA, mais os dois eixos ao lado dela e o carimbo de quando/de-qual-commit.
        O rótulo é DERIVADO dos eixos por taskf_celula() — nunca digitado. Uma célula não tem como
@@ -75,7 +75,7 @@
 #}
 
 {%- set c      = taskf_celula() -%}
-{%- set j      = taskf_janela() -%}
+{%- set j      = taskf_universo() -%}
 {%- set pisos  = [0, 3, 5, 10] -%}
 {%- set tabela = 'smartbetting-dados.futebol_taskF.taskf_teste2' -%}
 
@@ -124,7 +124,7 @@ WITH {{ task01_base() }},
     números publicados da [0.1] não ser tocada por esta medição. -#}
 apostas_congeladas AS (
     SELECT * FROM apostas
-    WHERE {{ taskf_janela_filtro() }}
+    WHERE {{ taskf_universo_filtro() }}
 ),
 
 {#- Uma passada, grão (mercado, premissa, benchmark). Só as linhas em que a premissa ACENDEU

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -1,0 +1,228 @@
+{#
+    [F-2] O TESTE 2 da task [F] — o mesmo do [0.1], sobre o universo congelado, com coluna de
+    célula. É a saída que a Costura B (#55) vai testar e de onde saem as 39 linhas do entregável.
+
+        diferença = média(acerto | premissa acesa) − média(prob justa | premissa acesa)
+
+    ────────────────────────────────────────────────────────────────────────────────
+    POR QUE ESTA ANÁLISE É UM SCRIPT DDL, E NÃO UM MODELO dbt
+
+    Um modelo segue o target, e o target default é `dev`, que aponta para o dataset de PRODUÇÃO
+    (`futebol`) — o mesmo que `prod`. Um `dbt build` distraído publicaria medição no board. O
+    destino aqui está escrito no SQL, fixo em `futebol_taskF`, e por isso não tem como escorregar.
+    Mesmo argumento e mesmo padrão do analyses/taskf_congela_baseline.sql. Ver ADR 0007.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    POR QUE A AGREGAÇÃO É UMA CÓPIA DO analyses/task01_teste2.sql
+
+    Copiar código costuma ser o erro que a ADR 0007 recusou nos modelos de premissas — lá a cópia
+    derivaria da produção em silêncio. Aqui a assimetria é outra: o original não é código vivo, é
+    o REGISTRO CONGELADO de uma task encerrada ([0.1], PR #11), e ninguém o edita. O que a cópia
+    precisa reproduzir é um cálculo parado, não um que anda.
+
+    E a cópia não é acreditada, é verificada: a reconciliação da célula `base` contra os números
+    publicados (analyses/taskf_reconciliacao_01.sql) é exatamente o teste de que ela computa a
+    mesma coisa — nos mesmos dados para os quais foi copiada. Extrair a agregação para um macro
+    compartilhado teria o custo oposto e maior: mexer no artefato que produziu os números de
+    referência, com o risco de reconciliar a medição contra um bug meu.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O QUE MUDA EM RELAÇÃO AO ORIGINAL — três coisas, e só três:
+
+    1. UNIVERSO CONGELADO. `apostas` é recortada por taskf_janela_filtro(). O original rodou sem
+       corte (a janela dele é o instante da execução). Ver macros/taskf_janela.sql: o teto é um
+       INSTANTE, não um dia, e é isso que devolve os 169 publicados em vez de 178.
+    2. COLUNA DE CÉLULA, mais os dois eixos ao lado dela e o carimbo de quando/de-qual-commit.
+       O rótulo é DERIVADO dos eixos por taskf_celula() — nunca digitado. Uma célula não tem como
+       ser gravada com o nome de outra.
+    3. PISO 3 acrescentado à varredura, que no original é [0, 5, 10]. É o que a spec #49 pede
+       ("piso varrido em [0, 3, 5, 10] ... para distinguir achado de escolha de corte"). Entra
+       agora porque é este ticket que define o formato da tabela, e mudar formato depois da #55
+       ter testes em cima dele custa mais. A reconciliação compara só 0/5/10, que é o que a [0.1]
+       publicou.
+
+    Fora isso a agregação é a do original, incluindo o grão (mercado, premissa, BENCHMARK) — as
+    linhas de consenso do Handicap e do Gols continuam saindo marcadas `usado_para_peso = false`,
+    porque o ROI delas é muito pior que o das sharp e essa diferença é sobre QUAIS jogos a
+    Pinnacle escolhe precificar, não sobre o benchmark.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    ACUMULATIVA POR CÉLULA. A tabela é criada uma vez e cada execução substitui SÓ a sua célula
+    (DELETE + INSERT). As quatro convivem, que é o que a Costura B precisa. O schema é escrito
+    por extenso de propósito: ele é o contrato que as células seguintes (#53, #54) têm de cumprir,
+    e um INSERT de formato diferente falha alto em vez de alargar a tabela em silêncio.
+
+    ⚠️ `medido_em` existe porque a spec exige que as quatro células rodem na MESMA EXECUÇÃO — o
+    baseline não é reaproveitado justamente porque `linha_subindo`/`linha_descendo` leem odds ao
+    vivo e viram sozinhas entre builds. Com o carimbo, "mesma execução" é conferível na tabela; sem
+    ele, é confiança. Quem escreve a Costura B (#55) precisa dele.
+
+    Rodar com (do dbt_futebol/) — a célula sai das vars, e a camada de premissas em futebol_taskF
+    tem de ter sido construída com as MESMAS vars antes:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
+        --select +int_futebol_premissas_1x2 +int_futebol_premissas_ou +int_futebol_premissas_ah \
+                 +int_futebol_premissas_btts +int_futebol_premissas_dc +int_futebol_corroboracao
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_teste2 \
+        --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"'}'
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_teste2.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+#}
+
+{%- set c      = taskf_celula() -%}
+{%- set j      = taskf_janela() -%}
+{%- set pisos  = [0, 3, 5, 10] -%}
+{%- set tabela = 'smartbetting-dados.futebol_taskF.taskf_teste2' -%}
+
+{#- Uma lista, três usos: o DDL, a lista de colunas do INSERT e a ordem da projeção. Escrita duas
+    vezes, ela derivaria — e um INSERT posicional com colunas trocadas de lugar não dá erro, dá
+    número errado. -#}
+{%- set colunas = [
+    'celula STRING', 'pit_escopo STRING', 'pit_recorte STRING',
+    'medido_em TIMESTAMP', 'git_sha STRING',
+    'janela_ini DATE', 'janela_fim DATE',
+    'jogos_no_universo INT64', 'linhas_no_universo INT64',
+    'mercado STRING', 'premissa STRING', 'benchmark STRING', 'usado_para_peso BOOL',
+    'fator_encolhimento FLOAT64', 'jogos_medios FLOAT64', 'pct_amostra_curta FLOAT64'
+] -%}
+{%- for piso in pisos -%}
+    {%- set _ = colunas.extend([
+        'n_p' ~ piso ~ ' INT64',
+        'a_odd_dava_p' ~ piso ~ ' FLOAT64',
+        'aconteceu_p' ~ piso ~ ' FLOAT64',
+        'diferenca_p' ~ piso ~ ' FLOAT64',
+        'peso_p' ~ piso ~ ' FLOAT64'
+    ]) -%}
+{%- endfor -%}
+{%- set _ = colunas.append('peso_p0_k0 FLOAT64') -%}
+{%- set nomes_colunas = [] -%}
+{%- for col in colunas -%}
+    {%- set _ = nomes_colunas.append(col.split(' ')[0]) -%}
+{%- endfor -%}
+
+
+CREATE TABLE IF NOT EXISTS `{{ tabela }}` (
+    {{ colunas | join(',\n    ') }}
+);
+
+
+DELETE FROM `{{ tabela }}` WHERE celula = '{{ c.nome }}';
+
+
+INSERT INTO `{{ tabela }}` ({{ nomes_colunas | join(', ') }})
+
+WITH {{ task01_base() }},
+
+{#- O UNIVERSO CONGELADO. Recortar aqui equivale a recortar `jogos_encerrados`: no task01_base()
+    todo o resto pende do universo de jogos por JOIN, e o `pit` é LEFT JOIN a partir dele. Fica
+    aqui, e não num parâmetro novo do macro compartilhado, para a definição que produziu os
+    números publicados da [0.1] não ser tocada por esta medição. -#}
+apostas_congeladas AS (
+    SELECT * FROM apostas
+    WHERE {{ taskf_janela_filtro() }}
+),
+
+{#- Uma passada, grão (mercado, premissa, benchmark). Só as linhas em que a premissa ACENDEU
+    entram nas médias — é essa a definição do Teste 2.
+
+    O PISO DE AMOSTRA entra como COLUNA, não como execução separada, porque o encolhimento (`k`) e
+    o piso tratam eixos DIFERENTES: `k` trata `n` pequeno (a premissa acendeu poucas vezes), o
+    piso trata jogo sem histórico. `clean_sheets_altos` tem n=105 (grande, o encolhimento mal
+    encosta) e 77% das linhas em jogo com menos de 5 partidas disputadas — a assinatura exata do
+    artefato que matou os +9,7% da Task [0]. Ver os dois lado a lado é o ponto. -#}
+agregado AS (
+    SELECT
+        a.market_id,
+        pl.premissa,
+        a.benchmark,
+        AVG(IF(pl.acesa, a.min_jogos, NULL))                     AS jogos_medios,
+        AVG(IF(pl.acesa, IF(a.min_jogos < 5, 1.0, 0.0), NULL))   AS frac_curta
+        {%- for piso in pisos %},
+        COUNTIF(pl.acesa AND a.min_jogos >= {{ piso }})          AS n_{{ piso }},
+        AVG(IF(pl.acesa AND a.min_jogos >= {{ piso }},
+               a.prob_justa_fechamento, NULL))                   AS p_odd_{{ piso }},
+        AVG(IF(pl.acesa AND a.min_jogos >= {{ piso }},
+               CAST(a.ganhou AS INT64), NULL))                   AS p_real_{{ piso }}
+        {%- endfor %}
+    FROM apostas_congeladas AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    GROUP BY a.market_id, pl.premissa, a.benchmark
+    HAVING COUNTIF(pl.acesa) > 0
+),
+
+janela AS (
+    SELECT
+        MIN(DATE(kickoff_utc))     AS janela_ini,
+        MAX(DATE(kickoff_utc))     AS janela_fim,
+        COUNT(DISTINCT fixture_id) AS jogos_no_universo,
+        COUNT(*)                   AS linhas_no_universo
+    FROM apostas_congeladas
+),
+
+{#- `preferido` calculado UMA vez, não repetido em cada coluna que depende dele. -#}
+rotulado AS (
+    SELECT
+        g.*,
+        CASE g.market_id
+            {%- for mid, m in task01_markets().items() %}
+            WHEN {{ mid }} THEN '{{ m.nome }}'
+            {%- endfor %}
+        END AS mercado,
+        g.benchmark = CASE g.market_id
+                          WHEN 12 THEN 'derivada'
+                          WHEN 8  THEN 'consenso'
+                          ELSE         'sharp'
+                      END AS preferido
+    FROM agregado AS g
+)
+
+SELECT
+    '{{ c.nome }}'                                          AS celula,
+    '{{ c.escopo }}'                                        AS pit_escopo,
+    '{{ c.recorte }}'                                       AS pit_recorte,
+    CURRENT_TIMESTAMP()                                     AS medido_em,
+    '{{ var("taskf_git_sha", "desconhecido") }}'            AS git_sha,
+    j.janela_ini,
+    j.janela_fim,
+    j.jogos_no_universo,
+    j.linhas_no_universo,
+    r.mercado,
+    r.premissa,
+    r.benchmark,
+    r.preferido                                             AS usado_para_peso,
+    -- Fator de encolhimento aplicado ao peso: n/(n+50). Exposto em vez de um flag binário de "n
+    -- suficiente" porque o corte seria arbitrário e este número já diz exatamente quanto da
+    -- medição sobreviveu. `desfalque_adversario` (n=7) fica em 0,12: qualquer sinal que ela
+    -- tivesse seria 88% descartado por falta de amostra, e isso é diferente de "medimos e deu
+    -- ruim".
+    ROUND(SAFE_DIVIDE(r.n_0, r.n_0 + 50), 2)                AS fator_encolhimento,
+    ROUND(r.jogos_medios, 1)                                AS jogos_medios,
+    ROUND(r.frac_curta * 100, 1)                            AS pct_amostra_curta
+    {%- for piso in pisos %},
+    r.n_{{ piso }}                                          AS n_p{{ piso }},
+    ROUND(r.p_odd_{{ piso }}  * 100, 1)                     AS a_odd_dava_p{{ piso }},
+    ROUND(r.p_real_{{ piso }} * 100, 1)                     AS aconteceu_p{{ piso }},
+    ROUND((r.p_real_{{ piso }} - r.p_odd_{{ piso }}) * 100, 1) AS diferenca_p{{ piso }},
+    -- peso = max(diferença, 0) × n/(n+k), k=50. Ganho negativo vira ZERO, não peso negativo: com
+    -- esta amostra, −5 é indistinguível de ruído.
+    IF(r.preferido,
+       ROUND(GREATEST((r.p_real_{{ piso }} - r.p_odd_{{ piso }}) * 100, 0)
+             * SAFE_DIVIDE(r.n_{{ piso }}, r.n_{{ piso }} + 50), 2),
+       NULL)                                                AS peso_p{{ piso }}
+    {%- endfor %},
+    -- Sensibilidade: peso sem encolhimento nenhum, no piso 0. Mostra o quanto o k=50 está
+    -- segurando.
+    IF(r.preferido,
+       ROUND(GREATEST((r.p_real_0 - r.p_odd_0) * 100, 0), 2),
+       NULL)                                                AS peso_p0_k0
+FROM rotulado AS r
+CROSS JOIN janela AS j

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -1,4 +1,4 @@
-{#
+/*
     [F-2] O TESTE 2 da task [F] — o mesmo do [0.1], sobre o universo congelado, com coluna de
     célula. É a saída que a Costura B (#55) vai testar e de onde saem as 39 linhas do entregável.
 
@@ -99,7 +99,7 @@
     (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
 
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
-#}
+*/
 
 {%- set c      = taskf_celula() -%}
 {%- set j      = taskf_universo() -%}
@@ -145,10 +145,8 @@ INSERT INTO `{{ tabela }}` ({{ nomes_colunas | join(', ') }})
 
 WITH {{ task01_base() }},
 
-{#- O UNIVERSO CONGELADO. Recortar aqui equivale a recortar `jogos_encerrados`: no task01_base()
-    todo o resto pende do universo de jogos por JOIN, e o `pit` é LEFT JOIN a partir dele. Fica
-    aqui, e não num parâmetro novo do macro compartilhado, para a definição que produziu os
-    números publicados da [0.1] não ser tocada por esta medição. -#}
+{#- O UNIVERSO CONGELADO. Por que o recorte cai aqui, em cima de `apostas`, e não num parâmetro
+    novo do task01_base(): está no cabeçalho de macros/taskf_universo.sql, junto do predicado. -#}
 apostas_congeladas AS (
     SELECT * FROM apostas
     WHERE {{ taskf_universo_filtro() }}

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -55,19 +55,46 @@
     ⚠️ `medido_em` existe porque a spec exige que as quatro células rodem na MESMA EXECUÇÃO — o
     baseline não é reaproveitado justamente porque `linha_subindo`/`linha_descendo` leem odds ao
     vivo e viram sozinhas entre builds. Com o carimbo, "mesma execução" é conferível na tabela; sem
-    ele, é confiança. Quem escreve a Costura B (#55) precisa dele.
+    ele, é confiança. Quem escreve a Costura B (#55) precisa dele, e a forma verificável é:
+    `fact_odds_snapshot.dbt_loaded_at` ANTERIOR aos quatro `medido_em`. Isso prova o que de fato
+    importa — que as quatro leram a MESMA construção dos fatos —, que é mais forte do que os
+    quatro carimbos serem próximos entre si.
 
-    Rodar com (do dbt_futebol/) — a célula sai das vars, e a camada de premissas em futebol_taskF
-    tem de ter sido construída com as MESMAS vars antes:
+    ────────────────────────────────────────────────────────────────────────────────
+    COMO RODAR (do dbt_futebol/) — DUAS FASES, e a separação não é economia, é correção.
+
+    FASE 1, uma vez só para as quatro células: a ancestria inteira, que é o que popula o dataset
+    de medição. Com `--target taskF` todo `ref()` resolve para futebol_taskF, então os fatos têm
+    de existir lá antes.
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
         --select +int_futebol_premissas_1x2 +int_futebol_premissas_ou +int_futebol_premissas_ah \
                  +int_futebol_premissas_btts +int_futebol_premissas_dc +int_futebol_corroboracao
 
+    FASE 2, uma vez POR CÉLULA: só os nós que respondem às vars — o PIT e os cinco modelos de
+    premissas. Nada de `+`.
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
+        --select int_futebol_team_form_pit int_futebol_premissas_1x2 int_futebol_premissas_ou \
+                 int_futebol_premissas_ah int_futebol_premissas_btts int_futebol_premissas_dc \
+        --vars '{pit_escopo: todas}'        # a célula; ausente = base
+
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_teste2 \
-        --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"'}'
+        --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', pit_escopo: todas}'
       bq query --use_legacy_sql=false --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_teste2.sql
+
+    ⚠️ NÃO use `+` na fase 2. O `+` reconstrói o `fact_odds_snapshot` a partir do NDJSON da landing
+    a cada célula, e aí as quatro deixam de ler a mesma construção dos fatos. O argumento que
+    sustenta a comparação entre células — um viés comum às quatro cancela — vale exatamente
+    porque elas leem UMA construção. Reconstruir por célula reinjeta entre elas a mesma variação
+    de 2 linhas que a reconciliação da `base` encontrou, e aí ela deixa de cancelar e passa a ser
+    lida como efeito de escopo. É também um rescan completo do NDJSON por célula, sem ganho.
+
+    ⚠️ Nas células de escopo juntado, duas guardas ficam vermelhas POR DESENHO — elas afirmam
+    coisa da célula `base`. Ver o cabeçalho de tests/assert_taskf_pit_default_igual_baseline.sql:
+
+      --exclude assert_taskf_pit_default_igual_baseline assert_pit_first_game_has_no_history
 
     (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
 

--- a/dbt_futebol/analyses/taskf_universo_congelado.sql
+++ b/dbt_futebol/analyses/taskf_universo_congelado.sql
@@ -17,7 +17,7 @@
                            [0.1] é um INSTANTE e não um dia: os 9 excedentes são os jogos de
                            04/08 com kickoff a partir das 16:00 UTC, que ainda não tinham sido
                            disputados quando a [0.1] executou.
-      C_janela_congelada   o corte da medição, que é o que taskf_janela() emite.
+      C_universo_congelado   o corte da medição, que é o que taskf_universo() emite.
       D_teto_alternativo   o MESMO corte com o teto na outra ponta do vão vazio (06:00 UTC em vez
                            de 12:00). Existe para mostrar que o teto não foi calibrado até o
                            número bater: entre ~02:00 e 16:00 UTC de 04/08 não há jogo nenhum na
@@ -43,7 +43,7 @@
     (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
 #}
 
-{%- set j = taskf_janela() %}
+{%- set j = taskf_universo() %}
 
 WITH {{ task01_base() }},
 
@@ -59,9 +59,9 @@ variantes AS (
 
     UNION ALL
 
-    SELECT 'C_janela_congelada', fixture_id, kickoff_utc, competition, benchmark
+    SELECT 'C_universo_congelado', fixture_id, kickoff_utc, competition, benchmark
     FROM apostas
-    WHERE {{ taskf_janela_filtro() }}
+    WHERE {{ taskf_universo_filtro() }}
 
     UNION ALL
 

--- a/dbt_futebol/analyses/taskf_universo_congelado.sql
+++ b/dbt_futebol/analyses/taskf_universo_congelado.sql
@@ -2,7 +2,7 @@
     [F-2] O universo congelado da medição, conferido contra o número publicado.
 
     A [F] compara quatro células entre si. Isso só significa alguma coisa se as quatro medirem os
-    MESMOS jogos, e a âncora desse "mesmos" é a janela publicada no doc de resultados da Task
+    MESMOS jogos, e a âncora desse "mesmos" é o recorte publicado no doc de resultados da Task
     [0.1]: 16/06/2026 a 04/08/2026, 169 jogos. Esta análise é a conferência dessa âncora — roda
     ANTES de materializar célula nenhuma, porque descobrir que o universo se mexeu depois de
     construir a camada de premissas é caro e tarde.
@@ -27,11 +27,11 @@
 
     E o piso: A e B devolvem `janela_ini = 2026-06-16` sem que ninguém peça, porque a coleta de
     odds é forward-only e começou nesse dia. O piso declarado é no-op — e fica declarado assim
-    mesmo, para a janela não depender de um efeito colateral da coleta.
+    mesmo, para o corte não depender de um efeito colateral da coleta.
 
     `jogos` sai de `apostas`, e não de `fact_fixtures`: o universo do Teste 2 é o de jogos
     liquidados COM preço nos 5 mercados do Motor, já com o filtro de meia-linha. Contar jogo
-    encerrado na janela daria outro número, maior, que não é o publicado.
+    encerrado no período daria outro número, maior, que não é o publicado.
 
     Rodar com (o target escolhe contra qual dataset se confere — `dev` lê produção, que é onde os
     169 foram publicados; `taskF` confere a célula já materializada):

--- a/dbt_futebol/analyses/taskf_universo_congelado.sql
+++ b/dbt_futebol/analyses/taskf_universo_congelado.sql
@@ -1,0 +1,89 @@
+{#
+    [F-2] O universo congelado da medição, conferido contra o número publicado.
+
+    A [F] compara quatro células entre si. Isso só significa alguma coisa se as quatro medirem os
+    MESMOS jogos, e a âncora desse "mesmos" é a janela publicada no doc de resultados da Task
+    [0.1]: 16/06/2026 a 04/08/2026, 169 jogos. Esta análise é a conferência dessa âncora — roda
+    ANTES de materializar célula nenhuma, porque descobrir que o universo se mexeu depois de
+    construir a camada de premissas é caro e tarde.
+
+    Quatro variantes de propósito, e não só a congelada:
+
+      A_sem_corte          o que a [0.1] rodou — todo jogo liquidado com odd, sem corte. Hoje ele
+                           é MAIOR que o publicado, porque o tempo passou; a diferença entre A e
+                           C é exatamente o que o congelamento remove.
+      B_ate_0408_por_dia   o corte ingênuo, `DATE(kickoff) <= '2026-08-04'`. Está aqui porque
+                           devolve **178** e não 169, e é essa diferença que prova que o teto da
+                           [0.1] é um INSTANTE e não um dia: os 9 excedentes são os jogos de
+                           04/08 com kickoff a partir das 16:00 UTC, que ainda não tinham sido
+                           disputados quando a [0.1] executou.
+      C_janela_congelada   o corte da medição, que é o que taskf_janela() emite.
+      D_teto_alternativo   o MESMO corte com o teto na outra ponta do vão vazio (06:00 UTC em vez
+                           de 12:00). Existe para mostrar que o teto não foi calibrado até o
+                           número bater: entre ~02:00 e 16:00 UTC de 04/08 não há jogo nenhum na
+                           base, então qualquer instante da faixa devolve os mesmos 169. C e D
+                           idênticos é o que torna o corte robusto; se um dia divergirem, apareceu
+                           jogo no vão e o teto precisa ser re-argumentado.
+
+    E o piso: A e B devolvem `janela_ini = 2026-06-16` sem que ninguém peça, porque a coleta de
+    odds é forward-only e começou nesse dia. O piso declarado é no-op — e fica declarado assim
+    mesmo, para a janela não depender de um efeito colateral da coleta.
+
+    `jogos` sai de `apostas`, e não de `fact_fixtures`: o universo do Teste 2 é o de jogos
+    liquidados COM preço nos 5 mercados do Motor, já com o filtro de meia-linha. Contar jogo
+    encerrado na janela daria outro número, maior, que não é o publicado.
+
+    Rodar com (o target escolhe contra qual dataset se confere — `dev` lê produção, que é onde os
+    169 foram publicados; `taskF` confere a célula já materializada):
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target dev --select taskf_universo_congelado
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_universo_congelado.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+#}
+
+{%- set j = taskf_janela() %}
+
+WITH {{ task01_base() }},
+
+variantes AS (
+    SELECT 'A_sem_corte' AS variante, fixture_id, kickoff_utc, competition, benchmark
+    FROM apostas
+
+    UNION ALL
+
+    SELECT 'B_ate_0408_por_dia', fixture_id, kickoff_utc, competition, benchmark
+    FROM apostas
+    WHERE DATE(kickoff_utc) BETWEEN DATE('{{ j.ini }}') AND DATE('{{ j.fim }}')
+
+    UNION ALL
+
+    SELECT 'C_janela_congelada', fixture_id, kickoff_utc, competition, benchmark
+    FROM apostas
+    WHERE {{ taskf_janela_filtro() }}
+
+    UNION ALL
+
+    SELECT 'D_teto_alternativo', fixture_id, kickoff_utc, competition, benchmark
+    FROM apostas
+    WHERE kickoff_utc >= TIMESTAMP('{{ j.ini }}')
+      AND kickoff_utc <  TIMESTAMP('2026-08-04 06:00:00')
+)
+
+SELECT
+    variante,
+    MIN(DATE(kickoff_utc))                            AS janela_ini,
+    MAX(DATE(kickoff_utc))                            AS janela_fim,
+    MAX(kickoff_utc)                                  AS ultimo_kickoff_utc,
+    COUNT(DISTINCT fixture_id)                        AS jogos,
+    {{ j.jogos_esperados }}                           AS jogos_esperados,
+    COUNT(DISTINCT fixture_id) - {{ j.jogos_esperados }} AS delta_vs_publicado,
+    COUNT(*)                                          AS linhas,
+    COUNT(DISTINCT competition)                       AS competicoes,
+    COUNTIF(benchmark = 'sharp')                      AS linhas_sharp,
+    COUNTIF(benchmark = 'consenso')                   AS linhas_consenso,
+    COUNTIF(benchmark = 'derivada')                   AS linhas_derivada
+FROM variantes
+GROUP BY variante
+ORDER BY variante

--- a/dbt_futebol/macros/taskf_celula.sql
+++ b/dbt_futebol/macros/taskf_celula.sql
@@ -1,0 +1,59 @@
+{#
+    O NOME DA CÉLULA sai dos eixos, e não de um rótulo que alguém digita.
+
+    A medição da task [F] (issue #49) é um 2x2 de eixos independentes:
+
+        pit_escopo \ pit_recorte |  temporada  |  ultimos_10
+        -------------------------+-------------+-------------
+        da_competicao            |  base       |  recorte
+        todas                    |  escopo     |  ambos
+
+    Por que derivar, e não aceitar uma var `taskf_celula` livre: se o rótulo fosse digitado, seria
+    possível materializar a célula `escopo` e gravá-la como `base`. Nada no dado denunciaria — as
+    quatro têm o mesmo formato —, e a comparação entre células, que é o entregável inteiro da [F],
+    passaria a comparar duas coisas erradas com cara de certo. Derivado dos eixos, o rótulo não
+    tem como discordar do que de fato rodou.
+
+    A saída carrega os dois valores de eixo ao lado do nome pelo mesmo motivo: quem lê a tabela de
+    medição não precisa confiar no dicionário acima, ele está na linha.
+
+    ⚠️ As listas de valores aceitos aparecem também no int_futebol_team_form_pit, que valida por
+    conta própria. A duplicação é consciente e assimétrica: o modelo valida porque produção passa
+    por ele, e esta macro valida porque uma análise compila SEM o modelo na seleção — aí a
+    validação do modelo não roda e um `pit_escopo: todos` (com S) mediria `base` calado, com o
+    rótulo `base`, que é exatamente o modo de falha que esta macro existe para fechar.
+
+    Uso:
+
+        {%- set c = taskf_celula() %}
+        SELECT '{{ c.nome }}' AS celula, '{{ c.escopo }}' AS pit_escopo, ...
+#}
+
+{% macro taskf_celula() %}
+
+    {%- set escopo  = var('pit_escopo',  'da_competicao') -%}
+    {%- set recorte = var('pit_recorte', 'temporada') -%}
+
+    {%- if escopo not in ['da_competicao', 'todas'] -%}
+        {{ exceptions.raise_compiler_error(
+            "pit_escopo inválido: '" ~ escopo ~ "'. Valores aceitos: da_competicao | todas.") }}
+    {%- endif -%}
+    {%- if recorte not in ['temporada', 'ultimos_10'] -%}
+        {{ exceptions.raise_compiler_error(
+            "pit_recorte inválido: '" ~ recorte ~ "'. Valores aceitos: temporada | ultimos_10.") }}
+    {%- endif -%}
+
+    {%- set nomes = {
+        'da_competicao|temporada':  'base',
+        'todas|temporada':          'escopo',
+        'da_competicao|ultimos_10': 'recorte',
+        'todas|ultimos_10':         'ambos'
+    } -%}
+
+    {{ return({
+        'nome':    nomes[escopo ~ '|' ~ recorte],
+        'escopo':  escopo,
+        'recorte': recorte
+    }) }}
+
+{% endmacro %}

--- a/dbt_futebol/macros/taskf_janela.sql
+++ b/dbt_futebol/macros/taskf_janela.sql
@@ -1,0 +1,72 @@
+{#
+    A JANELA CONGELADA da medição da task [F] (issue #49), escrita UMA vez.
+
+    ⚠️ `janela` aqui é o recorte de tempo do UNIVERSO DE MEDIÇÃO — as datas de kickoff que entram
+    na conta. Não confundir com a janela de COLETA DE ODDS (daily/t24h/t1h/t15m), que é o outro
+    sentido da palavra no glossário do CONTEXT.md, nem com o eixo `recorte` do PIT. São três
+    coisas distintas e só esta decide quais jogos são medidos.
+
+    O corte NÃO é escolha do implementador: é a janela publicada no doc de resultados da Task
+    [0.1] — 16/06/2026 a 04/08/2026, 169 jogos (`docs/TASK01_RESULTADOS.md`, ticket #5). A
+    terceira invariante da Costura B pede que a célula `base` reproduza aquele Teste 2, e a
+    reconciliação só fecha contra a mesma janela. Um corte diferente faria a comparação falhar
+    sem motivo aparente.
+
+    ⚠️ O TETO É UM INSTANTE, NÃO UM DIA — e isto foi medido, não escolhido. A [0.1] rodou SEM
+    corte congelado: o teto dela é o instante em que a query executou, e `janela_fim = 04/08` é
+    só o `MAX(DATE(kickoff))` que saiu daquilo. Cortar em `DATE(kickoff) <= '2026-08-04'` devolve
+    **178** jogos, não 169. Os 9 excedentes são exatamente os jogos de 04/08 com kickoff a partir
+    das 16:00 UTC (8 da Champions e 1 da Copa do Brasil, o das 22:30) — no dia inteiro só UM jogo
+    começou antes disso, o das 00:00 UTC, e ele está nos 169. Ou seja: quando a [0.1] rodou, os
+    outros nove ainda não tinham sido disputados.
+
+    O teto fica no MEIO do vão vazio: entre o fim do jogo das 00:00 (~02:00 UTC) e o kickoff das
+    16:00 não existe nenhum jogo na base. Qualquer instante nessa faixa de catorze horas devolve
+    os mesmos 169 — o corte é robusto a essa incerteza, e não um valor calibrado até o número
+    bater. As datas continuam sendo 16/06 e 04/08 nas duas pontas, porque o último jogo INCLUÍDO
+    é mesmo de 04/08; o que muda é a hora.
+
+    O piso de 16/06 é no-op e fica explícito de propósito: a coleta de odds é forward-only e
+    começou nesse dia, então o universo já nasce cortado ali. Medido — `A_sem_corte` e
+    `B_ate_0408` devolvem `janela_ini = 2026-06-16` sozinhos. Declarar o piso custa nada e tira a
+    janela da dependência de um efeito colateral da coleta.
+
+    Por que existe como macro, e não como duas datas digitadas em cada análise: as quatro células
+    são comparadas entre si, e duas análises com janelas que derivaram uma da outra comparam
+    universos diferentes sem ninguém perceber. Aqui a divergência é impossível por construção.
+
+    O `jogos_esperados` fica junto de propósito. Ele é o número publicado, e serve de gabarito:
+    quem materializar uma célula e vir outro número sabe na hora que o universo se mexeu (jogo
+    remarcado, resultado que entrou depois, odd que apareceu), em vez de descobrir isso na
+    diferença de uma premissa.
+
+    Uso:
+
+        {%- set j = taskf_janela() %}
+        WHERE {{ taskf_janela_filtro('a.') }}
+#}
+
+{% macro taskf_janela() %}
+    {{ return({
+        'ini':             '2026-06-16',
+        'fim':             '2026-08-04',
+        'teto_utc':        '2026-08-04 12:00:00',
+        'jogos_esperados': 169
+    }) }}
+{% endmacro %}
+
+
+{#-
+    Predicado da janela congelada, para não haver duas escritas do mesmo BETWEEN. `alias` inclui
+    o ponto: taskf_janela_filtro('a.')
+
+    Recortar em cima de `apostas` equivale a recortar `jogos_encerrados`: no task01_base() todo o
+    resto pende do universo de jogos por JOIN, e o `pit` é LEFT JOIN a partir dele. O recorte fica
+    aqui, e não num parâmetro novo do macro compartilhado, para que a definição que produziu os
+    números publicados da [0.1] não seja tocada por esta medição.
+-#}
+{% macro taskf_janela_filtro(alias='') %}
+    {%- set j = taskf_janela() -%}
+    ({{ alias }}kickoff_utc >= TIMESTAMP('{{ j.ini }}')
+     AND {{ alias }}kickoff_utc < TIMESTAMP('{{ j.teto_utc }}'))
+{%- endmacro %}

--- a/dbt_futebol/macros/taskf_publicado_01.sql
+++ b/dbt_futebol/macros/taskf_publicado_01.sql
@@ -1,0 +1,114 @@
+{#
+    OS NÚMEROS PUBLICADOS DO TESTE 2 DA TASK [0.1], transcritos para SQL.
+
+    A terceira invariante da Costura B pede que a célula `base` reproduza o Teste 2 publicado da
+    [0.1]. Esses números não existem em tabela nenhuma: a [0.1] rodou em 04/08/2026 e publicou o
+    resultado em prosa, em `docs/TASK01_RESULTADOS.md` (ticket #5). Reconciliar contra markdown
+    exige que alguém leia duas tabelas lado a lado e confie na própria vista. Aqui eles viram
+    dado, uma vez, e a comparação vira query.
+
+    ⚠️ ISTO É UMA TRANSCRIÇÃO, E TRANSCRIÇÃO ERRA. Um dígito trocado aqui FABRICA uma divergência
+    que alguém vai investigar como se fosse achado. A conferência é contra
+    `docs/TASK01_RESULTADOS.md`, seção "Ticket #5 — Teste 2 completo nos 5 mercados e peso
+    medido", e mais nada — não contra outra análise, não de memória.
+
+    ⚠️ E ELA É CONTRATO CONGELADO, pelo mesmo motivo da taskf_fingerprint_insumo_pit: as duas
+    pontas (a reconciliação da #51 e a guarda da #55) leem daqui. Mudar um valor move as duas de
+    uma vez, o que é o comportamento certo — mas mudar um valor só faz sentido se o doc publicado
+    mudar junto, e o doc é registro histórico. Na prática: não se mexe.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O QUE ESTÁ PUBLICADO, E O QUE NÃO ESTÁ
+
+    O doc não publica as 39 linhas inteiras. Publica três recortes, e a transcrição preserva a
+    diferença entre eles em vez de preencher buraco com zero:
+
+      as 20 de diferença positiva   linha completa no piso 0 (n, prob justa, acerto, diferença,
+                                    jogos médios, % amostra curta, os dois pesos).
+      as 19 de peso zero            SÓ a diferença no piso 0, que é como o doc as lista, em
+                                    parágrafo corrido. As demais colunas ficam NULL.
+      as 15 da varredura de piso    diferença nos pisos 5 e 10, e o n do piso 5. Vêm das duas
+                                    tabelas "desabam" / "sobrevivem". Para as outras 24, o doc
+                                    não publica piso 5 nem 10 e aqui elas ficam NULL.
+
+    NULL aqui significa NÃO PUBLICADO, nunca zero. A reconciliação tem de dizer, por linha, quais
+    campos eram comparáveis — senão "bateu" fica indistinguível de "não havia o que comparar".
+
+    ────────────────────────────────────────────────────────────────────────────────
+    BENCHMARK. Todas estas linhas são o benchmark PREFERIDO de cada mercado (sharp para 1X2,
+    Handicap e Gols; derivada para Dupla Chance; consenso para BTTS) — é o recorte que o doc
+    publica. As linhas de consenso do Handicap e do Gols existem na medição com
+    `usado_para_peso = false` e NÃO têm contraparte publicada.
+
+    `defesas_vazaveis` existe em DOIS mercados (Gols e BTTS) com números diferentes. A chave é
+    (mercado, premissa), nunca a premissa sozinha.
+
+    Emite UMA CTE no escopo do chamador, `publicado_01`. Uma CTE do chamador com esse nome a
+    sombreia em silêncio.
+
+    Uso:
+
+        WITH {{ taskf_publicado_01() }},
+        comparado AS (SELECT ... FROM medido JOIN publicado_01 USING (mercado, premissa))
+#}
+
+{% macro taskf_publicado_01() %}
+
+publicado_01 AS (
+    SELECT * FROM UNNEST([
+        STRUCT<mercado STRING, premissa STRING,
+               n_p0 INT64, a_odd_dava_p0 FLOAT64, aconteceu_p0 FLOAT64, diferenca_p0 FLOAT64,
+               jogos_medios FLOAT64, pct_amostra_curta FLOAT64,
+               peso_p0 FLOAT64, peso_p0_k0 FLOAT64,
+               n_p5 INT64, diferenca_p5 FLOAT64, diferenca_p10 FLOAT64>
+
+        {#- ── As 20 de diferença positiva. Tabela "Peso medido (melhor benchmark de cada
+            mercado)". Ordem preservada do doc, que é por peso k50 decrescente. ── #}
+        ('Gols',         'clean_sheets_altos',     105, 51.5, 68.6,  17.1,  5.3, 77.1, 11.58, 17.10,   24,  -1.7, -10.1),
+        ('Handicap',     'raramente_perde_por_2',  445, 63.1, 69.4,   6.3, 14.1, 20.9,  5.67,  6.31,  352,   7.4,   7.7),
+        ('Handicap',     'favorito_irregular',     453, 62.3, 68.2,   5.9, 14.8, 17.4,  5.29,  5.88,  374,   7.1,   7.9),
+        ('BTTS',         'ataque_dos_dois',         32, 50.6, 62.5,  11.9, 12.1, 37.5,  4.65, 11.91, NULL,  NULL,  NULL),
+        ('1X2',          'superioridade_xg',       109, 38.0, 43.1,   5.2,  6.3, 71.6,  3.54,  5.17,   31,  -8.9, -12.3),
+        ('Handicap',     'defesa_fora_solida',     322, 62.5, 66.5,   3.9,  8.4, 58.4,  3.39,  3.92,  134,   2.6,   2.8),
+        ('Gols',         'defesas_firmes',         246, 64.6, 68.3,   3.7, 11.4, 40.7,  3.05,  3.67, NULL,  NULL,  NULL),
+        ('Handicap',     'tende_golear',           154, 44.2, 48.1,   3.9,  3.5, 88.3,  2.91,  3.86,   18, -18.5, -22.3),
+        ('Gols',         'linha_descendo',         405, 53.0, 56.0,   3.1, 10.3, 46.9,  2.74,  3.08,  215,   5.3,   5.3),
+        ('Dupla Chance', 'lado_coberto_forte',     112, 74.0, 76.8,   2.8,  8.6, 58.0,  1.92,  2.78, NULL,  NULL,  NULL),
+        ('Gols',         'ataques_fracos',         357, 51.7, 53.8,   2.1,  9.6, 50.1,  1.81,  2.07,  178,  -1.1,  -1.1),
+        ('BTTS',         'defesa_forte',            70, 52.9, 55.7,   2.8,  4.4, 82.9,  1.65,  2.82,   12,  -3.3,  -6.3),
+        ('1X2',          'mando',                  107, 43.4, 45.8,   2.4,  9.0, 55.1,  1.63,  2.39,   48,  -6.4,  -8.3),
+        ('Dupla Chance', 'equilibrio_defensivo',   144, 63.3, 65.3,   2.0,  9.0, 54.2,  1.49,  2.01,   66,   6.4,   7.7),
+        ('Gols',         'xg_baixo_combinado',     307, 64.9, 66.4,   1.5,  8.7, 56.7,  1.31,  1.52,  133,   3.6,   4.1),
+        ('BTTS',         'defesas_vazaveis',        58, 47.8, 50.0,   2.2, 10.3, 46.6,  1.20,  2.24,   31,   8.7,   8.7),
+        ('Gols',         'historico_under',        144, 70.0, 71.5,   1.5, 17.0,  3.5,  1.11,  1.50,  139,   1.2,   2.1),
+        ('1X2',          'superioridade_tabela',    98, 50.2, 51.0,   0.8,  7.6, 64.3,  0.55,  0.82,   35,  -8.2,  -8.2),
+        ('Dupla Chance', 'adversario_limitado',    160, 68.7, 69.4,   0.7,  9.7, 50.0,  0.51,  0.66, NULL,  NULL,  NULL),
+        ('BTTS',         'historico_btts',          16, 50.0, 50.0,   0.0, 18.4,  0.0,  0.01,  0.03, NULL,  NULL,  NULL),
+
+        {#- ── As 19 de peso zero. O doc as lista em parágrafo corrido, "da menos ruim para a
+            pior", e publica SÓ a diferença no piso 0 — daí todo o resto NULL. O mercado de cada
+            uma sai do catálogo task01_markets(); `defesas_vazaveis` aqui é a do GOLS, e o doc
+            marca isso explicitamente porque a de BTTS está na tabela de cima. ── #}
+        ('Gols',         'historico_over',        NULL, NULL, NULL,  -0.5, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('BTTS',         'historico_seco',        NULL, NULL, NULL,  -0.9, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('1X2',          'forma',                 NULL, NULL, NULL,  -1.4, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Gols',         'linha_subindo',         NULL, NULL, NULL,  -1.5, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Handicap',     'supremacia',            NULL, NULL, NULL,  -1.9, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('BTTS',         'ataque_trava',          NULL, NULL, NULL,  -2.2, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('BTTS',         'ambos_marcam',          NULL, NULL, NULL,  -2.5, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Gols',         'xg_combinado_alto',     NULL, NULL, NULL,  -2.6, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Handicap',     'sem_rodizio',           NULL, NULL, NULL,  -2.7, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Handicap',     'adversario_fragil_fora',NULL, NULL, NULL,  -2.8, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Handicap',     'mando_forte',           NULL, NULL, NULL,  -3.1, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('1X2',          'forca_mismatch',        NULL, NULL, NULL,  -3.1, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Gols',         'ataque_combinado',      NULL, NULL, NULL,  -3.6, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Gols',         'ambos_vazam',           NULL, NULL, NULL,  -3.7, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Gols',         'defesas_vazaveis',      NULL, NULL, NULL,  -5.0, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Gols',         'ritmo_alto',            NULL, NULL, NULL,  -5.3, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('1X2',          'h2h_favoravel',         NULL, NULL, NULL, -10.7, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('Dupla Chance', 'invicto_recente',       NULL, NULL, NULL, -10.7, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL),
+        ('1X2',          'desfalque_adversario',     7, NULL, NULL, -24.9, NULL, NULL,  NULL,  NULL, NULL,  NULL,  NULL)
+    ])
+)
+
+{% endmacro %}

--- a/dbt_futebol/macros/taskf_universo.sql
+++ b/dbt_futebol/macros/taskf_universo.sql
@@ -42,11 +42,11 @@
 
     Uso:
 
-        {%- set j = taskf_janela() %}
-        WHERE {{ taskf_janela_filtro('a.') }}
+        {%- set j = taskf_universo() %}
+        WHERE {{ taskf_universo_filtro('a.') }}
 #}
 
-{% macro taskf_janela() %}
+{% macro taskf_universo() %}
     {{ return({
         'ini':             '2026-06-16',
         'fim':             '2026-08-04',
@@ -58,15 +58,15 @@
 
 {#-
     Predicado da janela congelada, para não haver duas escritas do mesmo BETWEEN. `alias` inclui
-    o ponto: taskf_janela_filtro('a.')
+    o ponto: taskf_universo_filtro('a.')
 
     Recortar em cima de `apostas` equivale a recortar `jogos_encerrados`: no task01_base() todo o
     resto pende do universo de jogos por JOIN, e o `pit` é LEFT JOIN a partir dele. O recorte fica
     aqui, e não num parâmetro novo do macro compartilhado, para que a definição que produziu os
     números publicados da [0.1] não seja tocada por esta medição.
 -#}
-{% macro taskf_janela_filtro(alias='') %}
-    {%- set j = taskf_janela() -%}
+{% macro taskf_universo_filtro(alias='') %}
+    {%- set j = taskf_universo() -%}
     ({{ alias }}kickoff_utc >= TIMESTAMP('{{ j.ini }}')
      AND {{ alias }}kickoff_utc < TIMESTAMP('{{ j.teto_utc }}'))
 {%- endmacro %}

--- a/dbt_futebol/macros/taskf_universo.sql
+++ b/dbt_futebol/macros/taskf_universo.sql
@@ -1,15 +1,17 @@
 {#
-    A JANELA CONGELADA da medição da task [F] (issue #49), escrita UMA vez.
+    O UNIVERSO CONGELADO da medição da task [F] (issue #49), escrito UMA vez.
 
-    ⚠️ `janela` aqui é o recorte de tempo do UNIVERSO DE MEDIÇÃO — as datas de kickoff que entram
-    na conta. Não confundir com a janela de COLETA DE ODDS (daily/t24h/t1h/t15m), que é o outro
-    sentido da palavra no glossário do CONTEXT.md, nem com o eixo `recorte` do PIT. São três
-    coisas distintas e só esta decide quais jogos são medidos.
+    ⚠️ Isto é o recorte de tempo do UNIVERSO DE MEDIÇÃO — os kickoffs que entram na conta. NÃO é
+    a janela de COLETA DE ODDS (daily/t24h/t1h/t15m) nem o eixo `recorte` do PIT: são três coisas
+    distintas e só esta decide quais jogos são medidos. O glossário do CONTEXT.md pede que a
+    palavra `janela` fique reservada à coleta de odds, e por isso ela não é usada aqui — a exceção
+    são as colunas `janela_ini`/`janela_fim`, que são os nomes da própria [0.1] e ficam como
+    estão para a saída medida bater campo a campo com a tabela publicada.
 
-    O corte NÃO é escolha do implementador: é a janela publicada no doc de resultados da Task
+    O corte NÃO é escolha do implementador: é o recorte publicado no doc de resultados da Task
     [0.1] — 16/06/2026 a 04/08/2026, 169 jogos (`docs/TASK01_RESULTADOS.md`, ticket #5). A
     terceira invariante da Costura B pede que a célula `base` reproduza aquele Teste 2, e a
-    reconciliação só fecha contra a mesma janela. Um corte diferente faria a comparação falhar
+    reconciliação só fecha contra o mesmo corte. Um corte diferente faria a comparação falhar
     sem motivo aparente.
 
     ⚠️ O TETO É UM INSTANTE, NÃO UM DIA — e isto foi medido, não escolhido. A [0.1] rodou SEM
@@ -28,11 +30,11 @@
 
     O piso de 16/06 é no-op e fica explícito de propósito: a coleta de odds é forward-only e
     começou nesse dia, então o universo já nasce cortado ali. Medido — `A_sem_corte` e
-    `B_ate_0408` devolvem `janela_ini = 2026-06-16` sozinhos. Declarar o piso custa nada e tira a
-    janela da dependência de um efeito colateral da coleta.
+    `B_ate_0408` devolvem `janela_ini = 2026-06-16` sozinhos. Declarar o piso custa nada e tira o
+    corte da dependência de um efeito colateral da coleta.
 
     Por que existe como macro, e não como duas datas digitadas em cada análise: as quatro células
-    são comparadas entre si, e duas análises com janelas que derivaram uma da outra comparam
+    são comparadas entre si, e duas análises com cortes que derivaram um do outro comparam
     universos diferentes sem ninguém perceber. Aqui a divergência é impossível por construção.
 
     O `jogos_esperados` fica junto de propósito. Ele é o número publicado, e serve de gabarito:
@@ -57,7 +59,7 @@
 
 
 {#-
-    Predicado da janela congelada, para não haver duas escritas do mesmo BETWEEN. `alias` inclui
+    Predicado do universo congelado, para não haver duas escritas do mesmo intervalo. `alias` inclui
     o ponto: taskf_universo_filtro('a.')
 
     Recortar em cima de `apostas` equivale a recortar `jogos_encerrados`: no task01_base() todo o

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -509,8 +509,10 @@ sources:
   # de as vars pit_escopo/pit_recorte entrarem no int_futebol_team_form_pit, e é essa anterioridade
   # que dá valor a eles. O schema é fixo em `futebol_taskF` de propósito — o baseline não segue o
   # target, senão a Costura A compararia produção contra ela mesma rodada com --target dev/prod.
-  # Exceção consciente ao "só modelo de staging lê source": o consumidor é o teste singular da
-  # Costura A, e `source()` é o único handle do dbt para uma tabela congelada que não é modelo.
+  # Exceção consciente ao "só modelo de staging lê source": os consumidores são o teste singular da
+  # Costura A (sobre os baselines) e a análise de reconciliação da #51 (sobre o taskf_teste2), e
+  # `source()` é o único handle do dbt para uma tabela que não é modelo. Nenhum MODELO lê daqui —
+  # se um dia ler, a medição terá vazado para o caminho que o board serve.
   - name: futebol_taskF
     description: >
       Dataset de medição da task [F] (ADR 0007). Guarda o baseline de equivalência da Costura A.
@@ -582,8 +584,8 @@ sources:
             description: "Commit de onde a célula foi medida (var taskf_git_sha)"
           - name: jogos_no_universo
             description: >
-              Jogos distintos da janela congelada. Idêntico nas quatro células por construção —
-              é a primeira invariante da Costura B.
+              Jogos distintos do universo congelado (169). Idêntico nas quatro células por
+              construção — é a primeira invariante da Costura B.
           - name: usado_para_peso
             description: >
               A linha está no benchmark PREFERIDO do mercado (sharp p/ 1X2, Handicap e Gols;

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -555,3 +555,38 @@ sources:
         description: >
           Quando o baseline foi congelado, de qual commit, e com quantas linhas/partições.
           Uma linha só.
+
+      - name: taskf_teste2
+        description: >
+          A saída do Teste 2 da medição, uma linha por (célula, mercado, premissa, benchmark).
+          Acumulativa: cada execução de analyses/taskf_teste2.sql substitui SÓ a sua célula
+          (DELETE + INSERT), e as quatro convivem — é sobre esta tabela que a Costura B (#55)
+          verifica as três invariantes. Também não é modelo, pelo mesmo motivo dos baselines
+          acima: o destino está escrito no SQL e fixo em futebol_taskF, então um `dbt build`
+          distraído não tem como publicá-la no dataset do board.
+        columns:
+          - name: celula
+            description: >
+              base | escopo | recorte | ambos. DERIVADA dos dois eixos por taskf_celula(), nunca
+              digitada — uma célula não tem como ser gravada com o nome de outra.
+          - name: pit_escopo
+            description: "O eixo de escopo que produziu a linha (da_competicao | todas)"
+          - name: pit_recorte
+            description: "O eixo de recorte que produziu a linha (temporada | ultimos_10)"
+          - name: medido_em
+            description: >
+              Quando a célula foi materializada. Existe porque a spec exige que as quatro rodem na
+              MESMA execução — `linha_subindo`/`linha_descendo` leem odds ao vivo e viram sozinhas
+              entre builds. Com o carimbo, "mesma execução" é conferível; sem ele, é confiança.
+          - name: git_sha
+            description: "Commit de onde a célula foi medida (var taskf_git_sha)"
+          - name: jogos_no_universo
+            description: >
+              Jogos distintos da janela congelada. Idêntico nas quatro células por construção —
+              é a primeira invariante da Costura B.
+          - name: usado_para_peso
+            description: >
+              A linha está no benchmark PREFERIDO do mercado (sharp p/ 1X2, Handicap e Gols;
+              derivada p/ Dupla Chance; consenso p/ BTTS). As de consenso do Handicap e do Gols
+              vêm FALSE: não pesam, mas ficam visíveis porque o ROI muito pior delas é informação
+              sobre quais jogos a Pinnacle escolhe precificar.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -23,7 +23,11 @@ que mudam alguma coisa terem o direito de significar algo.
 
 **38 das 39 premissas reproduzem o publicado EXATAMENTE**, em todos os campos comparáveis — até
 11 campos por premissa nas 15 de varredura completa. A única divergência é `linha_descendo`, com
-2 linhas de 405 e ≤ 0,2 pp.
+2 linhas de 405 e ≤ 0,2 pp, e ela sai marcada `INVESTIGAR`, não acomodada pela tolerância.
+
+`EXATO` aqui exige que **todos** os campos publicados tenham batido, e não só os que a régua em pp
+olha: contagem, prob justa média, acerto médio, jogos médios, % de amostra curta e os dois pesos
+entram na mesma conta (`campos_divergentes_fora_da_regua`).
 
 O caminho está certo. As células `escopo`, `recorte` e `ambos` podem ser medidas.
 
@@ -97,10 +101,14 @@ capturas com data posterior a 04/08** em qualquer das três janelas de fechament
 | t1h | 37.135 | 168 | 02/08 | **0** |
 | t24h | 34.854 | 162 | 03/08 | **0** |
 
-O insumo de `linha_caiu` é imóvel. Logo a tolerância continua valendo como **régua declarada** —
-foi anunciada antes da medição e a única linha que a usou passou nela —, mas ela **não explica**
-a divergência que encontrou. Passar na régua e ter causa conhecida são coisas diferentes, e a
-diferença está registrada aqui em vez de fechada por conveniência.
+O insumo de `linha_caiu` é imóvel. A consequência foi levada até o fim, e não só anotada: a
+reconciliação **mede** o mecanismo antes de invocá-lo (`capturas_apos_o_teto`), e como ele é zero,
+**nenhuma linha se classifica como `deriva_de_odds`**. `linha_descendo` sai como `INVESTIGAR`, que
+é o veredito honesto — a régua não é usada para acomodar uma divergência cuja causa a régua não
+cobre, que é exatamente o que o critério do ticket proíbe.
+
+A régua de 0,5 pp continua declarada e continua valendo. Ela volta a ter mordida no **universo
+estendido** da spec, que alcança o presente e onde `capturas_apos_o_teto` deixa de ser zero.
 
 ### A correção da spec #22 tem footprint ZERO — medido, não suposto
 
@@ -127,6 +135,12 @@ linhas comparadas.
 O teste do "nenhuma tem Pinnacle" foi **falsificado contra um controle**, porque um join quebrado
 daria zero do mesmo jeito: nas linhas *não* degeneradas o mesmo join casa 3.370 de 6.566 no
 Handicap e 3.054 de 6.692 no Gols. O zero é real.
+
+Esta conta **mora dentro da reconciliação**, na coluna `linhas_da_22_no_preferido`, e não numa
+query de rascunho: a regra de alcance é por mercado (no BTTS o preferido é o consenso, então
+qualquer linha nulada o alcança; nos outros quatro o preferido é ancorado na Pinnacle, então só
+alcança linha que a Pinnacle precificava). Os cinco mercados dão **0**. Se um dia der diferente —
+no universo estendido, ou numa janela nova —, o rótulo aparece sozinho e com o número ao lado.
 
 Isto confirma empiricamente a afirmação "TODAS consenso" que o cabeçalho do `task01_base()` faz
 sobre as 172 linhas, e a estende: a correção é **invisível ao benchmark preferido**, em todos os

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -167,18 +167,36 @@ que `% amostra curta` **sobe** ao removê-las e `jogos médios` não se move.
 4. **`int_futebol_team_form_pit`** — descartada. A Costura A passou nesta execução: a saída no
    default é igual, linha a linha, ao baseline congelado antes das vars.
 
+5. **Dedup não-determinístico do `fact_odds_snapshot`** — descartada, e vale registrar porque a
+   suspeita era boa. O dedup é `ROW_NUMBER() OVER (PARTITION BY fixture, casa, mercado, outcome,
+   janela ORDER BY loaded_at DESC)` — **sem critério de desempate**. Duas capturas com o mesmo
+   `loaded_at` e odds diferentes trocariam de vencedora entre builds *sem dado novo nenhum*, que
+   é exatamente a assinatura procurada. Medido nos 169 jogos, mercado de Gols: **108.196 chaves,
+   zero empates no topo, zero empates que mudariam a odd**. A porta existe, mas não passou
+   ninguém por ela nesta janela. Fica anotado como risco latente do modelo, não como causa.
+
 **O que sobra**, e fica registrado como resíduo aberto: o `fact_odds_snapshot` é reconstruído do
 NDJSON do GCS a cada build, e o `collection_date` vem do dado, não do instante da ingestão. Um
 arquivo que tenha chegado ao bucket depois de 04/08 carimbado com data anterior entraria na tabela
 sem aparecer no teste 2 acima — e uma casa a mais na média de t15m basta para virar uma linha
-marginal. É a única hipótese que sobrevive a tudo que foi medido, e ela é **candidata, não causa
-provada**.
+marginal. Das hipóteses levantadas é a única que sobrevive, e ela é **candidata, não causa
+provada**. Todas as sobreviventes moram no mesmo lugar: a reconstrução do `fact_odds_snapshot` a
+cada build.
 
 **Por que isso não invalida a medição:** o resíduo é 2 linhas em 1 premissa de 39, ele move a
 diferença em 0,2 pp, e ele afeta as quatro células **da mesma forma** — as quatro leem o mesmo
-`fact_odds_snapshot` na mesma execução. A [F] compara células entre si; um viés comum às quatro
-cancela na comparação. Ele importaria se alguém reaproveitasse o baseline publicado da [0.1] como
-célula `base`, que é exatamente o que a spec proíbe.
+`fact_odds_snapshot`. A [F] compara células entre si; um viés comum às quatro cancela na
+comparação. Ele importaria se alguém reaproveitasse o baseline publicado da [0.1] como célula
+`base`, que é exatamente o que a spec proíbe.
+
+⚠️ **Mas "o mesmo `fact_odds_snapshot`" é uma condição, não um dado.** Ela só vale se a ancestria
+for construída **uma vez** e as células seguintes rebuildarem só os nós que respondem às vars — o
+PIT e os cinco modelos de premissas. Rebuildar com `+` por célula reconstrói o
+`fact_odds_snapshot` do NDJSON a cada uma, e aí esta mesma variação de 2 linhas passa a existir
+*entre* as células, onde ela deixa de cancelar e vira efeito de escopo aos olhos de quem lê. O
+cabeçalho do `analyses/taskf_teste2.sql` traz as duas fases separadas por isso. Para a #55: a
+forma verificável de "mesma execução" é `fact_odds_snapshot.dbt_loaded_at` anterior aos quatro
+`medido_em`.
 
 ### O que a medição produziu além da reconciliação
 
@@ -197,7 +215,7 @@ ficam visíveis. Duas coisas nela não existiam antes:
 ```bash
 cd dbt_futebol
 
-# 1. a camada de premissas na célula base (vars no default), no dataset de medição
+# 1. a ancestria inteira, UMA vez para as quatro células (na base as vars ficam no default)
 DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
   --select +int_futebol_premissas_1x2 +int_futebol_premissas_ou +int_futebol_premissas_ah \
            +int_futebol_premissas_btts +int_futebol_premissas_dc +int_futebol_corroboracao

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1,0 +1,225 @@
+# Task [F] — Resultados
+
+Documento vivo. Cada ticket da [issue #49](https://github.com/tech-lamjav/analytics-engineering/issues/49)
+acrescenta a sua seção aqui. O SQL que produz cada número está em `dbt_futebol/analyses/`.
+
+Os resultados moram neste arquivo, e não no cabeçalho das análises, para que o SQL mude quando a
+lógica muda e não quando os números mudam. Mesmo padrão do `TASK01_RESULTADOS.md`.
+
+---
+
+## Ticket #51 — Célula `base` ponta a ponta
+
+`analyses/taskf_teste2.sql` + `analyses/taskf_reconciliacao_01.sql` · execução 2026-08-12 13:34
+UTC · commit `fa98ceb` · dataset `futebol_taskF`
+
+A célula que não muda nada — escopo na competição do jogo, recorte na temporada corrente — vai
+ponta a ponta: camada de premissas materializada no dataset de medição, Teste 2 rodando por cima,
+saída com coluna de célula, e comparação contra o Teste 2 publicado da [0.1]. É o tracer bullet: o
+caso em que a resposta já é conhecida, para o caminho inteiro ser exercitado antes de as células
+que mudam alguma coisa terem o direito de significar algo.
+
+### Veredito
+
+**38 das 39 premissas reproduzem o publicado EXATAMENTE**, em todos os campos comparáveis — até
+11 campos por premissa nas 15 de varredura completa. A única divergência é `linha_descendo`, com
+2 linhas de 405 e ≤ 0,2 pp.
+
+O caminho está certo. As células `escopo`, `recorte` e `ambos` podem ser medidas.
+
+### O universo congelado não é um corte por dia
+
+`analyses/taskf_universo_congelado.sql`
+
+| variante | período | jogos | vs publicado |
+|---|---|---|---|
+| `A_sem_corte` — o que a [0.1] rodou | 16/06 → 12/08 | 228 | +59 |
+| `B_ate_0408_por_dia` — `DATE(kickoff) <= '2026-08-04'` | 16/06 → 04/08 | **178** | **+9** |
+| `C_universo_congelado` — `kickoff < 04/08 12:00 UTC` | 16/06 → 04/08 | **169** | **0** |
+| `D_teto_alternativo` — o mesmo com teto às 06:00 UTC | 16/06 → 04/08 | 169 | 0 |
+
+O corte ingênuo por dia devolve 178, não 169. Os 9 excedentes são exatamente os jogos de 04/08
+com kickoff a partir das 16:00 UTC — 8 da Champions e o da Copa do Brasil das 22:30. No dia
+inteiro **um único** jogo começou antes disso, o das 00:00 UTC, e ele está nos 169.
+
+A explicação é que a [0.1] **rodou sem corte congelado**: o teto dela é o instante em que a query
+executou, e o `janela_fim = 04/08` publicado é só o `MAX(DATE(kickoff))` que saiu daquilo. Os
+nove jogos da noite ainda não tinham sido disputados. Reproduzir a janela publicada exige,
+portanto, um **instante**, e não uma data.
+
+O teto ficou às 12:00 UTC, no meio do vão vazio: entre o fim do jogo das 00:00 (~02:00) e o
+kickoff das 16:00 não existe jogo nenhum na base. A variante D mede a outra ponta da faixa e dá o
+mesmo resultado — o corte é **robusto a catorze horas de incerteza**, e não um valor calibrado até
+o número bater. As duas datas publicadas continuam verdadeiras: o último jogo incluído é mesmo de
+04/08.
+
+O piso de 16/06 é no-op — a coleta de odds é forward-only e começou nesse dia, então A e B já
+devolvem `janela_ini = 16/06` sozinhos. Fica declarado assim mesmo, para a janela não depender de
+um efeito colateral da coleta.
+
+**Composição dos 169:** copa_mundo 79 (46,7%), serie_b 39 (23,1%), brasileirao 28 (16,6%),
+sudamericana 15 (8,9%), copa_do_brasil 8 (4,7%). Os 46,7% da Copa do Mundo batem com os "47% da
+amostra" que a spec #49 atribui a ela, e Copa do Brasil + Sudamericana somam 23, contra os "cerca
+de 24 jogos" que a spec estima que o merge recupera.
+
+⚠️ **A Champions não tem UM jogo no universo primário.** Os únicos jogos dela na janela são os 8
+de 04/08 à noite, e o corte os remove. A pergunta da spec sobre a fase classificatória da
+Champions (user story 24) não tem amostra nenhuma no universo congelado — quem for executar a
+#58 precisa saber disso antes de desenhar a resposta, porque ela terá de sair do universo
+estendido ou de lugar nenhum.
+
+### A tolerância, declarada
+
+> **Tolerância: 0,5 pp de diferença absoluta, em qualquer piso, e SÓ para `linha_subindo` e
+> `linha_descendo`.**
+
+Ela vale para essas duas e para mais nenhuma. As outras 37 premissas leem fixture, estatística ou
+tabela — insumos determinísticos sobre um universo congelado — e para elas a régua é **igualdade
+exata**. `linha_subindo` e `linha_descendo` são as únicas que comparam preço com preço: acendem
+quando a média das probabilidades implícitas de todas as casas sobe de t24h para t15m.
+
+O valor 0,5 pp foi declarado **antes** de medir, calibrado pelo que o repositório já sabia:
+`docs/TASK01_RESULTADOS.md` registra que o mercado de Gols anda 0,2–0,4 pp entre execuções sem
+que nada mude, e que isso já produziu caça a bug inexistente.
+
+### ⚠️ A justificativa da tolerância não se aplica a uma janela congelada
+
+Este é o achado do ticket que ninguém tinha escrito.
+
+A tolerância existe porque "`linha_subindo`/`linha_descendo` leem odds ao vivo e viram sozinhas
+entre builds". Isso é **verdade no board vivo e falso num universo congelado do passado**: a
+coleta de odds é forward-only e para no apito. Medido — para os 169 jogos congelados há **zero
+capturas com data posterior a 04/08** em qualquer das três janelas de fechamento:
+
+| janela de coleta | linhas | jogos | última coleta | coletadas após 04/08 |
+|---|---|---|---|---|
+| t15m | 34.691 | 157 | 02/08 | **0** |
+| t1h | 37.135 | 168 | 02/08 | **0** |
+| t24h | 34.854 | 162 | 03/08 | **0** |
+
+O insumo de `linha_caiu` é imóvel. Logo a tolerância continua valendo como **régua declarada** —
+foi anunciada antes da medição e a única linha que a usou passou nela —, mas ela **não explica**
+a divergência que encontrou. Passar na régua e ter causa conhecida são coisas diferentes, e a
+diferença está registrada aqui em vez de fechada por conveniência.
+
+### A correção da spec #22 tem footprint ZERO — medido, não suposto
+
+A spec #22 corrigiu o de-vig em **05/08**, um dia *depois* de a [0.1] publicar. Os números
+publicados ainda continham as linhas de conjunto de saídas incompleto; os medidos já não contêm.
+Era a divergência de outra origem mais provável do ticket, e a hipótese de partida era que ela
+atingiria o BTTS, cujo benchmark preferido é justamente o consenso.
+
+**Ela não atinge nada.** Duas medições:
+
+| mercado | linhas na janela | conjunto incompleto | destas, com preço Pinnacle |
+|---|---|---|---|
+| 1X2 (1) | 507 | **0** | — |
+| Handicap (4) | 6.624 | 58 | **0** |
+| Gols (5) | 6.871 | 179 | **0** |
+| BTTS (8) | 338 | **0** | — |
+| Dupla Chance (12) | 507 | **0** | — |
+
+1X2, BTTS e Dupla Chance não têm nenhuma linha degenerada na janela. As 237 que existem estão em
+Handicap e Gols, e **nenhuma delas tem preço da Pinnacle em janela nenhuma** — são consenso puro.
+Como o benchmark preferido desses dois mercados é o sharp, a correção não alcança nenhuma das 39
+linhas comparadas.
+
+O teste do "nenhuma tem Pinnacle" foi **falsificado contra um controle**, porque um join quebrado
+daria zero do mesmo jeito: nas linhas *não* degeneradas o mesmo join casa 3.370 de 6.566 no
+Handicap e 3.054 de 6.692 no Gols. O zero é real.
+
+Isto confirma empiricamente a afirmação "TODAS consenso" que o cabeçalho do `task01_base()` faz
+sobre as 172 linhas, e a estende: a correção é **invisível ao benchmark preferido**, em todos os
+cinco mercados.
+
+### A única divergência: `linha_descendo`
+
+| campo | publicado | medido | delta |
+|---|---|---|---|
+| n (piso 0) | 405 | 403 | **−2** |
+| n (piso 5) | 215 | 213 | **−2** |
+| diferença piso 0 | +3,1 | +3,2 | +0,1 |
+| diferença piso 5 | +5,3 | +5,5 | +0,2 |
+| diferença piso 10 | +5,3 | +5,5 | +0,2 |
+| a odd dava (piso 0) | 53,0 | 52,9 | −0,1 |
+| aconteceu (piso 0) | 56,0 | 56,1 | +0,1 |
+| jogos médios | 10,3 | 10,3 | **0** |
+| % amostra curta | 46,9 | 47,1 | +0,2 |
+| peso k50 / k0 | 2,74 / 3,08 | 2,85 / 3,21 | +0,11 / +0,13 |
+
+São **duas linhas de aposta**, e não uma mudança de comportamento: 0,5% da amostra da premissa.
+As duas tinham `min_jogos >= 5` (saíram também do piso 5) e não eram de amostra curta — é por isso
+que `% amostra curta` **sobe** ao removê-las e `jogos médios` não se move.
+
+`linha_subindo`, que é o mesmo sinal do lado Over, reproduz a diferença publicada **exatamente**
+(−1,5). O doc não publica o `n` dela, então a superfície de comparação é menor.
+
+**O que foi descartado, com medição:**
+
+1. **Correção #22** — descartada. As linhas removidas por ela são consenso puro; `linha_descendo`
+   publicado é sharp. Nenhuma linha com Pinnacle foi removida em mercado nenhum.
+2. **Deriva de odds** — descartada. Zero capturas posteriores a 04/08 para os 169 jogos.
+3. **Mudança de código nos modelos do caminho** — descartada. Entre o commit que publicou a [0.1]
+   (`e6bc54e`) e este, os únicos modelos alterados no caminho de Gols são o `int_futebol_odds_devig`
+   (só a regra de emissão da #22) e dois `CASE` de slug em `fact_fixtures`/`fact_odds_snapshot`
+   que acrescentam Bundesliga, Ligue 1 e Primeira Liga — nenhuma das três está na janela.
+   `int_futebol_premissas_ou` não foi tocado.
+4. **`int_futebol_team_form_pit`** — descartada. A Costura A passou nesta execução: a saída no
+   default é igual, linha a linha, ao baseline congelado antes das vars.
+
+**O que sobra**, e fica registrado como resíduo aberto: o `fact_odds_snapshot` é reconstruído do
+NDJSON do GCS a cada build, e o `collection_date` vem do dado, não do instante da ingestão. Um
+arquivo que tenha chegado ao bucket depois de 04/08 carimbado com data anterior entraria na tabela
+sem aparecer no teste 2 acima — e uma casa a mais na média de t15m basta para virar uma linha
+marginal. É a única hipótese que sobrevive a tudo que foi medido, e ela é **candidata, não causa
+provada**.
+
+**Por que isso não invalida a medição:** o resíduo é 2 linhas em 1 premissa de 39, ele move a
+diferença em 0,2 pp, e ele afeta as quatro células **da mesma forma** — as quatro leem o mesmo
+`fact_odds_snapshot` na mesma execução. A [F] compara células entre si; um viés comum às quatro
+cancela na comparação. Ele importaria se alguém reaproveitasse o baseline publicado da [0.1] como
+célula `base`, que é exatamente o que a spec proíbe.
+
+### O que a medição produziu além da reconciliação
+
+A tabela `futebol_taskF.taskf_teste2` tem 60 linhas na célula `base`: as **39** do benchmark
+preferido (`usado_para_peso = true`) mais 21 de consenso do Handicap e do Gols, que não pesam mas
+ficam visíveis. Duas coisas nela não existiam antes:
+
+- **O piso 3**, que a spec #49 pede e a [0.1] não tinha, nas 39 linhas.
+- **Os pisos 5 e 10 das 19 premissas de peso zero.** A [0.1] publicou só a diferença no piso 0
+  delas, em parágrafo corrido. Agora há varredura completa — e ela mostra coisas que valem para a
+  [B], como `sem_rodizio` medindo −2,7 **idêntico nos quatro pisos** (n=188 em todos), o que é a
+  assinatura de uma premissa que só acende em jogo com histórico longo.
+
+### Reprodução
+
+```bash
+cd dbt_futebol
+
+# 1. a camada de premissas na célula base (vars no default), no dataset de medição
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
+  --select +int_futebol_premissas_1x2 +int_futebol_premissas_ou +int_futebol_premissas_ah \
+           +int_futebol_premissas_btts +int_futebol_premissas_dc +int_futebol_corroboracao
+
+# 2. o Teste 2 com coluna de célula
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_teste2 \
+  --vars '{taskf_git_sha: fa98ceb}'
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_teste2.sql
+
+# 3. a reconciliação contra o publicado
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_reconciliacao_01
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+
+# 4. a transcrição dos números publicados confere com o doc que os publicou
+.venv/bin/python3 scripts/confere_taskf_publicado_01.py
+```
+
+O `dbt build` do passo 1 fecha com **10 ERROR e 3 SKIP**, todos em testes de `relationships` cuja
+contraparte (`dim_teams`, `dim_players`, `fact_fixture_lineups`, `fact_fixture_events`) está fora
+da ancestria da medição e por isso não existe no dataset. Nenhum modelo falha; os 25 saem
+`success`, e passam a Costura A, as guardas de grão dos cinco modelos de premissas — soltar
+`competition_id` de um join é o caminho natural para fan-out, e é isso que elas pegam — e as duas
+guardas do conjunto de saídas do de-vig.

--- a/scripts/confere_taskf_publicado_01.py
+++ b/scripts/confere_taskf_publicado_01.py
@@ -20,6 +20,12 @@ Confere os tres recortes que o doc publica, e so eles:
 Campo que o doc nao publica fica NULL no macro e nao e conferido aqui — e a distincao entre
 "bateu" e "nao havia o que comparar" e mantida de proposito.
 
+⚠️ Os nomes dos campos sao LIDOS DO PROPRIO STRUCT<> do macro, nao digitados aqui. Duas razoes:
+os nomes das mensagens de divergencia passam a ser os nomes reais das colunas do artefato
+conferido, e reordenar os campos dentro do STRUCT deixa de passar despercebido — com uma lista
+digitada e ligacao posicional, trocar duas colunas de lugar mantem a contagem e compara os campos
+errados, calado, exatamente no script cujo proposito e pegar troca de digito.
+
 Rodar da raiz do repo:
 
     .venv/bin/python3 scripts/confere_taskf_publicado_01.py
@@ -34,8 +40,10 @@ RAIZ = pathlib.Path(__file__).resolve().parent.parent
 DOC = RAIZ / "docs" / "TASK01_RESULTADOS.md"
 MACRO = RAIZ / "dbt_futebol" / "macros" / "taskf_publicado_01.sql"
 
-CAMPOS = ("n_p0 a_odd_dava_p0 aconteceu_p0 diferenca_p0 jogos_medios pct_curta "
-          "peso_p0 peso_p0_k0 n_p5 dif_p5 dif_p10").split()
+# Ordem das colunas da tabela "Peso medido" do doc, DEPOIS de mercado e premissa. Explicita e por
+# nome: a ligacao com os valores do macro e feita pelos nomes lidos do STRUCT, nao por posicao.
+COLUNAS_TABELA1 = ["n_p0", "a_odd_dava_p0", "aconteceu_p0", "diferenca_p0",
+                   "jogos_medios", "pct_amostra_curta", "peso_p0", "peso_p0_k0"]
 
 doc = DOC.read_text(encoding="utf-8")
 macro = MACRO.read_text(encoding="utf-8")
@@ -47,15 +55,30 @@ def num(s):
     return None if s in ("", "-") else float(s)
 
 
-# ------------------------------------------------------------------- lado do MACRO
+# ------------------------------------------------- os nomes dos campos, lidos do STRUCT do macro
+struct = re.search(r"STRUCT<(.+?)>\s*$", macro, re.S | re.M)
+if not struct:
+    sys.exit("nao achei a declaracao STRUCT<> em " + str(MACRO))
+campos = [c.strip().split()[0] for c in struct.group(1).split(",")]
+if campos[:2] != ["mercado", "premissa"]:
+    sys.exit(f"o STRUCT deveria comecar com mercado, premissa — comeca com {campos[:2]}")
+campos = campos[2:]
+
+erros = []
+faltando = [c for c in COLUNAS_TABELA1 if c not in campos]
+if faltando:
+    erros.append(f"campos da tabela 1 ausentes do STRUCT do macro: {faltando}")
+
+# ------------------------------------------------------------------- lado do MACRO, por nome
 linhas_macro = {}
 for m in re.finditer(r"^\s*\('([^']+)',\s*'([^']+)',(.*)\),?\s*$", macro, re.M):
     mercado, premissa, resto = m.group(1), m.group(2), m.group(3)
     vals = [None if v.strip() == "NULL" else float(v) for v in resto.split(",")]
-    assert len(vals) == len(CAMPOS), f"{mercado}/{premissa}: {len(vals)} valores"
-    linhas_macro[(mercado, premissa)] = dict(zip(CAMPOS, vals))
+    if len(vals) != len(campos):
+        erros.append(f"{mercado}/{premissa}: {len(vals)} valores para {len(campos)} campos")
+        continue
+    linhas_macro[(mercado, premissa)] = dict(zip(campos, vals))
 
-erros = []
 if len(linhas_macro) != 39:
     erros.append(f"o macro tem {len(linhas_macro)} linhas, e o catalogo tem 39 premissas")
 
@@ -71,9 +94,9 @@ for mercado, resto in re.findall(
     if got is None:
         erros.append(f"FALTA no macro: {mercado}/{premissa}")
         continue
-    for campo, cel in zip(CAMPOS[:8], cels[1:9]):
-        if got[campo] != num(cel):
-            erros.append(f"{mercado}/{premissa}.{campo}: doc={num(cel)} macro={got[campo]}")
+    for campo, cel in zip(COLUNAS_TABELA1, cels[1:1 + len(COLUNAS_TABELA1)]):
+        if got.get(campo) != num(cel):
+            erros.append(f"{mercado}/{premissa}.{campo}: doc={num(cel)} macro={got.get(campo)}")
 
 # ------------------------------------------------------- doc: as 19 de peso zero
 sec19 = doc.split("As 19 com peso zero")[1].split("### O piso de amostra")[0]
@@ -106,14 +129,17 @@ for premissa, mercado_doc, resto in re.findall(
         erros.append(f"piso {premissa}: nenhuma linha do macro com diferenca_p0={d0}")
         continue
     got = linhas_macro[cands[0]]
-    for campo, v in (("dif_p5", num(cels[1])), ("dif_p10", num(cels[2])), ("n_p5", n5)):
-        if got[campo] != v:
-            erros.append(f"{cands[0]}.{campo}: doc={v} macro={got[campo]}")
+    for campo, v in (("diferenca_p5", num(cels[1])),
+                     ("diferenca_p10", num(cels[2])),
+                     ("n_p5", n5)):
+        if got.get(campo) != v:
+            erros.append(f"{cands[0]}.{campo}: doc={v} macro={got.get(campo)}")
 
-print(f"macro                          {len(linhas_macro)} linhas")
-print(f"doc, as 20 positivas           {n_t1} linhas x 8 campos")
-print(f"doc, as 19 de peso zero        {len(pares)} premissas")
-print(f"doc, a varredura de piso       {n_piso} linhas x 3 campos")
+print(f"campos lidos do STRUCT       {len(campos)} ({', '.join(campos)})")
+print(f"macro                        {len(linhas_macro)} linhas")
+print(f"doc, as 20 positivas         {n_t1} linhas x {len(COLUNAS_TABELA1)} campos")
+print(f"doc, as 19 de peso zero      {len(pares)} premissas")
+print(f"doc, a varredura de piso     {n_piso} linhas x 3 campos")
 print()
 
 if erros:

--- a/scripts/confere_taskf_publicado_01.py
+++ b/scripts/confere_taskf_publicado_01.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Confere a transcricao do Teste 2 da Task [0.1] contra o doc que a publicou.
+
+`dbt_futebol/macros/taskf_publicado_01.sql` transcreve para SQL os numeros que
+`docs/TASK01_RESULTADOS.md` publicou em prosa. A reconciliacao da celula `base` da task [F]
+(issue #51) e a terceira invariante da Costura B (#55) comparam a medicao contra essa
+transcricao — entao um digito trocado nela FABRICA uma divergencia que alguem vai investigar
+como se fosse achado, e o achado nao existe.
+
+Este script existe para que "a transcricao foi conferida" seja fato reproduzivel em vez de
+promessa. Le os dois arquivos, extrai os numeros dos dois lados e compara campo a campo.
+
+Confere os tres recortes que o doc publica, e so eles:
+
+  as 20 de diferenca positiva   linha completa no piso 0 (tabela "Peso medido").
+  as 19 de peso zero            so a diferenca no piso 0 (paragrafo corrido).
+  as 15 da varredura de piso    diferenca nos pisos 5 e 10 e o n do piso 5 (tabelas
+                                "desabam" / "sobrevivem").
+
+Campo que o doc nao publica fica NULL no macro e nao e conferido aqui — e a distincao entre
+"bateu" e "nao havia o que comparar" e mantida de proposito.
+
+Rodar da raiz do repo:
+
+    .venv/bin/python3 scripts/confere_taskf_publicado_01.py
+
+Sai com codigo 1 e lista as divergencias se houver alguma.
+"""
+import pathlib
+import re
+import sys
+
+RAIZ = pathlib.Path(__file__).resolve().parent.parent
+DOC = RAIZ / "docs" / "TASK01_RESULTADOS.md"
+MACRO = RAIZ / "dbt_futebol" / "macros" / "taskf_publicado_01.sql"
+
+CAMPOS = ("n_p0 a_odd_dava_p0 aconteceu_p0 diferenca_p0 jogos_medios pct_curta "
+          "peso_p0 peso_p0_k0 n_p5 dif_p5 dif_p10").split()
+
+doc = DOC.read_text(encoding="utf-8")
+macro = MACRO.read_text(encoding="utf-8")
+
+
+def num(s):
+    """Numero como o doc escreve: virgula decimal, sinal unicode, negrito."""
+    s = s.strip().replace("**", "").replace(",", ".").replace("+", "").replace("−", "-")
+    return None if s in ("", "-") else float(s)
+
+
+# ------------------------------------------------------------------- lado do MACRO
+linhas_macro = {}
+for m in re.finditer(r"^\s*\('([^']+)',\s*'([^']+)',(.*)\),?\s*$", macro, re.M):
+    mercado, premissa, resto = m.group(1), m.group(2), m.group(3)
+    vals = [None if v.strip() == "NULL" else float(v) for v in resto.split(",")]
+    assert len(vals) == len(CAMPOS), f"{mercado}/{premissa}: {len(vals)} valores"
+    linhas_macro[(mercado, premissa)] = dict(zip(CAMPOS, vals))
+
+erros = []
+if len(linhas_macro) != 39:
+    erros.append(f"o macro tem {len(linhas_macro)} linhas, e o catalogo tem 39 premissas")
+
+# --------------------------------------------------- doc: as 20 de diferenca positiva
+sec = doc.split("### Peso medido")[1].split("As 19 com peso zero")[0]
+n_t1 = 0
+for mercado, resto in re.findall(
+        r"^\|\s*(1X2|Gols|Handicap|BTTS|Dupla Chance)\s*\|(.+)\|\s*$", sec, re.M):
+    cels = [c.strip() for c in resto.split("|")]
+    premissa = cels[0].replace("`", "")
+    n_t1 += 1
+    got = linhas_macro.get((mercado, premissa))
+    if got is None:
+        erros.append(f"FALTA no macro: {mercado}/{premissa}")
+        continue
+    for campo, cel in zip(CAMPOS[:8], cels[1:9]):
+        if got[campo] != num(cel):
+            erros.append(f"{mercado}/{premissa}.{campo}: doc={num(cel)} macro={got[campo]}")
+
+# ------------------------------------------------------- doc: as 19 de peso zero
+sec19 = doc.split("As 19 com peso zero")[1].split("### O piso de amostra")[0]
+pares = re.findall(
+    r"`([a-z0-9_]+)`(?:\s*\((Gols|BTTS|1X2|Handicap|Dupla Chance)\))?\s*(−[\d,]+|0,0)", sec19)
+for premissa, mercado_doc, dif in pares:
+    dif = num(dif)
+    achadas = [k for k in linhas_macro
+               if k[1] == premissa and linhas_macro[k]["diferenca_p0"] == dif]
+    if not achadas:
+        erros.append(f"lista-19 {premissa} ({dif}): sem linha no macro com essa diferenca")
+    elif mercado_doc and achadas[0][0] != mercado_doc:
+        erros.append(f"lista-19 {premissa}: doc diz {mercado_doc}, macro diz {achadas[0][0]}")
+
+# ------------------------------------------------------ doc: a varredura de piso
+sec_piso = doc.split("### O piso de amostra")[1].split("### Leitura")[0]
+n_piso = 0
+for premissa, mercado_doc, resto in re.findall(
+        r"^\|\s*`([a-z0-9_]+)`\s*(?:\((Gols|BTTS)\))?\s*\|(.+)\|\s*$", sec_piso, re.M):
+    cels = [c.strip() for c in resto.split("|")]
+    if len(cels) < 4:
+        continue
+    n_piso += 1
+    d0 = num(cels[0])
+    n5 = num(cels[3].split("→")[1]) if "→" in cels[3] else None
+    cands = [k for k in linhas_macro
+             if k[1] == premissa and (not mercado_doc or k[0] == mercado_doc)
+             and linhas_macro[k]["diferenca_p0"] == d0]
+    if not cands:
+        erros.append(f"piso {premissa}: nenhuma linha do macro com diferenca_p0={d0}")
+        continue
+    got = linhas_macro[cands[0]]
+    for campo, v in (("dif_p5", num(cels[1])), ("dif_p10", num(cels[2])), ("n_p5", n5)):
+        if got[campo] != v:
+            erros.append(f"{cands[0]}.{campo}: doc={v} macro={got[campo]}")
+
+print(f"macro                          {len(linhas_macro)} linhas")
+print(f"doc, as 20 positivas           {n_t1} linhas x 8 campos")
+print(f"doc, as 19 de peso zero        {len(pares)} premissas")
+print(f"doc, a varredura de piso       {n_piso} linhas x 3 campos")
+print()
+
+if erros:
+    print(f"!!! {len(erros)} DIVERGENCIAS")
+    for e in erros:
+        print("  -", e)
+    sys.exit(1)
+
+print("OK — a transcricao bate com o doc em todos os campos publicados")


### PR DESCRIPTION
Closes #51

## Implementado — evidência por critério

Branch `worktree-impl-51-celula-base`, commits `fa98ceb` → `5956cc8`. Resultados em
`docs/TASKF_RESULTADOS.md`.

- [x] **A camada de premissas existe no dataset de medição na célula `base`** — os 5 modelos de
  premissas materializados em `futebol_taskF`, com as vars no default. `dbt build` fecha com os
  25 modelos em `success`; a **Costura A passa**, que é o que prova que o default é a célula
  `base` e não outra coisa. As guardas de grão dos 5 modelos passam também — soltar
  `competition_id` de um join é o caminho natural para fan-out, e é o que elas pegam.

- [x] **O universo está cortado exatamente em 16/06 a 04/08, 169 jogos** — e o corte **não é por
  dia**. `DATE(kickoff) <= '2026-08-04'` devolve **178**. Os 9 excedentes são exatamente os jogos
  de 04/08 com kickoff a partir das 16:00 UTC (8 da Champions + o da CdB das 22:30): no dia
  inteiro só um jogo começou antes disso, o das 00:00, e ele está nos 169. A [0.1] rodou **sem**
  corte congelado, então o teto dela é o instante da execução e `janela_fim = 04/08` é só o
  `MAX(DATE(kickoff))` disso. O teto ficou às 12:00 UTC, no meio de um vão de 14h sem jogo
  nenhum, e `analyses/taskf_universo_congelado.sql` mede **as duas pontas da faixa** — ambas dão
  169. O corte é robusto, não calibrado até o número bater.

- [x] **O Teste 2 roda sobre ela e a saída carrega coluna de célula** —
  `futebol_taskF.taskf_teste2`, 60 linhas na `base`: as 39 do benchmark preferido mais 21 de
  consenso de Handicap/Gols marcadas `usado_para_peso = false`. O rótulo da célula é **derivado**
  dos dois eixos por `taskf_celula()`, nunca digitado: não há como materializar `escopo` e gravar
  como `base`.

- [x] **`base` reproduz o Teste 2 publicado dentro de tolerância declarada por escrito** —
  **38 das 39 exatas**, em até 11 campos cada. Tolerância no doc: **0,5 pp, só para
  `linha_subindo`/`linha_descendo`**; para as outras 37 a régua é igualdade exata.

- [x] **A tolerância é justificada pela deriva de odds, e não usada para acomodar outra origem** —
  e a medição foi além do critério em dois pontos:
  1. A **correção da spec #22** (05/08, depois da publicação) era a divergência de outra origem
     mais provável. Ela tem **footprint zero**: 1X2/BTTS/DC não têm nenhuma linha de conjunto
     incompleto na janela, e as 237 de Handicap+Gols são consenso puro — nenhuma com preço
     Pinnacle, contra um controle que casa 3.370 de 6.566 linhas normais (o zero não é join
     quebrado). Como o preferido desses dois é o sharp, ela não alcança nada comparado. A
     hipótese de partida era que atingiria o BTTS; não atinge.
  2. ⚠️ **A justificativa da tolerância não se aplica a um universo congelado.** "As odds viram
     sozinhas entre builds" é verdade no board vivo e **falsa** num universo do passado: a coleta
     é forward-only e para no apito. Medido — **zero capturas posteriores a 04/08** nas três
     janelas de fechamento, para os 169 jogos. A régua vale como bar declarado antes de medir,
     mas **não explica** o que encontrou, e isso está escrito assim no doc em vez de fechado por
     conveniência.

- [x] **Divergência acima da tolerância investigada e explicada** — nenhuma ficou acima, e
  nenhuma foi acomodada: como o mecanismo da deriva é zero, a única divergência que existe
  (`linha_descendo`: 2 linhas de 405, ≤0,2 pp) sai marcada **`INVESTIGAR`**, não
  `DENTRO_DA_TOLERANCIA`. Foi investigada com **5 hipóteses testadas e descartadas**: a #22, a deriva de odds, mudança de código no
  caminho de Gols entre `e6bc54e` e HEAD, o `team_form_pit` (Costura A verde), e o dedup sem
  desempate do `fact_odds_snapshot` (`ORDER BY loaded_at DESC` sem tie-breaker — risco latente
  real, mas 108.196 chaves e **zero** empates nesta janela). Fica como resíduo aberto e delimitado
  no doc, com a candidata que sobrou nomeada como candidata, não como causa.

### Três avisos para quem revisa

1. ⚠️ **A Champions não tem UM jogo no universo congelado.** Os únicos dela na janela são os 8 de
   04/08 à noite, cortados pelo teto. A user story 24 da spec (a pergunta da Copa do Mundo
   estendida à fase classificatória) **não tem amostra** no universo primário — quem executar a
   **#58** precisa saber disso antes de desenhar a resposta.
2. **Para a #55**: os fatos medidos licenciam uma guarda mais apertada do que a spec supôs —
   igualdade **exata** para 37 premissas e para `jogos_no_universo`, e 0,5 pp só para as duas que
   leem preço. E "mesma execução" é verificável como `fact_odds_snapshot.dbt_loaded_at` anterior
   aos quatro `medido_em`, que prova o que importa (as quatro leram a MESMA construção dos fatos).
3. **Para a #53/#54**: rebuildar célula com `+` reinjeta **entre** as células a variação que a
   reconciliação encontrou, e lá ela não cancela — vira efeito de escopo. São duas fases:
   ancestria uma vez, depois só `int_futebol_team_form_pit` + os 5 modelos de premissas. Está no
   cabeçalho do `taskf_teste2.sql`.

### Nada do agendado mudou

Nenhum modelo `.sql` foi alterado (0 arquivos) e nenhum modelo referencia a source nova — o SQL
compilado de produção é idêntico. O `deriva-imagem` vai acusar depois do merge até alguém rodar
`build-and-push.sh dbt_futebol`, e o rebuild é seguro exatamente por isso.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
