### PR TITLE
[F-3] O eixo de escopo alcança todas as fontes de histórico

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -273,7 +273,11 @@ signal.
 
 **Escopo do PIT**:
 Which competitions a PIT aggregate counts. Today it is *da competição*: only fixtures of the
-same competition as the one being rated.
+same competition as the one being rated. It is **not one join** — `int_futebol_team_form_pit`
+holds one, and each of the five premissa models holds its own local history besides (the `last5`
+of Gols, BTTS and Dupla Chance, the Handicap's `margin_stats`, the xG/ritmo spine). Nine
+predicates over six models; the axis reaches all of them or the cell comes out mixed. Table sheet
+in ADR 0007.
 _Avoid_: "juntar os campeonatos" (silent about whether escopo, recorte, or both is changing)
 
 **Recorte do PIT**:

--- a/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
+++ b/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
@@ -10,11 +10,33 @@ saem dos 5 modelos de `intermediate/`, que fazem `ref('int_futebol_team_form_pit
 que decidem em quais jogos a premissa acende. A medição exige, portanto, **re-materializar a
 camada de premissas inteira** sob outro escopo de PIT.
 
-Decidimos fazer isso com uma **var** nas fontes do PIT que são competição-scoped
-(`int_futebol_team_form_pit`, os `last5` locais de Gols e BTTS, o spine de xG), cujo **default
-reproduz exatamente o comportamento de hoje**, mais um **target `taskF` novo apontando para o
-dataset `futebol_taskF`**. É o mesmo padrão que a Task 0 usou para guardar o estado contaminado
-em `futebol_task0`.
+Decidimos fazer isso com uma **var** em **todas** as fontes de histórico competição-scoped, cujo
+**default reproduz exatamente o comportamento de hoje**, mais um **target `taskF` novo apontando
+para o dataset `futebol_taskF`**. É o mesmo padrão que a Task 0 usou para guardar o estado
+contaminado em `futebol_task0`.
+
+São seis modelos e nove predicados de join:
+
+| modelo | mecanismo | premissas alcançadas |
+|---|---|---|
+| `int_futebol_team_form_pit` | o join do agregado PIT | as que leem médias/forma dele |
+| `int_futebol_premissas_1x2` | spine de xG | `superioridade_xg` |
+| `int_futebol_premissas_ou` | spine de xG, `pace_team`, `league_pace_median`, `last5` | `xg_combinado_alto`, `xg_baixo_combinado`, `ritmo_alto`, `historico_over`, `historico_under` |
+| `int_futebol_premissas_btts` | `last5` | `historico_btts`, `historico_seco` |
+| `int_futebol_premissas_ah` | `margin_stats` | `raramente_perde_por_2`, `favorito_irregular` |
+| `int_futebol_premissas_dc` | `team_hist` | `equilibrio_defensivo`, `invicto_recente` |
+
+⚠️ A redação anterior desta ADR enumerava só três mecanismos locais (os `last5` de Gols e de BTTS
+e o spine de xG). Era enumeração incompleta, não regra: o Handicap e a Dupla Chance têm histórico
+competição-scoped próprio pelos mesmos motivos, e deixá-los de fora produziria célula misturada
+dentro do MESMO modelo — `tende_golear` juntado ao lado de `raramente_perde_por_2` não juntado. O
+critério de saída é o da ADR 0008: ficam de fora **quatro** premissas, as de tabela. Com a
+enumeração antiga ficariam oito.
+
+⚠️ O `margin_stats` do Handicap não tem filtro de temporada nem no default: ele já atravessa
+season hoje. O eixo mexe só na dimensão competição, então sob `todas` ele passa a contar todas as
+competições e todo o tempo coletado. É achado para a tabela de 39 linhas — estas duas premissas
+nunca sofreram o zeramento de virada de temporada que as outras sofrem.
 
 ## Por que isto não é opcional
 
@@ -42,3 +64,16 @@ Fica uma var no código de produção que **produção nunca usa**. Um leitor fu
 e não vai saber se pode remover. Por isso a var vem acompanhada de um teste que compara a saída
 com default contra a tabela publicada: enquanto ele passar, "o default preserva o comportamento"
 é fato verificado, e não promessa no comentário.
+
+A lista de valores aceitos existe **uma vez**, em `macros/taskf_eixos.sql`. Sete cópias dela —
+seis modelos mais a `taskf_celula()` — não ficam iguais para sempre, e a divergência seria muda:
+um modelo aceitando um valor que outro rejeita mede célula misturada sem levantar nada.
+
+"O primeiro jogo de um time" também passa a ser **relativo à célula**. O guard de look-ahead da
+Task 0 (`assert_pit_first_game_has_no_history`) particiona pelo escopo e pelo recorte da célula,
+em vez de sempre por (time, competição, temporada). Sem isso ele ficaria vermelho por desenho
+fora do default — sob `todas` ele acusa 224 linhas, que **são o mecanismo funcionando**: o
+primeiro jogo de Copa do Brasil de um time passa a carregar até 17 partidas de Brasileirão, o de
+Sudamericana até 25. Guard vermelho por desenho é guard que se exclui da linha de comando, e aí a
+célula roda sem guarda de look-ahead — o defeito que contaminou a medição que a [F] existe para
+refazer. A única exclusão que a medição precisa é a Costura A, que é default-only por definição.

--- a/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
+++ b/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
@@ -33,6 +33,13 @@ dentro do MESMO modelo — `tende_golear` juntado ao lado de `raramente_perde_po
 critério de saída é o da ADR 0008: ficam de fora **quatro** premissas, as de tabela. Com a
 enumeração antiga ficariam oito.
 
+⚠️ No `league_pace_median`, o eixo alcança o **histórico** de cada time do pool, não o **pool**.
+A mediana é o benchmark "a liga em que estou jogando": juntar campeonatos no pool compararia o
+ritmo do time contra uma liga que não existe. Os dois lados da comparação — o ritmo do time
+avaliado e o de cada time do pool — são medidos sob o mesmo escopo, que é o que a comparação
+exige. Isto **não** é a exceção da ADR 0008: `ritmo_alto` não está na lista fechada de quatro
+premissas de tabela, e é o histórico dele que muda entre células.
+
 ⚠️ O `margin_stats` do Handicap não tem filtro de temporada nem no default: ele já atravessa
 season hoje. O eixo mexe só na dimensão competição, então sob `todas` ele passa a contar todas as
 competições e todo o tempo coletado. É achado para a tabela de 39 linhas — estas duas premissas

--- a/dbt_futebol/macros/taskf_celula.sql
+++ b/dbt_futebol/macros/taskf_celula.sql
@@ -17,11 +17,12 @@
     A saída carrega os dois valores de eixo ao lado do nome pelo mesmo motivo: quem lê a tabela de
     medição não precisa confiar no dicionário acima, ele está na linha.
 
-    ⚠️ As listas de valores aceitos aparecem também no int_futebol_team_form_pit, que valida por
-    conta própria. A duplicação é consciente e assimétrica: o modelo valida porque produção passa
-    por ele, e esta macro valida porque uma análise compila SEM o modelo na seleção — aí a
-    validação do modelo não roda e um `pit_escopo: todos` (com S) mediria `base` calado, com o
-    rótulo `base`, que é exatamente o modo de falha que esta macro existe para fechar.
+    A LEITURA E A VALIDAÇÃO DOS EIXOS não moram aqui: vêm de taskf_eixos(), que é a fonte única
+    dos valores aceitos. Continua valendo que uma análise compila SEM os modelos na seleção — aí a
+    validação deles não roda, e é por isso que esta macro também valida (via taskf_eixos): um
+    `pit_escopo: todos` (com S) mediria `base` calado, com o rótulo `base`, que é exatamente o modo
+    de falha que esta macro existe para fechar. O que mudou é que a lista de valores aceitos existe
+    UMA vez, e não uma por consumidor.
 
     Uso:
 
@@ -31,17 +32,9 @@
 
 {% macro taskf_celula() %}
 
-    {%- set escopo  = var('pit_escopo',  'da_competicao') -%}
-    {%- set recorte = var('pit_recorte', 'temporada') -%}
-
-    {%- if escopo not in ['da_competicao', 'todas'] -%}
-        {{ exceptions.raise_compiler_error(
-            "pit_escopo inválido: '" ~ escopo ~ "'. Valores aceitos: da_competicao | todas.") }}
-    {%- endif -%}
-    {%- if recorte not in ['temporada', 'ultimos_10'] -%}
-        {{ exceptions.raise_compiler_error(
-            "pit_recorte inválido: '" ~ recorte ~ "'. Valores aceitos: temporada | ultimos_10.") }}
-    {%- endif -%}
+    {%- set eixos   = taskf_eixos() -%}
+    {%- set escopo  = eixos.escopo -%}
+    {%- set recorte = eixos.recorte -%}
 
     {%- set nomes = {
         'da_competicao|temporada':  'base',

--- a/dbt_futebol/macros/taskf_eixos.sql
+++ b/dbt_futebol/macros/taskf_eixos.sql
@@ -1,0 +1,49 @@
+{#
+    OS DOIS EIXOS DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007), lidos e validados num lugar só.
+
+        pit_escopo   da_competicao (default) | todas
+                     Quais COMPETIÇÕES contam no histórico do time.
+
+        pit_recorte  temporada (default)     | ultimos_10
+                     Qual TRECHO do passado conta.
+
+    ⚠️ `recorte`, nunca `janela`: janela é a janela de coleta de odds (daily/t24h/t1h/t15m) e as
+    duas coisas não têm relação. Ver o glossário no CONTEXT.md.
+
+    POR QUE UMA MACRO, E NÃO A VALIDAÇÃO REPETIDA EM CADA CONSUMIDOR. O eixo de escopo não mora
+    num modelo só: além do int_futebol_team_form_pit, os cinco modelos de premissas têm fontes de
+    histórico competição-scoped próprias (os `last5` locais de Gols, BTTS e Dupla Chance, o
+    `margin_stats` do Handicap e o spine de xG/ritmo). São SEIS modelos lendo as mesmas vars, mais
+    a taskf_celula() que rotula a saída. Sete cópias da lista de valores aceitos não ficam iguais
+    para sempre, e a divergência seria MUDA: um modelo aceitando um valor que outro rejeita mede
+    célula misturada sem levantar nada. É o mesmo raciocínio que pôs a digital do insumo do PIT
+    numa macro só (taskf_fingerprint_insumo_pit).
+
+    FAIL-CLOSED, e é o ponto todo. Valor desconhecido levanta erro de compilação em vez de cair no
+    default: sem isso, um `pit_escopo: todos` (com S) mediria `base` calado — com o rótulo `base`,
+    porque taskf_celula() deriva o nome dos mesmos valores —, e a comparação entre células, que é
+    o entregável inteiro da [F], compararia duas coisas erradas com cara de certo.
+
+    Uso:
+
+        {%- set eixos = taskf_eixos() -%}
+        {%- if eixos.escopo == 'da_competicao' %} AND l.competition_id = a.competition_id {% endif %}
+#}
+
+{% macro taskf_eixos() %}
+
+    {%- set escopo  = var('pit_escopo',  'da_competicao') -%}
+    {%- set recorte = var('pit_recorte', 'temporada') -%}
+
+    {%- if escopo not in ['da_competicao', 'todas'] -%}
+        {{ exceptions.raise_compiler_error(
+            "pit_escopo inválido: '" ~ escopo ~ "'. Valores aceitos: da_competicao | todas.") }}
+    {%- endif -%}
+    {%- if recorte not in ['temporada', 'ultimos_10'] -%}
+        {{ exceptions.raise_compiler_error(
+            "pit_recorte inválido: '" ~ recorte ~ "'. Valores aceitos: temporada | ultimos_10.") }}
+    {%- endif -%}
+
+    {{ return({'escopo': escopo, 'recorte': recorte}) }}
+
+{% endmacro %}

--- a/dbt_futebol/models/intermediate/_int_futebol__models.yml
+++ b/dbt_futebol/models/intermediate/_int_futebol__models.yml
@@ -153,6 +153,10 @@ models:
       dataset futebol_taskF (target `taskF`). A tabela do campeonato (rank/points/ppg/n_teams/
       goal_diff) NÃO segue os eixos: classificação existe dentro de uma competição, então ela
       permanece competição+temporada em todas as células, por construção (ADR 0008).
+      ⚠️ Este NÃO é o único lugar que o eixo de escopo alcança (#52): cada um dos 5 modelos de
+      premissas tem histórico competição-scoped próprio e lê a mesma var — 9 predicados de join
+      em 6 modelos. Mexer só aqui produziria célula misturada. Tabela de quem-alcança-o-quê na
+      ADR 0007. Os valores aceitos e a validação vivem em macros/taskf_eixos.sql, uma vez só.
     columns:
       - name: fixture_id
         tests: [not_null]
@@ -275,6 +279,13 @@ models:
       (Home/Draw/Away). 7 premissas (§12.1) + penalidades pick_empate/desfalque_proprio
       + evidencias[]/avisos[]. desfalque pesado por importância (S7): só titular importante
       fora (Missing Fixture AND is_important, via int_futebol_desfalques) dispara.
+      ⚠️ MEDIÇÃO (task [F], ADR 0007, #52): o spine de xG é fonte de histórico competição-scoped
+      PRÓPRIA deste modelo e aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz
+      o comportamento acima — no default o SQL compilado é idêntico ao de antes da var. Produção
+      nunca a passa; ela serve às células de medição (dataset futebol_taskF, target `taskF`).
+      Alcança superioridade_xg. NÃO alcança superioridade_tabela (rank/ppg vêm do team_form_pit,
+      competição-scoped em todas as células, ADR 0008) nem h2h_favoravel, por motivo oposto: o
+      fact_h2h já cruza campeonatos hoje e restringi-lo seria mudar premissa.
     columns:
       - name: fixture_id
         tests: [not_null]
@@ -302,6 +313,15 @@ models:
       consenso do mercado (média das PROBABILIDADES IMPLÍCITAS 1/odd de todas as casas, não de
       odds cruas), distinto da corroboração sharp da Pinnacle. last5 (historico_over/under) na
       MESMA season/competição anteriores ao jogo. evidencias[]/avisos[] = bullets pro front.
+      ⚠️ MEDIÇÃO (task [F], ADR 0007, #52): o spine de xG/ritmo e o last5 de gols são fontes de
+      histórico competição-scoped PRÓPRIAS deste modelo e aceitam a var pit_escopo
+      (da_competicao|todas), cujo DEFAULT reproduz o comportamento acima — no default o SQL
+      compilado é idêntico ao de antes da var. Produção nunca a passa; ela serve às células de
+      medição (dataset futebol_taskF, target `taskF`). Alcança xg_combinado_alto,
+      xg_baixo_combinado, ritmo_alto, historico_over e historico_under. No ritmo, o POOL de times
+      da mediana segue sendo o da competição do jogo em qualquer célula (é o benchmark "a liga em
+      que estou jogando"); o que segue o eixo é o histórico de cada time do pool, medido igual ao
+      do time avaliado.
     columns:
       - name: fixture_id
         tests: [not_null]
@@ -330,6 +350,14 @@ models:
       os dois lados; o par Home/Away é complementar). side_handicap = IF(Home, line, -line):
       <0 favorito (5 premissas, Σ40), >0 azarão (3 premissas, Σ30), =0 pick (nenhuma dispara).
       Penalidade handicap_alto (|line|>=2.5, -12). evidencias[]/avisos[] = bullets pro front.
+      ⚠️ MEDIÇÃO (task [F], ADR 0007, #52): o margin_stats é fonte de histórico competição-scoped
+      PRÓPRIA deste modelo e aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz
+      o comportamento acima — no default o SQL compilado é idêntico ao de antes da var. Produção
+      nunca a passa; ela serve às células de medição (dataset futebol_taskF, target `taskF`).
+      Alcança raramente_perde_por_2 e favorito_irregular. NÃO alcança supremacia nem sem_rodizio
+      (rank/ppg/n_teams vêm do team_form_pit, competição-scoped em todas as células, ADR 0008).
+      ⚠️ O margin_stats não tem filtro de season nem no default — já atravessa temporada hoje —,
+      então sob `todas` ele passa a contar todas as competições E todo o tempo coletado.
     columns:
       - name: fixture_id
         tests: [not_null]
@@ -360,6 +388,11 @@ models:
       sheet%/failed-to-score% sobre o total da temporada; gols por venue; historico_btts/seco =
       últimos 5 jogos de cada (>=3 ~ 60%). Sem penalidade específica (só globais). evidencias[]/
       avisos[] pro front. No mart, BTTS usa de-vig de CONSENSO (Pinnacle não precifica BTTS).
+      ⚠️ MEDIÇÃO (task [F], ADR 0007, #52): o last5 de BTTS é fonte de histórico competição-scoped
+      PRÓPRIA deste modelo e aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz
+      o comportamento acima — no default o SQL compilado é idêntico ao de antes da var. Produção
+      nunca a passa; ela serve às células de medição (dataset futebol_taskF, target `taskF`).
+      Alcança historico_btts e historico_seco.
     columns:
       - name: fixture_id
         tests: [not_null]
@@ -388,6 +421,13 @@ models:
       anteriores ao jogo (season-bounded p/ não sangrar a temporada passada na pausa de off-season).
       O 12 (sem empate) não é produzido. Penalidade odd_muito_baixa e gate próprio (>=1,25, sem
       juice) ficam no mart. evidencias[]/avisos[] pro front.
+      ⚠️ MEDIÇÃO (task [F], ADR 0007, #52): o team_hist é fonte de histórico competição-scoped
+      PRÓPRIA deste modelo e aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz
+      o comportamento acima — no default o SQL compilado é idêntico ao de antes da var. Produção
+      nunca a passa; ela serve às células de medição (dataset futebol_taskF, target `taskF`).
+      Alcança equilibrio_defensivo e invicto_recente. lado_coberto_forte e adversario_limitado
+      seguem o que o 1X2 fizer: leem x_superioridade_tabela e x_h2h_favoravel de lá, já colapsados
+      em booleano.
     columns:
       - name: fixture_id
         tests: [not_null]

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
@@ -1,7 +1,23 @@
 {{ config(
     materialized='table',
-    description='S1 do Motor de Score — premissas de contexto do mercado RESULTADO (1X2). 3 linhas por fixture (outcome Home/Draw/Away). S = lado apostado, O = adversário. ⚠️ Task 0 (look-ahead): forca_mismatch/mando/superioridade_tabela/forma leem int_futebol_team_form_pit (point-in-time por fixture), NÃO mais fact_team_season_stats + standings_latest — que em 24/25 entregavam a temporada fechada e a tabela final a jogos da rodada 1. Cada premissa é um booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.1 do épico MOTOR_SCORE_CONFIABILIDADE.md). Penalidades específicas: pick_empate (-10), desfalque_proprio (-15). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/injuries). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities.'
+    description='S1 do Motor de Score — premissas de contexto do mercado RESULTADO (1X2). 3 linhas por fixture (outcome Home/Draw/Away). S = lado apostado, O = adversário. ⚠️ Task 0 (look-ahead): forca_mismatch/mando/superioridade_tabela/forma leem int_futebol_team_form_pit (point-in-time por fixture), NÃO mais fact_team_season_stats + standings_latest — que em 24/25 entregavam a temporada fechada e a tabela final a jogos da rodada 1. Cada premissa é um booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.1 do épico MOTOR_SCORE_CONFIABILIDADE.md). Penalidades específicas: pick_empate (-10), desfalque_proprio (-15). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/injuries). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities. ⚠️ MEDIÇÃO (task [F], ADR 0007): o spine de xG aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz exatamente o comportamento descrito acima — no default o SQL compilado é idêntico ao de antes da var existir. Produção nunca a passa; ela serve às células de medição, materializadas no dataset futebol_taskF. superioridade_tabela NÃO segue o eixo (rank/ppg vêm do team_form_pit, que os mantém competição-scoped em todas as células, ADR 0008), e o h2h_favoravel também não, por motivo oposto: o fact_h2h já cruza campeonatos hoje, e restringi-lo seria mudar premissa.'
 ) }}
+{#- EIXO DE ESCOPO DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — produção nunca passa esta var.
+
+    Além do que vem do team_form_pit, este modelo tem UMA fonte de histórico competição-scoped
+    própria: o spine de xG (CTE `xg`), que alimenta `superioridade_xg`. Ela responde ao mesmo
+    eixo, senão a célula sai MISTURADA — `forca_mismatch` com histórico juntado e
+    `superioridade_xg` sem —, e um número assim não responde a pergunta da spec.
+    `superioridade_tabela` fica de fora por desenho: rank e ppg vêm do team_form_pit, que os
+    mantém competição-scoped em todas as células (ADR 0008). O `fact_h2h` também fica de fora, e
+    por motivo oposto: ele JÁ cruza campeonatos hoje, e restringi-lo seria mudar premissa.
+
+    Valores aceitos, validação e o porquê do fail-closed em macros/taskf_eixos.sql. No default
+    (`da_competicao`) o SQL compilado é IDÊNTICO ao de antes desta var.
+
+    O eixo de RECORTE (`pit_recorte`) ainda NÃO alcança esta fonte: o filtro de season dela
+    continua fixo. É o trabalho da #54. -#}
+{%- set pit_escopo = taskf_eixos().escopo %}
 
 WITH fixtures AS (
     SELECT
@@ -59,7 +75,9 @@ xg AS (
     JOIN {{ ref('fact_fixture_stats') }} st
         ON  st.team_id        = sp.team_id
         AND st.season         = sp.season
+        {%- if pit_escopo == 'da_competicao' %}
         AND st.competition_id = sp.competition_id
+        {%- endif %}
         AND st.date_utc       < DATE(sp.kickoff_utc)
     JOIN {{ ref('fact_fixture_stats') }} opp
         ON  opp.fixture_id = st.fixture_id

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
@@ -1,8 +1,30 @@
 {{ config(
     materialized='table',
     description='S3 do Motor de Score — premissas de contexto do mercado HANDICAP ASIATICO (market_id 4). ⚠️ Task 0 (look-ahead): supremacia/tende_golear/adversario_fragil_fora/mando_forte/sem_rodizio/defesa_fora_solida leem int_futebol_team_form_pit (point-in-time por fixture) — o lado FAVORITO era 100% contaminado. raramente_perde_por_2 e favorito_irregular já eram limpos (margin_stats com kickoff_utc <) e não mudaram. 2 linhas por (fixture, line_value): outcome_side Home e Away. Convenção dos dados (API-Football, confirmada 2026-06-24): line_value é o handicap na ÓTICA DO MANDANTE e é o MESMO p/ os dois lados — "Home -1.5" e "Away -1.5" são o PAR complementar (de-vig soma ~1.03, pin_n_outcomes=2). Logo o handicap NA ÓTICA DO LADO = IF(side=Home, line_value, -line_value): side_handicap<0 => FAVORITO (dá handicap), >0 => AZARÃO (recebe), =0 => pick (nenhuma premissa dispara). Favorito: 5 premissas (Σ40, §12.3); Azarão: 3 (Σ30). Penalidade específica: handicap_alto (-12, |line_value|>=2.5). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. Gate/edge/Score saem no mart fact_value_opportunities (gate de completude Pinnacle = par >=2, igual O/U).
-    ⚠️ Reconciliação §12.3: o bloco "Azarão" do playbook mistura rótulos S/O (ex.: "favorito_irregular | S venceu por 2+..."); aqui as premissas seguem o NOME/INTENÇÃO: raramente_perde_por_2 e defesa_fora_solida medem o AZARÃO (S); favorito_irregular mede o FAVORITO (O). Ao calibrar, alinhar o .md a esta leitura.'
+    ⚠️ Reconciliação §12.3: o bloco "Azarão" do playbook mistura rótulos S/O (ex.: "favorito_irregular | S venceu por 2+..."); aqui as premissas seguem o NOME/INTENÇÃO: raramente_perde_por_2 e defesa_fora_solida medem o AZARÃO (S); favorito_irregular mede o FAVORITO (O). Ao calibrar, alinhar o .md a esta leitura. ⚠️ MEDIÇÃO (task [F], ADR 0007): o margin_stats aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz exatamente o comportamento descrito acima — no default o SQL compilado é idêntico ao de antes da var existir. Produção nunca a passa; ela serve às células de medição, materializadas no dataset futebol_taskF. supremacia e sem_rodizio NÃO seguem o eixo (rank/ppg/n_teams vêm do team_form_pit, que os mantém competição-scoped em todas as células, ADR 0008). ⚠️ O margin_stats não tem filtro de season nem no default — ele já atravessa temporada hoje —, então sob `todas` ele passa a contar todas as competições E todo o tempo coletado.'
 ) }}
+{#- EIXO DE ESCOPO DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — produção nunca passa esta var.
+
+    Além do que vem do team_form_pit, este modelo tem UMA fonte de histórico competição-scoped
+    própria: o `margin_stats`, que alimenta `raramente_perde_por_2` e `favorito_irregular`. Ela
+    responde ao mesmo eixo, senão a célula sai MISTURADA — `tende_golear` com histórico juntado e
+    `raramente_perde_por_2` sem —, e um número assim não responde a pergunta da spec. Vale notar
+    que a spec #49 e o ticket #52 enumeram só o `last5` de Gols, o de BTTS e o spine de xG; a
+    regra que eles declaram, porém, é "todas as fontes de histórico competição-scoped", e o
+    critério de saída da spec (user story 26) fixa em QUATRO as premissas que ficam fora do
+    merge — as quatro de tabela da ADR 0008. Deixar esta fonte de fora faria seis.
+
+    ⚠️ Este `margin_stats` NÃO tem filtro de season hoje: já atravessa temporada. O eixo mexe só
+    na dimensão competição, então sob `todas` ele vira histórico de todas as competições e de
+    todo o tempo coletado. É correto — e é achado para a tabela de 39 linhas, porque significa que
+    estas duas premissas nunca sofreram o zeramento de virada de temporada que as outras sofrem.
+
+    `supremacia` e `sem_rodizio` ficam de fora por desenho: leem rank/ppg/n_teams do
+    team_form_pit, que os mantém competição-scoped em todas as células (ADR 0008).
+
+    Valores aceitos, validação e o porquê do fail-closed em macros/taskf_eixos.sql. No default
+    (`da_competicao`) o SQL compilado é IDÊNTICO ao de antes desta var. -#}
+{%- set pit_escopo = taskf_eixos().escopo %}
 
 WITH fixtures AS (
     SELECT
@@ -84,7 +106,9 @@ margin_stats AS (
     FROM fixture_teams ft
     JOIN team_results r
         ON r.team_id        = ft.team_id
+       {%- if pit_escopo == 'da_competicao' %}
        AND r.competition_id = ft.competition_id
+       {%- endif %}
        AND r.kickoff_utc    < ft.kickoff_utc
     GROUP BY ft.fixture_id, ft.team_id
 ),

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_btts.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_btts.sql
@@ -1,7 +1,20 @@
 {{ config(
     materialized='table',
-    description='S4 do Motor de Score — premissas de contexto do mercado AMBOS MARCAM / BTTS (market_id 8). ⚠️ Task 0 (look-ahead): ambos_marcam/defesa_forte/ataque_trava/ataque_dos_dois/defesas_vazaveis leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats. historico_btts/historico_seco já eram limpos (last5 com kickoff <). 2 linhas por fixture: Yes e No. Sim: dois ataques ativos e defesas vazáveis (4 premissas, Σ34). Não (espelho): uma defesa forte ou um ataque que trava (3 premissas, Σ28). Σ por lado < 55 -> sem clamp. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.4). Convenções herdadas do S2: clean sheet%/failed-to-score% sobre o TOTAL da temporada (SAFE_DIVIDE p/ played_total=0); gols feitos médios por VENUE (mandante em casa, visitante fora). historico_btts/seco = últimos 5 jogos FINALIZADOS de cada time na MESMA competição, anteriores ao jogo (>=3 de 5 ~ 60%). Sem penalidade específica (só as globais, aplicadas no mart). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities (BTTS via de-vig de CONSENSO, pois a Pinnacle não precifica BTTS — valor_fonte=consenso).'
+    description='S4 do Motor de Score — premissas de contexto do mercado AMBOS MARCAM / BTTS (market_id 8). ⚠️ Task 0 (look-ahead): ambos_marcam/defesa_forte/ataque_trava/ataque_dos_dois/defesas_vazaveis leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats. historico_btts/historico_seco já eram limpos (last5 com kickoff <). 2 linhas por fixture: Yes e No. Sim: dois ataques ativos e defesas vazáveis (4 premissas, Σ34). Não (espelho): uma defesa forte ou um ataque que trava (3 premissas, Σ28). Σ por lado < 55 -> sem clamp. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.4). Convenções herdadas do S2: clean sheet%/failed-to-score% sobre o TOTAL da temporada (SAFE_DIVIDE p/ played_total=0); gols feitos médios por VENUE (mandante em casa, visitante fora). historico_btts/seco = últimos 5 jogos FINALIZADOS de cada time na MESMA competição, anteriores ao jogo (>=3 de 5 ~ 60%). Sem penalidade específica (só as globais, aplicadas no mart). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities (BTTS via de-vig de CONSENSO, pois a Pinnacle não precifica BTTS — valor_fonte=consenso). ⚠️ MEDIÇÃO (task [F], ADR 0007): o last5 de BTTS aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz exatamente o comportamento descrito acima — no default o SQL compilado é idêntico ao de antes da var existir. Produção nunca a passa; ela serve às células de medição, materializadas no dataset futebol_taskF.'
 ) }}
+{#- EIXO DE ESCOPO DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — produção nunca passa esta var.
+
+    Além do que vem do team_form_pit, este modelo tem UMA fonte de histórico competição-scoped
+    própria: o `last5` de BTTS, que alimenta `historico_btts` e `historico_seco`. Ela responde ao
+    mesmo eixo, senão a célula sai MISTURADA — `defesa_forte` com histórico juntado e
+    `historico_btts` sem —, e um número assim não responde a pergunta da spec.
+
+    Valores aceitos, validação e o porquê do fail-closed em macros/taskf_eixos.sql. No default
+    (`da_competicao`) o SQL compilado é IDÊNTICO ao de antes desta var.
+
+    O eixo de RECORTE (`pit_recorte`) ainda NÃO alcança esta fonte: o filtro de season dela
+    continua fixo. É o trabalho da #54. -#}
+{%- set pit_escopo = taskf_eixos().escopo %}
 
 WITH fixtures AS (
     SELECT
@@ -58,7 +71,9 @@ last5 AS (
     FROM fixture_teams ft
     JOIN team_fixtures_long h
         ON h.team_id        = ft.team_id
+       {%- if pit_escopo == 'da_competicao' %}
        AND h.competition_id = ft.competition_id
+       {%- endif %}
        AND h.season         = ft.season
        AND h.kickoff_utc    < ft.kickoff_utc
     GROUP BY ft.fixture_id, ft.team_id

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_dc.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_dc.sql
@@ -1,7 +1,26 @@
 {{ config(
     materialized='table',
-    description='S5 do Motor de Score — premissas de contexto do mercado DUPLA CHANCE (market_id 12). ⚠️ Task 0 (look-ahead): equilibrio_defensivo/adversario_limitado leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats; lado_coberto_forte herda a correção via int_futebol_premissas_1x2 (era a premissa MAIS contaminada, com as duas fontes sujas). invicto_recente já era limpa. 2 linhas por fixture: 1X (mandante ou empate, S=Home) e X2 (empate ou visitante, S=Away). DC é aposta de proteção: vale quando o mercado superprecifica a zebra do lado DESCOBERTO (O). 4 premissas (Σ34, sem clamp — bem abaixo de 55), espelha §12.5. lado_coberto_forte REUSA forca_mismatch/superioridade_tabela do int_futebol_premissas_1x2 (do lado S); adversario_limitado reusa o h2h_favoravel do 1X2. equilibrio_defensivo e invicto_recente derivam de fact_team_season_stats (gols sofridos no total) e dos jogos FINALIZADOS da MESMA season/competição anteriores ao jogo (goleados = cedeu 3+, e derrotas nos últimos 5) — o filtro de season evita sangrar a temporada passada pela pausa de off-season. O 12 (sem empate) NÃO é produzido (não casa com o padrão S/O da §12.5). Penalidade específica (odd_muito_baixa <1,20) e o gate próprio (melhor_odd >=1,25, sem odd_juice) são aplicados no mart fact_value_opportunities. Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front.'
+    description='S5 do Motor de Score — premissas de contexto do mercado DUPLA CHANCE (market_id 12). ⚠️ Task 0 (look-ahead): equilibrio_defensivo/adversario_limitado leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats; lado_coberto_forte herda a correção via int_futebol_premissas_1x2 (era a premissa MAIS contaminada, com as duas fontes sujas). invicto_recente já era limpa. 2 linhas por fixture: 1X (mandante ou empate, S=Home) e X2 (empate ou visitante, S=Away). DC é aposta de proteção: vale quando o mercado superprecifica a zebra do lado DESCOBERTO (O). 4 premissas (Σ34, sem clamp — bem abaixo de 55), espelha §12.5. lado_coberto_forte REUSA forca_mismatch/superioridade_tabela do int_futebol_premissas_1x2 (do lado S); adversario_limitado reusa o h2h_favoravel do 1X2. equilibrio_defensivo e invicto_recente derivam de fact_team_season_stats (gols sofridos no total) e dos jogos FINALIZADOS da MESMA season/competição anteriores ao jogo (goleados = cedeu 3+, e derrotas nos últimos 5) — o filtro de season evita sangrar a temporada passada pela pausa de off-season. O 12 (sem empate) NÃO é produzido (não casa com o padrão S/O da §12.5). Penalidade específica (odd_muito_baixa <1,20) e o gate próprio (melhor_odd >=1,25, sem odd_juice) são aplicados no mart fact_value_opportunities. Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. ⚠️ MEDIÇÃO (task [F], ADR 0007): o team_hist aceita a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz exatamente o comportamento descrito acima — no default o SQL compilado é idêntico ao de antes da var existir. Produção nunca a passa; ela serve às células de medição, materializadas no dataset futebol_taskF. lado_coberto_forte e adversario_limitado seguem o que o 1X2 fizer: leem x_superioridade_tabela e x_h2h_favoravel de lá, já colapsados em booleano.'
 ) }}
+{#- EIXO DE ESCOPO DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — produção nunca passa esta var.
+
+    Além do que vem do team_form_pit, este modelo tem UMA fonte de histórico competição-scoped
+    própria: o `team_hist`, que alimenta `equilibrio_defensivo` (thrash_rate) e `invicto_recente`
+    (last5_lost). Ela responde ao mesmo eixo, senão a célula sai MISTURADA — o `s_ga_total` da
+    mesma premissa `equilibrio_defensivo` vem do team_form_pit e viria juntado, e o `thrash_rate`
+    ao lado dele não —, e um número assim não responde a pergunta da spec. Como no Handicap, esta
+    fonte não está na enumeração da spec #49; está na regra que ela declara. Ver o cabeçalho do
+    int_futebol_premissas_ah.sql.
+
+    `lado_coberto_forte` e `adversario_limitado` seguem o que o 1X2 fizer: leem
+    x_superioridade_tabela e x_h2h_favoravel de lá, já colapsados em booleano.
+
+    Valores aceitos, validação e o porquê do fail-closed em macros/taskf_eixos.sql. No default
+    (`da_competicao`) o SQL compilado é IDÊNTICO ao de antes desta var.
+
+    O eixo de RECORTE (`pit_recorte`) ainda NÃO alcança esta fonte: o filtro de season dela
+    continua fixo. É o trabalho da #54. -#}
+{%- set pit_escopo = taskf_eixos().escopo %}
 
 WITH fixtures AS (
     SELECT
@@ -69,7 +88,9 @@ team_hist AS (
     FROM team_fixtures tf
     JOIN team_results_long h
         ON h.team_id        = tf.team_id
+       {%- if pit_escopo == 'da_competicao' %}
        AND h.competition_id = tf.competition_id
+       {%- endif %}
        AND h.season         = tf.season
        AND h.kickoff_utc    < tf.kickoff_utc
     GROUP BY tf.fixture_id, tf.team_id

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ou.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ou.sql
@@ -1,7 +1,24 @@
 {{ config(
     materialized='table',
-    description='S2 do Motor de Score — premissas de contexto do mercado GOLS Over/Under (market_id 5). ⚠️ Task 0 (look-ahead): ataque_combinado/defesas_firmes/defesas_vazaveis/clean_sheets_altos/ataques_fracos/ambos_vazam leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats; xg_combinado_alto/xg_baixo_combinado/ritmo_alto passaram a usar o spine ancorado no kickoff (item C) em vez da média da season inteira — era o caso que fazia o MESMO xG medir −2,4 no 1X2 (point-in-time) e +0,5 aqui. historico_over/under e linha_subindo/descendo já eram limpos. 2 linhas por (fixture, line_value): Over e Under, por linha L. Universo de linhas = canônicas {1.5,2.5,3.5} de toda fixture UNION as linhas presentes nas odds (market_id=5) — assim valida no Brasileirão mesmo sem odds (pausa FIFA) e ainda deixa a penalidade linha_extrema disparar em linhas extremas do mercado. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.2; Over Σ56 / Under Σ52, com clamp ao teto 55 — Over é o único lado que encosta no teto). Penalidade específica: linha_extrema (-10, L<=0,5 ou L>=4,5). Movimento de linha (linha_subindo/descendo) = CONSENSO do mercado (média das PROBABILIDADES IMPLÍCITAS 1/odd de TODAS as casas t24h->t15m; odd crua super-ponderaria o leg de odd alta), DISTINTO da corroboração linha_sharp_confirma (só Pinnacle) p/ não contar o mesmo sinal 2x (§10.8). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/ritmo). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities.'
+    description='S2 do Motor de Score — premissas de contexto do mercado GOLS Over/Under (market_id 5). ⚠️ Task 0 (look-ahead): ataque_combinado/defesas_firmes/defesas_vazaveis/clean_sheets_altos/ataques_fracos/ambos_vazam leem int_futebol_team_form_pit (point-in-time por fixture) no lugar de fact_team_season_stats; xg_combinado_alto/xg_baixo_combinado/ritmo_alto passaram a usar o spine ancorado no kickoff (item C) em vez da média da season inteira — era o caso que fazia o MESMO xG medir −2,4 no 1X2 (point-in-time) e +0,5 aqui. historico_over/under e linha_subindo/descendo já eram limpos. 2 linhas por (fixture, line_value): Over e Under, por linha L. Universo de linhas = canônicas {1.5,2.5,3.5} de toda fixture UNION as linhas presentes nas odds (market_id=5) — assim valida no Brasileirão mesmo sem odds (pausa FIFA) e ainda deixa a penalidade linha_extrema disparar em linhas extremas do mercado. Cada premissa é 1 booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.2; Over Σ56 / Under Σ52, com clamp ao teto 55 — Over é o único lado que encosta no teto). Penalidade específica: linha_extrema (-10, L<=0,5 ou L>=4,5). Movimento de linha (linha_subindo/descendo) = CONSENSO do mercado (média das PROBABILIDADES IMPLÍCITAS 1/odd de TODAS as casas t24h->t15m; odd crua super-ponderaria o leg de odd alta), DISTINTO da corroboração linha_sharp_confirma (só Pinnacle) p/ não contar o mesmo sinal 2x (§10.8). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/ritmo). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities. ⚠️ MEDIÇÃO (task [F], ADR 0007): o spine de xG/ritmo e o last5 de gols aceitam a var pit_escopo (da_competicao|todas), cujo DEFAULT reproduz exatamente o comportamento descrito acima — no default o SQL compilado é idêntico ao de antes da var existir. Produção nunca a passa; ela serve às células de medição, materializadas no dataset futebol_taskF. O POOL de times da mediana de ritmo segue sendo o da competição do jogo em qualquer célula (é o benchmark "a liga em que estou jogando"); o que segue o eixo é o histórico de cada time do pool, medido igual ao do time avaliado.'
 ) }}
+{#- EIXO DE ESCOPO DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — produção nunca passa esta var.
+
+    Além do que vem do team_form_pit, este modelo tem DUAS fontes de histórico competição-scoped
+    próprias: o spine de xG/ritmo (CTEs `xg`, `pace_team`, `league_pace_median`) e o `last5` de
+    gols totais. Elas respondem ao mesmo eixo, senão a célula sai MISTURADA — `clean_sheets_altos`
+    com histórico juntado e `historico_over` sem —, e um número assim não responde a pergunta da
+    spec. As quatro premissas de tabela seguem competição-scoped em todas as células (ADR 0008),
+    mas `ritmo_alto` não é uma delas: só a mediana da liga é benchmark de competição, o ritmo de
+    cada time é histórico e segue o eixo.
+
+    Valores aceitos, validação e o porquê do fail-closed em macros/taskf_eixos.sql. No default
+    (`da_competicao`) o SQL compilado é IDÊNTICO ao de antes desta var — nenhum ramo novo é
+    emitido no caminho que produção usa.
+
+    O eixo de RECORTE (`pit_recorte`) ainda NÃO alcança estas fontes: o filtro de season delas
+    continua fixo. É o trabalho da #54, uma linha por site. -#}
+{%- set pit_escopo = taskf_eixos().escopo %}
 
 WITH fixtures AS (
     SELECT
@@ -67,7 +84,9 @@ xg AS (
     JOIN {{ ref('fact_fixture_stats') }} st
         ON  st.team_id        = sp.team_id
         AND st.season         = sp.season
+        {%- if pit_escopo == 'da_competicao' %}
         AND st.competition_id = sp.competition_id
+        {%- endif %}
         AND st.date_utc       < DATE(sp.kickoff_utc)
     GROUP BY sp.fixture_id, sp.team_id
 ),
@@ -80,12 +99,18 @@ pace_team AS (
     JOIN {{ ref('fact_fixture_stats') }} st
         ON  st.team_id        = sp.team_id
         AND st.season         = sp.season
+        {%- if pit_escopo == 'da_competicao' %}
         AND st.competition_id = sp.competition_id
+        {%- endif %}
         AND st.date_utc       < DATE(sp.kickoff_utc)
     GROUP BY sp.fixture_id, sp.team_id, sp.competition_id, sp.season
 ),
 -- Mediana da liga sobre as médias por time NO INSTANTE DO JOGO: 1 mediana por (liga, season,
 -- fixture), e não mais uma única mediana da season fechada.
+{#- ⚠️ [F]: o POOL de times (`lt`) é da competição do jogo em qualquer célula — a mediana é o
+    benchmark "a liga em que estou jogando", e juntar campeonatos no pool compararia o ritmo do
+    time contra uma liga que não existe. O que segue o eixo é o HISTÓRICO de cada time do pool,
+    exatamente como no `pace_team` acima — os dois lados da comparação são medidos igual. #}
 league_pace_median AS (
     SELECT fixture_id,
            APPROX_QUANTILES(pace_avg, 2)[OFFSET(1)] AS pace_median
@@ -98,7 +123,9 @@ league_pace_median AS (
         JOIN {{ ref('fact_fixture_stats') }} st
             ON  st.team_id        = lt.team_id
             AND st.season         = sp.season
+            {%- if pit_escopo == 'da_competicao' %}
             AND st.competition_id = sp.competition_id
+            {%- endif %}
             AND st.date_utc       < DATE(sp.kickoff_utc)
         GROUP BY sp.fixture_id, lt.team_id
     )
@@ -132,7 +159,9 @@ last5 AS (
     FROM fixture_teams ft
     JOIN team_fixtures_long h
         ON h.team_id        = ft.team_id
+       {%- if pit_escopo == 'da_competicao' %}
        AND h.competition_id = ft.competition_id
+       {%- endif %}
        AND h.season         = ft.season
        AND h.kickoff_utc    < ft.kickoff_utc
     GROUP BY ft.fixture_id, ft.team_id

--- a/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
@@ -41,8 +41,9 @@
       dbt run --target taskF --select int_futebol_team_form_pit \
         --vars '{pit_escopo: todas, pit_recorte: ultimos_10}'
 -#}
-{%- set pit_escopo  = taskf_eixos().escopo -%}
-{%- set pit_recorte = taskf_eixos().recorte -%}
+{%- set eixos       = taskf_eixos() -%}
+{%- set pit_escopo  = eixos.escopo -%}
+{%- set pit_recorte = eixos.recorte -%}
 {#- Fora do default, a tabela do campeonato precisa do próprio agregado, competição-scoped
     (ADR 0008) — e o rank/ppg passam a sair dele, não do agregado da célula. -#}
 {%- set tabela_propria = (pit_escopo != 'da_competicao') or (pit_recorte != 'temporada') -%}

--- a/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql
@@ -18,6 +18,17 @@
     ⚠️ `recorte`, nunca `janela`: janela é a janela de coleta de odds (daily/t24h/t1h/t15m) e as
     duas coisas não têm relação. Ver o glossário no CONTEXT.md.
 
+    ⚠️ ESTE MODELO NÃO É A ÚNICA FONTE QUE O EIXO DE ESCOPO ALCANÇA. Cada um dos cinco modelos de
+    premissas tem histórico competição-scoped próprio — os `last5` de Gols, BTTS e Dupla Chance, o
+    `margin_stats` do Handicap e o spine de xG/ritmo — e todos leem a MESMA var. São nove
+    predicados de join em seis modelos; a tabela de quem-alcança-o-quê está na ADR 0007. Mexer só
+    aqui produziria célula misturada (`clean_sheets_altos` juntado ao lado de `historico_over` não
+    juntado), que é exatamente o número que não responde a pergunta da spec.
+
+    Os valores aceitos e a validação vivem em macros/taskf_eixos.sql, uma vez só: sete cópias da
+    lista — os seis modelos mais a taskf_celula() — não ficam iguais para sempre, e a divergência
+    seria muda.
+
     Os dois defaults reproduzem o comportamento de hoje, e a igualdade é fato verificado, não
     promessa: tests/assert_taskf_pit_default_igual_baseline.sql compara a saída no default contra
     o baseline congelado antes de esta var existir. No default o SQL compilado é IDÊNTICO ao de
@@ -30,16 +41,8 @@
       dbt run --target taskF --select int_futebol_team_form_pit \
         --vars '{pit_escopo: todas, pit_recorte: ultimos_10}'
 -#}
-{%- set pit_escopo  = var('pit_escopo',  'da_competicao') -%}
-{%- set pit_recorte = var('pit_recorte', 'temporada') -%}
-{%- if pit_escopo not in ['da_competicao', 'todas'] -%}
-    {{ exceptions.raise_compiler_error(
-        "pit_escopo inválido: '" ~ pit_escopo ~ "'. Valores aceitos: da_competicao | todas.") }}
-{%- endif -%}
-{%- if pit_recorte not in ['temporada', 'ultimos_10'] -%}
-    {{ exceptions.raise_compiler_error(
-        "pit_recorte inválido: '" ~ pit_recorte ~ "'. Valores aceitos: temporada | ultimos_10.") }}
-{%- endif -%}
+{%- set pit_escopo  = taskf_eixos().escopo -%}
+{%- set pit_recorte = taskf_eixos().recorte -%}
 {#- Fora do default, a tabela do campeonato precisa do próprio agregado, competição-scoped
     (ADR 0008) — e o rank/ppg passam a sair dele, não do agregado da célula. -#}
 {%- set tabela_propria = (pit_escopo != 'da_competicao') or (pit_recorte != 'temporada') -%}

--- a/dbt_futebol/tests/assert_pit_first_game_has_no_history.sql
+++ b/dbt_futebol/tests/assert_pit_first_game_has_no_history.sql
@@ -1,9 +1,26 @@
 {{ config(tags=['guarda']) }}
+{%- set eixos = taskf_eixos() %}
 -- Guard de regressão da Task 0 (look-ahead).
 -- No PRIMEIRO jogo de um time numa (competição, temporada) não existe passado: played_total tem
 -- de ser 0 e rank/médias têm de ser NULL. Era exatamente aqui que o modelo antigo entregava a
 -- temporada FECHADA (played_total=38, tabela final) a um jogo da rodada 1.
 -- Falha = alguma fonte voltou a ser lida sem âncora no kickoff.
+{#-
+    ⚠️ "PRIMEIRO JOGO" É RELATIVO À CÉLULA (task [F], issue #49, ADR 0007), e a partição abaixo
+    segue os dois eixos porque o join do modelo segue. Em produção nada muda: no default a
+    partição é (team_id, competition_id, season) e o SQL compilado é IDÊNTICO ao de antes.
+
+    Por que não deixar o guard falhar fora do default e mandar excluí-lo. Sob `pit_escopo: todas`
+    ele acusa 224 linhas — e elas são o mecanismo da medição FUNCIONANDO: o primeiro jogo de Copa
+    do Brasil de um time passa a carregar até 17 partidas de Brasileirão, o de Sudamericana até
+    25. É a hipótese da spec virando número. Mas guard vermelho por desenho é guard que se exclui
+    da linha de comando, e aí a célula inteira roda SEM guarda de look-ahead — justamente o defeito
+    (Task 0) que contaminou a medição que esta task existe para refazer. Com a partição seguindo a
+    célula, a invariante continua sendo asserida nas quatro, e a única exclusão que a medição
+    precisa é a Costura A, que é default-only por definição.
+
+    Verificado nas quatro células: 0 violações.
+#}
 
 WITH primeiro_jogo AS (
     SELECT
@@ -17,7 +34,7 @@ WITH primeiro_jogo AS (
         goals_for_avg_home
     FROM {{ ref('int_futebol_team_form_pit') }}
     QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY team_id, competition_id, season
+        PARTITION BY team_id{% if eixos.escopo == 'da_competicao' %}, competition_id{% endif %}{% if eixos.recorte == 'temporada' %}, season{% endif %}
         ORDER BY kickoff_utc
     ) = 1
 )

--- a/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
+++ b/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
@@ -37,13 +37,18 @@
 --
 -- Falsificada uma vez com `--vars '{pit_escopo: todas}'`, que a deixa vermelha (12.868
 -- divergências). Consequência disso: nas células juntadas esta guarda é VERMELHA POR DESENHO,
--- porque a saída ali de fato não é a de produção. Quem roda as células exclui as duas guardas que
--- afirmam coisa de célula `base` — esta e o `assert_pit_first_game_has_no_history`, cuja
--- invariante é competição-scoped por definição (ver #53):
+-- porque a saída ali de fato não é a de produção. Ela é a ÚNICA exclusão que a medição precisa —
+-- é default-only por definição, já que o que ela afirma é justamente "o default reproduz
+-- produção":
 --
 --   dbt build --target taskF --select int_futebol_team_form_pit \
 --     --vars '{pit_escopo: todas}' \
---     --exclude assert_taskf_pit_default_igual_baseline assert_pit_first_game_has_no_history
+--     --exclude assert_taskf_pit_default_igual_baseline
+--
+-- ⚠️ Esta receita já mandou excluir também o `assert_pit_first_game_has_no_history`. NÃO EXCLUA
+-- MAIS (#52): a partição dele passou a seguir os eixos da célula, ele é verde nas quatro, e
+-- excluí-lo faz a célula rodar sem guarda de look-ahead — o defeito (Task 0) que contaminou a
+-- medição que a [F] existe para refazer.
 
 {% set colunas = [
     'fixture_id', 'team_id', 'competition', 'competition_id', 'season', 'kickoff_utc',


### PR DESCRIPTION
Closes #52

## Duas decisões que vão além da letra dos critérios — leia antes do resto

**1. O Handicap e a Dupla Chance entraram, e os critérios do #52 não os listam.** Os ACs enumeram
três fontes (o `last5` de Gols, o de BTTS e o spine de xG). O código tem **seis** mecanismos: o
`margin_stats` do Handicap e o `team_hist` da Dupla Chance também são histórico competição-scoped
local. Parei na regra, não na enumeração — e a regra está no próprio #52: *"O eixo de escopo passa
a alcançar **todas** as fontes de histórico competição-scoped, e não só o
`int_futebol_team_form_pit`"*. A #49 concorda (*"aplicado **uniformemente**"*) e a user story 26
fecha a conta: ela fixa em **quatro** as premissas que ficam de fora do merge — as de tabela da
ADR 0008. Parando na enumeração ficariam **oito**, e duas delas (`raramente_perde_por_2` e
`favorito_irregular`) são das três que a própria #49 aponta como sobreviventes da amostra curta.
Pior, a célula sairia misturada **dentro do mesmo modelo**: `tende_golear` juntado ao lado de
`raramente_perde_por_2` não juntado. A ADR 0007 foi corrigida com a tabela completa.

**2. Um teste `tag:guarda` foi alterado, e o #52 não pede isso.** É o
`assert_pit_first_game_has_no_history`, o guard de look-ahead da Task 0. Detalhe abaixo; o resumo é
que sem ele o AC *"O grão dos cinco modelos de premissas segue verde"* não é verificável sob
`todas`, porque a #49 manda rodar com `dbt build` e um guard vermelho pula os cinco modelos.
No default o compilado dele é byte-idêntico e as 14 guardas contra produção seguem verdes.

## Implementado — evidência por critério

Branch `worktree-impl-52-escopo-fontes`, commits `5789c38` → `6c5ac14`.

- [x] **Os `last5` locais de Gols respondem ao mesmo eixo** — e não só eles: no modelo de Gols são
  **quatro** sites (`xg`, `pace_team`, o interior do `league_pace_median` e o `last5`).

- [x] **Os `last5` locais de BTTS idem** — 1 site.

- [x] **O spine de xG idem** — 1 site no 1X2, mais os do Gols acima. Ao todo **9 predicados em 6
  modelos**; o compilado sob `todas` perde exatamente esses 9 e nada mais.

- [x] **O default de todas elas continua reproduzindo produção — a Costura A segue verde** — e a
  prova é mais forte do que uma comparação de dado: **no default o SQL compilado é byte-idêntico**
  nos seis modelos (`diff` do compilado antes/depois sai vazio), e o do teste alterado também. Como
  a entrada é a mesma, "o default reproduz produção" é implicação, não medição. A Costura A passa
  em cima disso.

- [x] **O grão dos cinco modelos segue verde** — `dbt build --target taskF` no default: **43/43**,
  com a Costura A e o guard da Task 0 dentro. Sob `todas`: **42/42, SKIP=0**, os 6 testes de
  `unique_combination` passando e as contagens de linha idênticas às do default nos cinco modelos.

- [x] **O `fact_h2h` não foi alterado** — 0 arquivos. Ele já cruza campeonatos por definição.

## A fiação foi falsificada, não só vista funcionar

Por mecanismo, e com a desigualdade que a **#53** vai cobrar como AC (*"para todo par (jogo, time),
a contagem em `escopo` é maior ou igual à de `base`"*):

| família | pares | perdem | ganham | jogos `base` → `todas` |
|---|---|---|---|---|
| season-scoped (OU/BTTS/DC) | 21.054 | **0** | 6.434 | 237.630 → 289.920 |
| AH `margin_stats` (sem season) | 21.054 | **0** | 9.061 | 743.302 → 939.424 |
| spine de xG/ritmo (1X2+OU) | 21.054 | **0** | 6.383 | 236.975 → 289.444 |

E o laço fecha na premissa. As **11** de fonte local mudaram; os **3 controles da ADR 0008**
ficaram idênticos na linha:

| premissa | `base` | `escopo` | Δ |
|---|---|---|---|
| CONTROLE `superioridade_tabela` | 5.552 | 5.552 | **0** |
| CONTROLE `supremacia` | 10.122 | 10.122 | **0** |
| CONTROLE `sem_rodizio` | 13.535 | 13.535 | **0** |
| `raramente_perde_por_2` (AH) | 33.796 | 35.564 | +1.768 |
| `favorito_irregular` (AH) | 33.304 | 34.946 | +1.642 |
| `historico_under` (OU) | 7.884 | 8.654 | +770 |
| `equilibrio_defensivo` (DC) | 5.200 | 5.822 | +622 |
| `ritmo_alto` (OU) | 16.111 | 16.568 | +457 |
| `historico_over` (OU) | 7.300 | 7.653 | +353 |
| `historico_seco` (BTTS) | 4.701 | 5.036 | +335 |
| `xg_combinado_alto` (OU) | 11.107 | 11.422 | +315 |
| `superioridade_xg` (1X2) | 3.978 | 4.155 | +177 |
| `invicto_recente` (DC) | 2.337 | 2.246 | −91 |
| `historico_btts` (BTTS) | 1.769 | 1.826 | +57 |

`invicto_recente` cair é coerente: mais histórico, mais chance de ter perdido nos últimos 5.
Nenhum site ficou morto e nenhum vazou para onde não devia.

## O guard de look-ahead, em detalhe

Sob `todas` o `assert_pit_first_game_has_no_history` acusava **224 linhas** — e elas são o
**mecanismo da medição funcionando**: o primeiro jogo de Copa do Brasil de um time passa a carregar
até **17** partidas de Brasileirão, o de Sudamericana até **25**, o da Champions de 3 a 5. É a
hipótese da #49 virando número.

Mas guard vermelho por desenho é guard que se exclui da linha de comando — e aí a célula roda **sem
guarda de look-ahead**, que é o defeito (Task 0) que contaminou a medição que a [F] existe para
refazer. Em `dbt build` ele ainda derrubava os 5 modelos de premissas por skip.

A partição agora segue os dois eixos. A invariante é asserida nas **quatro** células (0 violações em
cada), o compilado no default é byte-idêntico, e a única exclusão que a medição precisa passa a ser
a Costura A — default-only por definição.

⚠️ **A receita antiga mandava excluir os dois.** O cabeçalho da Costura A instruía
`--exclude assert_taskf_pit_default_igual_baseline assert_pit_first_game_has_no_history`. Quem
executasse a #53 copiando dali rodaria a célula sem o guard. Corrigido no `6c5ac14`, com aviso ao
lado, e **verificado**: sob `todas`, excluindo só a Costura A, o build fecha 42/42 com SKIP=0.

## Nada do agendado mudou

Nenhum workflow YAML, nenhum script de deploy, nenhum `--select`. As **14** guardas do agendado
rodadas contra produção depois da mudança: **PASS=14, ERROR=0**. As seis tabelas de produção não
foram reescritas — última modificação 12:11–12:12 UTC, o run agendado.

⚠️ Arquivos `.sql` de modelo mudaram, então o `deriva-imagem` vai acusar depois do merge até alguém
rodar `build-and-push.sh dbt_futebol`. O rebuild é seguro **exatamente porque** o compilado é
idêntico: a imagem nova produz o mesmo SQL que a atual.

## Para quem pega a #53 e a #54

1. **Ao rodar célula, exclua SÓ a Costura A.** Não volte a excluir o guard de look-ahead.
2. **A desigualdade `todas` ≥ `base` do AC da #53 já está verificada** por mecanismo — a tabela
   acima. Zero pares perdem histórico.
3. **O eixo de RECORTE ainda não alcança as fontes locais**: o filtro de season delas segue fixo. É
   uma linha por site, nos mesmos oito lugares, e o guard de look-ahead já está preparado para os
   dois eixos (particiona por `(team_id)` quando escopo=todas e recorte=ultimos_10).
4. **O `margin_stats` do Handicap não tem filtro de season nem no default** — já atravessa
   temporada hoje. Sob `todas` ele conta todas as competições E todo o tempo coletado. É achado para
   a tabela de 39 linhas: estas duas premissas nunca sofreram o zeramento de virada de temporada.
5. **Continua valendo o aviso do PR #62**: nunca rebuildar célula com `+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
