### PR TITLE
[F-4] Célula escopo: todas as competições, temporada mantida

### DIFF
--- a/dbt_futebol/analyses/taskf_delta_celulas.sql
+++ b/dbt_futebol/analyses/taskf_delta_celulas.sql
@@ -1,0 +1,160 @@
+/*
+    [F-4] O NÚMERO DE CADA PREMISSA, LADO A LADO, ENTRE DUAS CÉLULAS. Por default `base` contra
+    `escopo`, que é a comparação que a #53 pede: a primeira célula que produz número novo.
+
+    A tabela do entregável final (as 39 linhas da #59) sai desta comparação repetida para as
+    outras células; aqui ela é o que responde "o que o número vira quando junta" para o eixo de
+    escopo isolado.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O QUE ESPERAR, ANTES DE OLHAR — para o resultado poder desmentir algo:
+
+    1. As TRÊS PREMISSAS DE TABELA do catálogo medido (`superioridade_tabela`, `supremacia`,
+       `sem_rodizio`) têm de sair IDÊNTICAS NO PISO 0. A ADR 0008 as mantém competição-scoped em
+       todas as células: rank e ppg saem do agregado próprio do team_form_pit, que não segue os
+       eixos. Se uma delas se mexer no piso 0, a ADR 0008 não está implementada como diz.
+       (A quarta que a ADR nomeia, `x_superioridade_tabela`, não é premissa medida: é coluna
+       interna do 1X2 que a Dupla Chance reusa dentro do `lado_coberto_forte`, o qual TAMBÉM lê
+       `forca_mismatch` e portanto segue o eixo.)
+
+    2. ⚠️ IDÊNTICAS NO PISO 0, NÃO NOS DEMAIS PISOS. O `min_jogos` segue a célula inclusive nas
+       linhas dessas três — é a seção "Consequences" da própria ADR 0008: o piso é propriedade do
+       jogo, não da premissa. Com o histórico junto, jogos que não passavam no piso 5 passam a
+       passar, então `n_p5` e `diferenca_p5` mudam mesmo com a premissa imóvel. O mesmo vale para
+       `jogos_medios` e `pct_amostra_curta`, que não têm piso e leem o `min_jogos` da célula.
+       Por isso o veredito das três olha SÓ o piso 0: exigir igualdade nos demais seria cobrar da
+       ADR 0008 uma coisa que ela explicitamente não promete.
+
+    3. `historico_over`, `historico_under`, `historico_btts`, `historico_seco` e as duas de xG
+       leem histórico competição-scoped PRÓPRIO, fora do team_form_pit (#52), e por isso TÊM de
+       se mexer. Se elas não se mexerem, o eixo não alcançou todas as fontes e a célula está
+       misturada.
+
+    4. `h2h_favoravel` e `adversario_limitado` (que o reusa) são as imunes por definição: o
+       `fact_h2h` já cruza campeonatos hoje e a spec o deixa como está. Elas só podem mudar via
+       piso — `n_p5` para cima, `diferenca_p0` parada.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A COMPARAÇÃO É FULL OUTER de propósito: premissa que existe numa célula e não na outra sai
+    como `SEM_CONTRAPARTE` em vez de desaparecer do resultado. Uma premissa some da tabela quando
+    ela não acende nenhuma vez na célula (o `HAVING COUNTIF(acesa) > 0` do taskf_teste2), e isso é
+    achado, não linha a esconder.
+
+    As células a comparar são vars, validadas contra os quatro nomes possíveis — um nome digitado
+    errado devolveria zero linha ou uma coluna inteira de `SEM_CONTRAPARTE`, e as duas coisas se
+    parecem demais com um resultado.
+
+    COMO RODAR (do dbt_futebol/), depois de as duas células terem sido medidas pelo taskf_teste2:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_delta_celulas
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_delta_celulas.sql
+
+      # outro par de células:
+      ... --select taskf_delta_celulas --vars '{taskf_celula_a: base, taskf_celula_b: ambos}'
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set cel_a = var('taskf_celula_a', 'base') -%}
+{%- set cel_b = var('taskf_celula_b', 'escopo') -%}
+{%- set celulas_validas = ['base', 'escopo', 'recorte', 'ambos'] -%}
+{%- for c in [cel_a, cel_b] -%}
+    {%- if c not in celulas_validas -%}
+        {{ exceptions.raise_compiler_error(
+            "célula inválida: '" ~ c ~ "'. Valores aceitos: " ~ celulas_validas | join(' | ')) }}
+    {%- endif -%}
+{%- endfor -%}
+{%- if cel_a == cel_b -%}
+    {{ exceptions.raise_compiler_error(
+        "taskf_celula_a e taskf_celula_b são a mesma célula ('" ~ cel_a ~ "') — nada a comparar.") }}
+{%- endif -%}
+
+{%- set pisos = [0, 3, 5, 10] -%}
+{#- As premissas de tabela do catálogo medido (ADR 0008). O veredito delas é o piso 0; ver o
+    cabeçalho. -#}
+{%- set premissas_de_tabela = ['superioridade_tabela', 'supremacia', 'sem_rodizio'] -%}
+{#- Campos que, mudando, contam como "a premissa se mexeu". `n_p0` entra porque mudança no
+    conjunto de linhas em que a premissa acende é efeito, não ruído. -#}
+{%- set campos_piso0 = ['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'diferenca_p0'] -%}
+
+WITH a AS (
+    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }} WHERE celula = '{{ cel_a }}'
+),
+b AS (
+    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }} WHERE celula = '{{ cel_b }}'
+),
+
+juntado AS (
+    SELECT
+        mercado,
+        premissa,
+        benchmark,
+        COALESCE(a.usado_para_peso, b.usado_para_peso)  AS usado_para_peso,
+        a.celula IS NULL                                AS so_na_b,
+        b.celula IS NULL                                AS so_na_a,
+        a.jogos_medios        AS jogos_medios_a,       b.jogos_medios        AS jogos_medios_b,
+        a.pct_amostra_curta   AS pct_curta_a,          b.pct_amostra_curta   AS pct_curta_b,
+        a.fator_encolhimento  AS encolhimento_a,       b.fator_encolhimento  AS encolhimento_b
+        {%- for piso in pisos %},
+        a.n_p{{ piso }}          AS n_p{{ piso }}_a,          b.n_p{{ piso }}          AS n_p{{ piso }}_b,
+        a.diferenca_p{{ piso }}  AS dif_p{{ piso }}_a,        b.diferenca_p{{ piso }}  AS dif_p{{ piso }}_b,
+        a.peso_p{{ piso }}       AS peso_p{{ piso }}_a,       b.peso_p{{ piso }}       AS peso_p{{ piso }}_b,
+        a.a_odd_dava_p{{ piso }} AS a_odd_dava_p{{ piso }}_a, b.a_odd_dava_p{{ piso }} AS a_odd_dava_p{{ piso }}_b,
+        a.aconteceu_p{{ piso }}  AS aconteceu_p{{ piso }}_a,  b.aconteceu_p{{ piso }}  AS aconteceu_p{{ piso }}_b
+        {%- endfor %}
+    FROM a FULL OUTER JOIN b USING (mercado, premissa, benchmark)
+),
+
+classificado AS (
+    SELECT
+        j.*,
+        premissa IN ({{ premissas_de_tabela | map('tojson') | join(', ') }}) AS e_premissa_de_tabela,
+
+        {#- Quantos campos do piso 0 se mexeram. IS DISTINCT FROM p/ NULL contar como igual a
+            NULL, e não como divergência. -#}
+        ({% for campo in campos_piso0 %}
+          IF({{ campo }}_a IS DISTINCT FROM {{ campo }}_b, 1, 0){{ " + " if not loop.last }}
+         {%- endfor %})                                     AS campos_piso0_mudados,
+
+        ({% for piso in pisos %}
+          IF(n_p{{ piso }}_a IS DISTINCT FROM n_p{{ piso }}_b, 1, 0)
+          + IF(dif_p{{ piso }}_a IS DISTINCT FROM dif_p{{ piso }}_b, 1, 0){{ " + " if not loop.last }}
+         {%- endfor %}
+          + IF(jogos_medios_a IS DISTINCT FROM jogos_medios_b, 1, 0)
+          + IF(pct_curta_a IS DISTINCT FROM pct_curta_b, 1, 0))  AS campos_mudados
+    FROM juntado AS j
+)
+
+SELECT
+    mercado,
+    premissa,
+    benchmark,
+    usado_para_peso,
+    CASE
+        WHEN so_na_a OR so_na_b               THEN 'SEM_CONTRAPARTE'
+        WHEN e_premissa_de_tabela
+             AND campos_piso0_mudados = 0     THEN 'TABELA_IMOVEL_NO_PISO0'
+        WHEN e_premissa_de_tabela             THEN 'TABELA_MEXEU_CONTRA_A_ADR_0008'
+        WHEN campos_mudados = 0               THEN 'IDENTICO'
+        ELSE                                       'MUDOU'
+    END                                       AS veredito,
+    campos_mudados,
+    campos_piso0_mudados,
+    jogos_medios_a, jogos_medios_b,
+    ROUND(jogos_medios_b - jogos_medios_a, 1)    AS delta_jogos_medios,
+    pct_curta_a, pct_curta_b,
+    ROUND(pct_curta_b - pct_curta_a, 1)          AS delta_pct_curta
+    {%- for piso in pisos %},
+    n_p{{ piso }}_a, n_p{{ piso }}_b, n_p{{ piso }}_b - n_p{{ piso }}_a AS delta_n_p{{ piso }},
+    dif_p{{ piso }}_a, dif_p{{ piso }}_b,
+    ROUND(dif_p{{ piso }}_b - dif_p{{ piso }}_a, 1)                     AS delta_dif_p{{ piso }}
+    {%- endfor %},
+    peso_p0_a, peso_p0_b, ROUND(peso_p0_b - peso_p0_a, 2) AS delta_peso_p0,
+    peso_p5_a, peso_p5_b, ROUND(peso_p5_b - peso_p5_a, 2) AS delta_peso_p5,
+    '{{ cel_a }}' AS celula_a,
+    '{{ cel_b }}' AS celula_b
+FROM classificado
+ORDER BY ABS(COALESCE(dif_p5_b - dif_p5_a, 0)) DESC, mercado, premissa, benchmark

--- a/dbt_futebol/analyses/taskf_delta_celulas.sql
+++ b/dbt_futebol/analyses/taskf_delta_celulas.sql
@@ -78,7 +78,7 @@
 {%- set premissas_de_tabela = ['superioridade_tabela', 'supremacia', 'sem_rodizio'] -%}
 {#- Campos que, mudando, contam como "a premissa se mexeu". `n_p0` entra porque mudança no
     conjunto de linhas em que a premissa acende é efeito, não ruído. -#}
-{%- set campos_piso0 = ['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'diferenca_p0'] -%}
+{%- set campos_piso0 = ['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'dif_p0'] -%}
 
 WITH a AS (
     SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }} WHERE celula = '{{ cel_a }}'

--- a/dbt_futebol/analyses/taskf_delta_celulas.sql
+++ b/dbt_futebol/analyses/taskf_delta_celulas.sql
@@ -30,9 +30,17 @@
        se mexer. Se elas não se mexerem, o eixo não alcançou todas as fontes e a célula está
        misturada.
 
-    4. `h2h_favoravel` e `adversario_limitado` (que o reusa) são as imunes por definição: o
-       `fact_h2h` já cruza campeonatos hoje e a spec o deixa como está. Elas só podem mudar via
-       piso — `n_p5` para cima, `diferenca_p0` parada.
+    4. `h2h_favoravel` (1X2) é a ÚNICA imune por definição: o `fact_h2h` já cruza campeonatos hoje
+       e a spec o deixa como está — "é a única fonte imune ao efeito medido" (#49). Ela só pode
+       mudar via piso: `n_p5` para cima, `diferenca_p0` parada.
+
+       ⚠️ `adversario_limitado` (DC) NÃO é imune, embora reuse o h2h. A premissa é
+       `o_aproveitamento < 45 OR x_h2h_favoravel`, e `o_aproveitamento` sai de
+       `wins_total/draws_total/played_total` do PIT — que seguem o eixo. Medido entre `base` e
+       `escopo`: `n_p0` 160 → 165 e `diferenca_p0` +0,7 → +1,2. Uma premissa que reusa fonte imune
+       só herda a imunidade se **todos** os seus insumos forem imunes; aqui o OR basta para
+       quebrá-la. Esta linha esteve errada no primeiro commit desta análise e foi corrigida com o
+       número que a desmentiu — a expectativa existe para poder ser falsificada, e foi.
 
     ────────────────────────────────────────────────────────────────────────────────
     A COMPARAÇÃO É FULL OUTER de propósito: premissa que existe numa célula e não na outra sai
@@ -60,7 +68,9 @@
 
 {%- set cel_a = var('taskf_celula_a', 'base') -%}
 {%- set cel_b = var('taskf_celula_b', 'escopo') -%}
-{%- set celulas_validas = ['base', 'escopo', 'recorte', 'ambos'] -%}
+{#- Os quatro nomes vêm da macro que os define, nunca de uma segunda lista digitada aqui: uma
+    cópia que precisa ficar igual para sempre não fica, e a divergência seria muda. -#}
+{%- set celulas_validas = taskf_nomes_de_celula().values() | list -%}
 {%- for c in [cel_a, cel_b] -%}
     {%- if c not in celulas_validas -%}
         {{ exceptions.raise_compiler_error(

--- a/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
+++ b/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
@@ -53,7 +53,11 @@
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */
 
-{%- set carimbos = 'smartbetting-dados.futebol_taskF.taskf_pit_por_celula' -%}
+{#- O carimbo é lido por `source()`, como todo o resto do dataset de medição. Só a ESCRITA dele
+    (analyses/taskf_pit_por_celula.sql) é literal, e por um motivo específico da ADR 0007 — o
+    destino não pode seguir o `--target`. CODING_STANDARDS.md: "Relations only via ref() /
+    source() — never hardcoded table names". -#}
+{%- set carimbos = source('futebol_taskF', 'taskf_pit_por_celula') -%}
 {%- set pisos    = [3, 5, 10] -%}
 
 WITH {{ task01_base() }},
@@ -88,8 +92,8 @@ pares AS (
         b.competition,
         b.played_total AS played_base,
         e.played_total AS played_escopo
-    FROM (SELECT * FROM `{{ carimbos }}` WHERE celula = 'base')   AS b
-    JOIN (SELECT * FROM `{{ carimbos }}` WHERE celula = 'escopo') AS e
+    FROM (SELECT * FROM {{ carimbos }} WHERE celula = 'base')   AS b
+    JOIN (SELECT * FROM {{ carimbos }} WHERE celula = 'escopo') AS e
       USING (fixture_id, team_id)
     JOIN fixtures_do_universo USING (fixture_id)
 ),
@@ -134,6 +138,7 @@ por_competicao AS (
     SELECT
         f.competition,
         f.competition_id,
+        f.n_competition_ids,
         f.familia,
         f.temporadas_observadas,
         f.temporadas_atravessando,
@@ -175,7 +180,7 @@ por_competicao AS (
 empilhado AS (
     SELECT
         'competicao' AS nivel, 1 AS nivel_ord, competition AS chave, familia,
-        competition_id, temporadas_observadas, temporadas_atravessando,
+        competition_id, n_competition_ids, temporadas_observadas, temporadas_atravessando,
         primeiro_kickoff, ultimo_kickoff,
         jogos_no_universo, linhas_no_universo, pares, pares_com_ganho, soma_do_ganho, ganho_max
         {%- for piso in pisos %},
@@ -191,7 +196,7 @@ empilhado AS (
         GROUP BY fica ambíguo. #}
     SELECT
         'familia', 2, familia AS chave, familia,
-        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
         CAST(NULL AS DATE),  CAST(NULL AS DATE),
         {{ metricas }}
     FROM por_competicao
@@ -201,7 +206,7 @@ empilhado AS (
 
     SELECT
         'total', 3, 'TODAS', CAST(NULL AS STRING),
-        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
         CAST(NULL AS DATE),  CAST(NULL AS DATE),
         {{ metricas }}
     FROM por_competicao
@@ -212,6 +217,7 @@ SELECT
     chave,
     familia,
     competition_id,
+    n_competition_ids,
     temporadas_observadas,
     temporadas_atravessando,
     primeiro_kickoff,

--- a/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
+++ b/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
@@ -186,9 +186,11 @@ empilhado AS (
     UNION ALL
 
     {#- Os NULL dos rollups são CASTADOS: sem o cast o literal entra como INT64 e a união com uma
-        coluna DATE falha por falta de supertipo comum. -#}
+        coluna DATE falha por falta de supertipo comum. #}
+    {#- `AS chave` não é decoração: sem ele o SELECT tem duas colunas chamadas `familia` e o
+        GROUP BY fica ambíguo. #}
     SELECT
-        'familia', 2, familia, familia,
+        'familia', 2, familia AS chave, familia,
         CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
         CAST(NULL AS DATE),  CAST(NULL AS DATE),
         {{ metricas }}

--- a/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
+++ b/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
@@ -1,0 +1,233 @@
+/*
+    [F-4] O EFEITO DO EIXO DE ESCOPO QUEBRADO POR FAMÍLIA DE COMPETIÇÃO — e, antes disso, a prova
+    de quais famílias sequer têm amostra na janela congelada.
+
+    A #53 pede o efeito separado em `ano_calendario` e `split_year` (spec #49, user story 12). A
+    razão é que na JANELA MEDIDA as duas se comportam de maneira diferente sob o eixo de escopo:
+    numa split-year o rótulo de `season` vira no meio do ano, e como o eixo de escopo não toca o
+    filtro `l.season = a.season`, o histórico doméstico do time continua cortado — só a célula
+    `ambos` o alcança. A classificação é derivada do calendário pela macro
+    taskf_familia_competicao(); o critério e as armadilhas dele estão no cabeçalho de lá.
+
+    ⚠️ ANTES DE LER O EFEITO, LEIA A COMPOSIÇÃO. "Efeito nulo numa família" e "família sem
+    amostra" são coisas diferentes e a segunda é a que se espera aqui: a #51 já mediu que os
+    únicos jogos de Champions da janela são os 8 de 04/08 à noite, que o teto do universo
+    congelado remove. Uma célula vazia da quebra tem de ser lida como SEM AMOSTRA, nunca como
+    "juntar campeonato não muda nada para as europeias" — a janela congelada (16/06 a 04/08) cai
+    inteira na virada de temporada, e é por isso que ela é o pior lugar possível para medir
+    split-year. As linhas de competição fora do universo saem com `jogos_no_universo = 0` de
+    propósito: a ausência é o achado, e escondê-la faria a quebra parecer completa.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    TRÊS COISAS NA MESMA SAÍDA, com a coluna `nivel` separando os grãos:
+
+      nivel = 'competicao'  uma linha por competição EXISTENTE (as 13, não só as do universo),
+                            com a família e a evidência que a classificou ao lado.
+      nivel = 'familia'     o rollup por família.
+      nivel = 'total'       o universo inteiro, que serve de denominador e de conferência.
+
+    Somar linhas de níveis diferentes conta o mesmo jogo duas vezes — filtre `nivel` sempre.
+
+    O MECANISMO é medido no carimbo por célula (`taskf_pit_por_celula`), não em `apostas`: são as
+    partidas anteriores que cada par (jogo, time) ganhou ao soltar a competição. `min_jogos` do
+    jogo é o MENOR `played_total` entre os dois times — a mesma definição do task01_base(), porque
+    as premissas comparam os dois lados. As contagens de piso mostram quantos jogos do universo
+    passam a satisfazer cada corte da varredura com o histórico junto (user story 5 da spec).
+
+    ⚠️ De onde vem cada metade. O UNIVERSO (quais jogos e quais linhas de aposta) sai do
+    task01_base() sobre a camada de premissas MATERIALIZADA AGORA, então esta análise deve rodar
+    com as duas células já carimbadas — a corrente é a última que rodou. O EFEITO sai do carimbo,
+    que tem as duas células gravadas e não depende de qual está materializada. Que o universo seja
+    idêntico nas quatro células é invariante da Costura B (#55); aqui ele é reportado
+    (`jogos_no_universo`) e tem de bater com as duas linhas correspondentes do `taskf_teste2`.
+
+    COMO RODAR (do dbt_futebol/), depois de as DUAS células terem sido carimbadas:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+        --select taskf_familia_e_mecanismo
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set carimbos = 'smartbetting-dados.futebol_taskF.taskf_pit_por_celula' -%}
+{%- set pisos    = [3, 5, 10] -%}
+
+WITH {{ task01_base() }},
+
+{{ taskf_familia_competicao() }},
+
+apostas_congeladas AS (
+    SELECT * FROM apostas
+    WHERE {{ taskf_universo_filtro() }}
+),
+
+universo_por_competicao AS (
+    SELECT
+        competition,
+        COUNT(DISTINCT fixture_id) AS jogos_no_universo,
+        COUNT(*)                   AS linhas_no_universo
+    FROM apostas_congeladas
+    GROUP BY competition
+),
+
+fixtures_do_universo AS (
+    SELECT DISTINCT fixture_id FROM apostas_congeladas
+),
+
+{#- INNER JOIN de propósito: par que existe numa célula e não na outra é assunto da
+    analyses/taskf_monotonicidade_escopo.sql, que o mede nos dois sentidos e emite veredito. Aqui
+    ele seria ruído silencioso dentro de uma média. -#}
+pares AS (
+    SELECT
+        b.fixture_id,
+        b.team_id,
+        b.competition,
+        b.played_total AS played_base,
+        e.played_total AS played_escopo
+    FROM (SELECT * FROM `{{ carimbos }}` WHERE celula = 'base')   AS b
+    JOIN (SELECT * FROM `{{ carimbos }}` WHERE celula = 'escopo') AS e
+      USING (fixture_id, team_id)
+    JOIN fixtures_do_universo USING (fixture_id)
+),
+
+por_fixture AS (
+    SELECT
+        fixture_id,
+        ANY_VALUE(competition) AS competition,
+        MIN(played_base)       AS min_jogos_base,
+        MIN(played_escopo)     AS min_jogos_escopo
+    FROM pares
+    GROUP BY fixture_id
+),
+
+mecanismo_por_competicao AS (
+    SELECT
+        competition,
+        COUNT(*)                                     AS pares,
+        COUNTIF(played_escopo > played_base)         AS pares_com_ganho,
+        SUM(played_escopo - played_base)             AS soma_do_ganho,
+        MAX(played_escopo - played_base)             AS ganho_max
+    FROM pares
+    GROUP BY competition
+),
+
+piso_por_competicao AS (
+    SELECT
+        competition
+        {%- for piso in pisos %},
+        COUNTIF(min_jogos_base   >= {{ piso }})      AS jogos_min{{ piso }}_base,
+        COUNTIF(min_jogos_escopo >= {{ piso }})      AS jogos_min{{ piso }}_escopo,
+        COUNTIF(min_jogos_base <  {{ piso }}
+                AND min_jogos_escopo >= {{ piso }})  AS jogos_cruzam_piso{{ piso }}
+        {%- endfor %}
+    FROM por_fixture
+    GROUP BY competition
+),
+
+{#- Uma linha por competição EXISTENTE, com zeros onde o universo não alcança. A família vem da
+    esquerda porque é ela que tem as 13; o universo e o mecanismo entram por LEFT JOIN. -#}
+por_competicao AS (
+    SELECT
+        f.competition,
+        f.competition_id,
+        f.familia,
+        f.temporadas_observadas,
+        f.temporadas_atravessando,
+        DATE(f.primeiro_kickoff)                 AS primeiro_kickoff,
+        DATE(f.ultimo_kickoff)                   AS ultimo_kickoff,
+        COALESCE(u.jogos_no_universo, 0)         AS jogos_no_universo,
+        COALESCE(u.linhas_no_universo, 0)        AS linhas_no_universo,
+        COALESCE(m.pares, 0)                     AS pares,
+        COALESCE(m.pares_com_ganho, 0)           AS pares_com_ganho,
+        COALESCE(m.soma_do_ganho, 0)             AS soma_do_ganho,
+        m.ganho_max                              AS ganho_max
+        {%- for piso in pisos %},
+        COALESCE(p.jogos_min{{ piso }}_base, 0)     AS jogos_min{{ piso }}_base,
+        COALESCE(p.jogos_min{{ piso }}_escopo, 0)   AS jogos_min{{ piso }}_escopo,
+        COALESCE(p.jogos_cruzam_piso{{ piso }}, 0)  AS jogos_cruzam_piso{{ piso }}
+        {%- endfor %}
+    FROM familia_competicao       AS f
+    LEFT JOIN universo_por_competicao  AS u USING (competition)
+    LEFT JOIN mecanismo_por_competicao AS m USING (competition)
+    LEFT JOIN piso_por_competicao      AS p USING (competition)
+),
+
+{#- Os rollups somam o grão de competição em vez de reagregar o dado bruto: contagem é aditiva, e
+    a média sai de soma/pares no fim — reagregar seria uma segunda definição do mesmo número. -#}
+{%- set metricas %}
+        SUM(jogos_no_universo)   AS jogos_no_universo,
+        SUM(linhas_no_universo)  AS linhas_no_universo,
+        SUM(pares)               AS pares,
+        SUM(pares_com_ganho)     AS pares_com_ganho,
+        SUM(soma_do_ganho)       AS soma_do_ganho,
+        MAX(ganho_max)           AS ganho_max
+        {%- for piso in pisos %},
+        SUM(jogos_min{{ piso }}_base)    AS jogos_min{{ piso }}_base,
+        SUM(jogos_min{{ piso }}_escopo)  AS jogos_min{{ piso }}_escopo,
+        SUM(jogos_cruzam_piso{{ piso }}) AS jogos_cruzam_piso{{ piso }}
+        {%- endfor %}
+{%- endset %}
+
+empilhado AS (
+    SELECT
+        'competicao' AS nivel, 1 AS nivel_ord, competition AS chave, familia,
+        competition_id, temporadas_observadas, temporadas_atravessando,
+        primeiro_kickoff, ultimo_kickoff,
+        jogos_no_universo, linhas_no_universo, pares, pares_com_ganho, soma_do_ganho, ganho_max
+        {%- for piso in pisos %},
+        jogos_min{{ piso }}_base, jogos_min{{ piso }}_escopo, jogos_cruzam_piso{{ piso }}
+        {%- endfor %}
+    FROM por_competicao
+
+    UNION ALL
+
+    {#- Os NULL dos rollups são CASTADOS: sem o cast o literal entra como INT64 e a união com uma
+        coluna DATE falha por falta de supertipo comum. -#}
+    SELECT
+        'familia', 2, familia, familia,
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS DATE),  CAST(NULL AS DATE),
+        {{ metricas }}
+    FROM por_competicao
+    GROUP BY familia
+
+    UNION ALL
+
+    SELECT
+        'total', 3, 'TODAS', CAST(NULL AS STRING),
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS DATE),  CAST(NULL AS DATE),
+        {{ metricas }}
+    FROM por_competicao
+)
+
+SELECT
+    nivel,
+    chave,
+    familia,
+    competition_id,
+    temporadas_observadas,
+    temporadas_atravessando,
+    primeiro_kickoff,
+    ultimo_kickoff,
+    jogos_no_universo,
+    ROUND(SAFE_DIVIDE(jogos_no_universo,
+                      SUM(IF(nivel = 'total', jogos_no_universo, 0)) OVER ()) * 100, 1)
+                                                              AS pct_do_universo,
+    linhas_no_universo,
+    pares,
+    pares_com_ganho,
+    ROUND(SAFE_DIVIDE(pares_com_ganho, pares) * 100, 1)       AS pct_pares_com_ganho,
+    ROUND(SAFE_DIVIDE(soma_do_ganho, pares), 2)               AS ganho_medio_por_par,
+    ganho_max
+    {%- for piso in pisos %},
+    jogos_min{{ piso }}_base,
+    jogos_min{{ piso }}_escopo,
+    jogos_cruzam_piso{{ piso }}
+    {%- endfor %}
+FROM empilhado
+ORDER BY nivel_ord, jogos_no_universo DESC, chave

--- a/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
+++ b/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
@@ -1,0 +1,198 @@
+/*
+    [F-4] A INVARIANTE DA CÉLULA `escopo`: soltar a competição do join só pode ACRESCENTAR
+    partidas anteriores. Para todo par (jogo, time), `escopo` >= `base`.
+
+    O critério de aceite da #53 diz por que ela importa: "se alguma for menor, há fan-out ou perda
+    de linha". Juntar competições é remover uma condição de um LEFT JOIN — o conjunto de partidas
+    anteriores de `escopo` é um SUPERCONJUNTO do de `base` por construção, e nenhum dado pode
+    fazer a contagem cair. Se cair, o que mudou não foi o escopo: foi o grão.
+
+    ⚠️ AS GUARDAS DE GRÃO NÃO COBREM ISTO. O `unique_combination_of_columns` dos seis modelos pega
+    fan-out (linha a mais) e não pega perda de linha (linha a menos) — um par que sumiu deixa a
+    tabela mais única, não menos. Aqui as duas pontas são conferidas, nos dois sentidos
+    (`so_no_base` e `so_no_escopo`), e o eixo de escopo não deveria mexer em nenhuma das duas: ele
+    toca a condição do LEFT JOIN, nunca o produto âncora × time que define as linhas de saída.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    TRÊS MODOS DE FALHA, TRÊS VEREDITOS — e o segundo é o que esta análise tem de mais importante:
+
+      CHAVES_DIVERGENTES            algum par existe numa célula e não na outra.
+      VIOLACAO_DE_MONOTONICIDADE    algum par tem `escopo` < `base`.
+      MESMO_CONTEUDO_NAS_DUAS       NENHUM par ganhou partida. Isto não é "efeito nulo": sob
+                                    `pit_escopo: todas` sabe-se de antemão que o primeiro jogo de
+                                    Copa do Brasil de um time passa a carregar o Brasileirão — a
+                                    falsificação do #50 contou 224 primeiros jogos com passado.
+                                    Zero ganho, portanto, quer dizer que as duas linhas da tabela
+                                    de carimbos contêm o MESMO dado: o carimbo rodou fora de ordem
+                                    e uma célula foi gravada com o rótulo da outra. É a guarda de
+                                    não-vacuidade — sem ela, a ordem errada de execução sairia
+                                    daqui como `OK`, que é o pior resultado possível.
+
+    O LADO `base` AINDA É CONFERIDO CONTRA O BASELINE CONGELADO, e por isso o rótulo `base` não
+    depende só da disciplina de quem rodou: `baseline_int_futebol_team_form_pit` foi gravado ANTES
+    de as vars existirem (analyses/taskf_congela_baseline.sql), então ele é a definição de "sem
+    medição dentro". A comparação usa a mesma restrição de partições da Costura A — a impressão
+    digital do insumo, via taskf_fingerprint_insumo_pit() —, porque fixture novo e resultado que
+    entrou mudam a saída legitimamente e não são regressão.
+
+    ⚠️ ESTA ANÁLISE NÃO CHAMA taskf_celula(). Ela lê os literais 'base' e 'escopo' da tabela de
+    carimbos de propósito: é uma comparação ENTRE células e não pertence a nenhuma delas. Chamar a
+    macro a faria depender das vars da linha de comando, que é exatamente o acoplamento que ela
+    existe para auditar.
+
+    POR QUE ANÁLISE E NÃO TESTE SINGULAR. Um teste dbt roda dentro da execução de UMA célula, e a
+    outra ainda não existe: no build da `base` ele passaria em branco (vacuidade) e no da `escopo`
+    ele afirmaria algo sobre um carimbo gravado antes. As invariantes que se assere sobre a saída
+    das quatro células juntas são a Costura B (#55), por decisão da spec. Prior art de formato:
+    analyses/taskf_reconciliacao_01.sql, que também é comparação e também emite veredito.
+
+    COMO RODAR (do dbt_futebol/), depois de as DUAS células terem sido carimbadas:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+        --select taskf_monotonicidade_escopo
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set carimbos = 'smartbetting-dados.futebol_taskF.taskf_pit_por_celula' -%}
+
+WITH {{ taskf_fingerprint_insumo_pit() }},
+
+-- As partições cujo insumo não se mexeu desde o congelamento. Mesma restrição da Costura A, pelo
+-- mesmo motivo, e emitida pela mesma macro.
+particoes_casadas AS (
+    SELECT b.competition_id, b.season
+    FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }} b
+    JOIN fp_insumo_pit a
+        ON  a.competition_id = b.competition_id
+        AND a.season         = b.season
+    WHERE a.n_fixtures    = b.n_fixtures
+      AND a.fp_fixtures   = b.fp_fixtures
+      AND a.n_grupos      = b.n_grupos
+      AND a.fp_standings IS NOT DISTINCT FROM b.fp_standings
+),
+
+cel_base AS (
+    SELECT fixture_id, team_id, competition, competition_id, season, kickoff_utc, played_total
+    FROM `{{ carimbos }}` WHERE celula = 'base'
+),
+
+cel_escopo AS (
+    SELECT fixture_id, team_id, competition, competition_id, season, kickoff_utc, played_total
+    FROM `{{ carimbos }}` WHERE celula = 'escopo'
+),
+
+-- FULL OUTER para que par que existe de um lado só apareça, em vez de sumir no join.
+emparelhado AS (
+    SELECT
+        fixture_id,
+        team_id,
+        COALESCE(b.competition, e.competition)     AS competition,
+        COALESCE(b.kickoff_utc, e.kickoff_utc)     AS kickoff_utc,
+        b.played_total                             AS played_base,
+        e.played_total                             AS played_escopo
+    FROM cel_base AS b
+    FULL OUTER JOIN cel_escopo AS e USING (fixture_id, team_id)
+),
+
+-- O lado `base` do carimbo contra o baseline gravado antes de as vars existirem.
+base_casada AS (
+    SELECT fixture_id, team_id, played_total
+    FROM cel_base JOIN particoes_casadas USING (competition_id, season)
+),
+baseline_casado AS (
+    SELECT fixture_id, team_id, played_total
+    FROM {{ source('futebol_taskF', 'baseline_int_futebol_team_form_pit') }}
+    JOIN particoes_casadas USING (competition_id, season)
+),
+contra_baseline AS (
+    SELECT
+        (SELECT COUNT(*) FROM base_casada)      AS pares_conferidos_vs_baseline,
+        (SELECT COUNT(*) FROM baseline_casado)  AS pares_no_baseline_casado,
+        (SELECT COUNT(*) FROM (
+            SELECT * FROM base_casada EXCEPT DISTINCT SELECT * FROM baseline_casado
+        ))                                      AS divergencias_vs_baseline
+),
+
+carimbos_das_celulas AS (
+    SELECT
+        COUNTIF(celula = 'base')   > 0 AS tem_base,
+        COUNTIF(celula = 'escopo') > 0 AS tem_escopo,
+        MIN(IF(celula = 'base',   medido_em, NULL)) AS base_medido_em,
+        MIN(IF(celula = 'escopo', medido_em, NULL)) AS escopo_medido_em,
+        MIN(IF(celula = 'base',   git_sha,   NULL)) AS base_git_sha,
+        MIN(IF(celula = 'escopo', git_sha,   NULL)) AS escopo_git_sha
+    FROM `{{ carimbos }}`
+    WHERE celula IN ('base', 'escopo')
+),
+
+resumo AS (
+    SELECT
+        COUNTIF(played_base   IS NOT NULL)                                 AS pares_base,
+        COUNTIF(played_escopo IS NOT NULL)                                 AS pares_escopo,
+        COUNTIF(played_escopo IS NULL)                                     AS so_no_base,
+        COUNTIF(played_base   IS NULL)                                     AS so_no_escopo,
+        COUNTIF(played_escopo >  played_base)                              AS pares_com_ganho,
+        COUNTIF(played_escopo =  played_base)                              AS pares_iguais,
+        COUNTIF(played_escopo <  played_base)                              AS violacoes,
+        ROUND(AVG(IF(played_escopo > played_base,
+                     played_escopo - played_base, NULL)), 2)               AS ganho_medio_quando_ganha,
+        MAX(played_escopo - played_base)                                   AS ganho_max,
+        ROUND(AVG(played_base),   2)                                       AS played_medio_base,
+        ROUND(AVG(played_escopo), 2)                                       AS played_medio_escopo,
+        ARRAY_AGG(
+            IF(played_escopo < played_base,
+               TO_JSON_STRING(STRUCT(fixture_id, team_id, competition, kickoff_utc,
+                                     played_base, played_escopo)),
+               NULL)
+            IGNORE NULLS LIMIT 5
+        )                                                                  AS exemplos_de_violacao,
+        ARRAY_AGG(
+            IF(played_base IS NULL OR played_escopo IS NULL,
+               TO_JSON_STRING(STRUCT(fixture_id, team_id, competition, kickoff_utc,
+                                     played_base, played_escopo)),
+               NULL)
+            IGNORE NULLS LIMIT 5
+        )                                                                  AS exemplos_de_chave_faltando
+    FROM emparelhado
+)
+
+SELECT
+    CASE
+        WHEN NOT c.tem_base OR NOT c.tem_escopo       THEN 'FALTA_UMA_DAS_CELULAS'
+        WHEN r.so_no_base > 0 OR r.so_no_escopo > 0   THEN 'CHAVES_DIVERGENTES'
+        WHEN r.violacoes > 0                          THEN 'VIOLACAO_DE_MONOTONICIDADE'
+        WHEN r.pares_com_ganho = 0                    THEN 'MESMO_CONTEUDO_NAS_DUAS'
+        WHEN b.divergencias_vs_baseline > 0
+             OR b.pares_conferidos_vs_baseline
+                != b.pares_no_baseline_casado         THEN 'BASE_NAO_BATE_O_BASELINE'
+        ELSE                                               'OK'
+    END                                    AS veredito,
+    r.pares_base,
+    r.pares_escopo,
+    r.so_no_base,
+    r.so_no_escopo,
+    r.violacoes,
+    r.pares_com_ganho,
+    r.pares_iguais,
+    ROUND(SAFE_DIVIDE(r.pares_com_ganho, r.pares_base) * 100, 1) AS pct_pares_com_ganho,
+    r.ganho_medio_quando_ganha,
+    r.ganho_max,
+    r.played_medio_base,
+    r.played_medio_escopo,
+    b.pares_conferidos_vs_baseline,
+    b.pares_no_baseline_casado,
+    b.divergencias_vs_baseline,
+    c.base_medido_em,
+    c.escopo_medido_em,
+    c.base_git_sha,
+    c.escopo_git_sha,
+    r.exemplos_de_violacao,
+    r.exemplos_de_chave_faltando
+FROM resumo AS r
+CROSS JOIN contra_baseline AS b
+CROSS JOIN carimbos_das_celulas AS c

--- a/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
+++ b/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
@@ -58,7 +58,11 @@
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */
 
-{%- set carimbos = 'smartbetting-dados.futebol_taskF.taskf_pit_por_celula' -%}
+{#- O carimbo é lido por `source()`, como todo o resto do dataset de medição — o schema é fixo em
+    futebol_taskF na declaração, então ele não segue o `--target` (que é o motivo de a ESCRITA, em
+    analyses/taskf_pit_por_celula.sql, ser literal). CODING_STANDARDS.md: "Relations only via
+    ref() / source() — never hardcoded table names". -#}
+{%- set carimbos = source('futebol_taskF', 'taskf_pit_por_celula') -%}
 
 WITH {{ taskf_fingerprint_insumo_pit() }},
 
@@ -78,12 +82,12 @@ particoes_casadas AS (
 
 cel_base AS (
     SELECT fixture_id, team_id, competition, competition_id, season, kickoff_utc, played_total
-    FROM `{{ carimbos }}` WHERE celula = 'base'
+    FROM {{ carimbos }} WHERE celula = 'base'
 ),
 
 cel_escopo AS (
     SELECT fixture_id, team_id, competition, competition_id, season, kickoff_utc, played_total
-    FROM `{{ carimbos }}` WHERE celula = 'escopo'
+    FROM {{ carimbos }} WHERE celula = 'escopo'
 ),
 
 -- FULL OUTER para que par que existe de um lado só apareça, em vez de sumir no join.
@@ -126,7 +130,7 @@ carimbos_das_celulas AS (
         MIN(IF(celula = 'escopo', medido_em, NULL)) AS escopo_medido_em,
         MIN(IF(celula = 'base',   git_sha,   NULL)) AS base_git_sha,
         MIN(IF(celula = 'escopo', git_sha,   NULL)) AS escopo_git_sha
-    FROM `{{ carimbos }}`
+    FROM {{ carimbos }}
     WHERE celula IN ('base', 'escopo')
 ),
 

--- a/dbt_futebol/analyses/taskf_pit_por_celula.sql
+++ b/dbt_futebol/analyses/taskf_pit_por_celula.sql
@@ -1,0 +1,105 @@
+/*
+    [F-4] A CONTAGEM DE PARTIDAS ANTERIORES de cada célula, guardada para as células poderem ser
+    comparadas entre si.
+
+    Por que existe. O critério de aceite da #53 é uma invariante ENTRE células — "para todo par
+    (jogo, time), a contagem de partidas anteriores em `escopo` é maior ou igual à de `base`" —, e
+    o `int_futebol_team_form_pit` é uma tabela SÓ: cada célula sobrescreve a anterior no dataset
+    de medição. Sem este carimbo, comparar as duas exigiria rodar as duas de novo, uma de cada
+    lado da comparação, e aí não seriam mais a mesma execução. Aqui cada célula deixa a sua
+    contagem gravada e a comparação (analyses/taskf_monotonicidade_escopo.sql) lê as duas.
+
+    ⚠️ ORDEM DE EXECUÇÃO, POR CÉLULA — build → carimbo → Teste 2, os três com as MESMAS `--vars`:
+
+      1. dbt build   --target taskF --select <os 6 nós>   --vars '{...}'
+      2. dbt compile --target taskF --select taskf_pit_por_celula --vars '{...}'  + bq query
+      3. dbt compile --target taskF --select taskf_teste2         --vars '{...}'  + bq query
+
+    O rótulo da célula é DERIVADO das vars em tempo de compilação (taskf_celula(), que não deixa
+    uma célula ser gravada com o nome de outra), mas o DADO vem do que estiver materializado no
+    dataset naquele instante. As duas coisas só coincidem se o carimbo vier depois do build da
+    MESMA célula. Rodar fora de ordem grava dado de uma célula com o rótulo de outra, e nada na
+    tabela denuncia — as duas têm o mesmo formato.
+
+    Isso não fica só na disciplina: a análise de monotonicidade tem veredito de NÃO-VACUIDADE
+    (`MESMO_CONTEUDO_NAS_DUAS`, quando nenhum par ganhou partida) e confere o lado `base` contra o
+    baseline congelado ANTES de as vars existirem. Ordem errada cai num dos dois.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    POR QUE UM SCRIPT DDL, E NÃO UM MODELO dbt. Mesmo argumento do analyses/taskf_teste2.sql: um
+    modelo segue o target, e o target default é `dev`, que aponta para o dataset de PRODUÇÃO. O
+    destino aqui está escrito no SQL, fixo em `futebol_taskF`, e por isso não tem como escorregar.
+    Ver ADR 0007.
+
+    POR QUE SÓ OS `played_*`, E NÃO A LINHA INTEIRA DO PIT. A pergunta da #53 é sobre CONTAGEM de
+    partidas anteriores; médias de gols e rank são funções do mesmo join e não acrescentam
+    verificação nenhuma — quem quiser a linha inteira de uma célula tem a tabela materializada
+    enquanto ela é a corrente. As chaves (fixture, time, competição, season, kickoff) vêm junto
+    porque a comparação precisa quebrar por competição e por família.
+
+    ACUMULATIVA POR CÉLULA, igual ao taskf_teste2: a tabela é criada uma vez e cada execução
+    substitui SÓ a sua célula (DELETE + INSERT). As quatro convivem.
+
+    ⚠️ O carimbo é do PIT INTEIRO, sem recorte de universo. A invariante de monotonicidade vale
+    para todo par (jogo, time) que o modelo produz, não só para os do universo congelado: fan-out
+    e perda de linha são defeitos do mecanismo, e limitá-los à janela esconderia os que acontecem
+    fora dela. O recorte do universo é aplicado depois, por quem mede efeito
+    (analyses/taskf_familia_e_mecanismo.sql), e não por quem carimba.
+
+    COMO RODAR (do dbt_futebol/), depois do build da célula:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_pit_por_celula \
+        --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', pit_escopo: todas}'
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_pit_por_celula.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set c      = taskf_celula() -%}
+{%- set tabela = 'smartbetting-dados.futebol_taskF.taskf_pit_por_celula' -%}
+
+{#- Uma lista, três usos: o DDL, a lista de colunas do INSERT e a ordem da projeção. Escrita duas
+    vezes, ela derivaria — e um INSERT posicional com colunas trocadas de lugar não dá erro, dá
+    número errado. Mesma técnica do analyses/taskf_teste2.sql. -#}
+{%- set colunas = [
+    'celula STRING', 'pit_escopo STRING', 'pit_recorte STRING',
+    'medido_em TIMESTAMP', 'git_sha STRING',
+    'fixture_id INT64', 'team_id INT64',
+    'competition STRING', 'competition_id INT64', 'season INT64',
+    'kickoff_utc TIMESTAMP',
+    'played_home INT64', 'played_away INT64', 'played_total INT64'
+] -%}
+{%- set nomes_colunas = [] -%}
+{%- for col in colunas -%}
+    {%- set _ = nomes_colunas.append(col.split(' ')[0]) -%}
+{%- endfor -%}
+
+
+CREATE TABLE IF NOT EXISTS `{{ tabela }}` (
+    {{ colunas | join(',\n    ') }}
+);
+
+
+DELETE FROM `{{ tabela }}` WHERE celula = '{{ c.nome }}';
+
+
+INSERT INTO `{{ tabela }}` ({{ nomes_colunas | join(', ') }})
+SELECT
+    '{{ c.nome }}'                               AS celula,
+    '{{ c.escopo }}'                             AS pit_escopo,
+    '{{ c.recorte }}'                            AS pit_recorte,
+    CURRENT_TIMESTAMP()                          AS medido_em,
+    '{{ var("taskf_git_sha", "desconhecido") }}' AS git_sha,
+    fixture_id,
+    team_id,
+    competition,
+    competition_id,
+    season,
+    kickoff_utc,
+    played_home,
+    played_away,
+    played_total
+FROM {{ ref('int_futebol_team_form_pit') }}

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -71,18 +71,28 @@
         --select +int_futebol_premissas_1x2 +int_futebol_premissas_ou +int_futebol_premissas_ah \
                  +int_futebol_premissas_btts +int_futebol_premissas_dc +int_futebol_corroboracao
 
-    FASE 2, uma vez POR CÉLULA: só os nós que respondem às vars — o PIT e os cinco modelos de
-    premissas. Nada de `+`.
+    FASE 2, uma vez POR CÉLULA, TRÊS PASSOS NA ORDEM: build → carimbo do PIT → Teste 2, os três
+    com as MESMAS `--vars`. O build toca só os nós que respondem às vars — o PIT e os cinco
+    modelos de premissas. Nada de `+`.
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
         --select int_futebol_team_form_pit int_futebol_premissas_1x2 int_futebol_premissas_ou \
                  int_futebol_premissas_ah int_futebol_premissas_btts int_futebol_premissas_dc \
         --vars '{pit_escopo: todas}'        # a célula; ausente = base
 
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_pit_por_celula \
+        --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', pit_escopo: todas}'
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_pit_por_celula.sql
+
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_teste2 \
         --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', pit_escopo: todas}'
       bq query --use_legacy_sql=false --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_teste2.sql
+
+    ⚠️ O CARIMBO DO PIT vem DEPOIS do build da mesma célula, sempre. O rótulo dele sai das vars em
+    tempo de compilação e o dado sai do que está materializado: fora de ordem, uma célula é
+    gravada com o nome de outra. Ver o cabeçalho de analyses/taskf_pit_por_celula.sql.
 
     ⚠️ NÃO use `+` na fase 2. O `+` reconstrói o `fact_odds_snapshot` a partir do NDJSON da landing
     a cada célula, e aí as quatro deixam de ler a mesma construção dos fatos. O argumento que
@@ -91,10 +101,17 @@
     de 2 linhas que a reconciliação da `base` encontrou, e aí ela deixa de cancelar e passa a ser
     lida como efeito de escopo. É também um rescan completo do NDJSON por célula, sem ganho.
 
-    ⚠️ Nas células de escopo juntado, duas guardas ficam vermelhas POR DESENHO — elas afirmam
-    coisa da célula `base`. Ver o cabeçalho de tests/assert_taskf_pit_default_igual_baseline.sql:
+    ⚠️ Nas células fora do default, UMA guarda fica vermelha por desenho: a Costura A, que é
+    default-only por definição — o que ela afirma é justamente "o default reproduz produção". Ela
+    é a única exclusão que a medição precisa. Ver o cabeçalho de
+    tests/assert_taskf_pit_default_igual_baseline.sql:
 
-      --exclude assert_taskf_pit_default_igual_baseline assert_pit_first_game_has_no_history
+      --exclude assert_taskf_pit_default_igual_baseline
+
+    ⚠️ Esta receita já mandou excluir também o `assert_pit_first_game_has_no_history`. NÃO EXCLUA
+    MAIS (#52): a partição dele passou a seguir os eixos da célula, ele é verde nas quatro, e
+    excluí-lo faz a célula rodar sem guarda de look-ahead — o defeito (Task 0) que contaminou a
+    medição que a [F] existe para refazer.
 
     (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
 

--- a/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
+++ b/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
@@ -42,3 +42,16 @@ sinalize isso no número.
 O `min_jogos` **continua seguindo a célula**, inclusive nas linhas dessas quatro premissas. O
 piso de amostra é propriedade do jogo, não da premissa — um jogo com PIT juntado suficiente
 é o mesmo jogo, independentemente de qual premissa está sendo avaliada nele.
+
+⚠️ **Consequência disso, e a leitura exata de "idêntico por construção": a igualdade entre células
+é no PISO 0.** Nos pisos maiores as três premissas de tabela do catálogo medido mudam de número,
+porque o piso corta um conjunto diferente de jogos — e isso é o parágrafo acima em ação, não uma
+falha da decisão. Medido entre `base` e `escopo` (#53, `docs/TASKF_RESULTADOS.md`): `n_p0`
+idêntico nas três (98, 301, 188), enquanto no piso 5 `superioridade_tabela` vai de 35 para 47 e
+`supremacia` de 95 para 121. `sem_rodizio` fica em 188 nos quatro pisos das duas células — ela só
+acende em jogo que já tem histórico longo.
+
+A quarta premissa que esta ADR nomeia, `x_superioridade_tabela`, **não é uma das 39 medidas**: é
+coluna interna do `int_futebol_premissas_1x2` que a Dupla Chance reusa dentro do
+`lado_coberto_forte`, o qual também lê `forca_mismatch` e portanto segue o eixo. Quem for conferir
+a ADR na tabela do entregável procura três linhas, não quatro.

--- a/dbt_futebol/macros/taskf_celula.sql
+++ b/dbt_futebol/macros/taskf_celula.sql
@@ -36,17 +36,33 @@
     {%- set escopo  = eixos.escopo -%}
     {%- set recorte = eixos.recorte -%}
 
-    {%- set nomes = {
-        'da_competicao|temporada':  'base',
-        'todas|temporada':          'escopo',
-        'da_competicao|ultimos_10': 'recorte',
-        'todas|ultimos_10':         'ambos'
-    } -%}
-
     {{ return({
-        'nome':    nomes[escopo ~ '|' ~ recorte],
+        'nome':    taskf_nomes_de_celula()[escopo ~ '|' ~ recorte],
         'escopo':  escopo,
         'recorte': recorte
     }) }}
 
+{% endmacro %}
+
+
+{#-
+    O 2x2 em forma de dicionário, exposto à parte para que os NOMES das quatro células existam uma
+    vez só. Quem rotula uma célula chama taskf_celula(); quem precisa da LISTA dos quatro nomes
+    — as análises que comparam duas células e validam qual par foi pedido — lê daqui:
+
+        {%- set validas = taskf_nomes_de_celula().values() | list -%}
+
+    É o mesmo argumento que pôs os valores aceitos dos eixos em taskf_eixos() e a digital do
+    insumo do PIT em taskf_fingerprint_insumo_pit(): uma segunda cópia da lista não fica igual à
+    primeira para sempre, e a divergência aqui seria muda — uma análise recusando `ambos` como
+    nome inválido depois de a #54 o materializar devolveria zero linha, que se parece com "as duas
+    células são idênticas".
+-#}
+{% macro taskf_nomes_de_celula() %}
+    {{ return({
+        'da_competicao|temporada':  'base',
+        'todas|temporada':          'escopo',
+        'da_competicao|ultimos_10': 'recorte',
+        'todas|ultimos_10':         'ambos'
+    }) }}
 {% endmacro %}

--- a/dbt_futebol/macros/taskf_familia_competicao.sql
+++ b/dbt_futebol/macros/taskf_familia_competicao.sql
@@ -1,0 +1,74 @@
+{#
+    FAMÍLIA DA COMPETIÇÃO — `ano_calendario` ou `split_year` —, DERIVADA do calendário e não
+    digitada numa lista.
+
+    Para que serve. A spec #49 (user story 12, e o critério de aceite da #53) pede o efeito da
+    medição quebrado por família, porque as duas se comportam de maneira diferente sob o eixo de
+    escopo NA JANELA MEDIDA: numa competição de ano-calendário o rótulo de `season` é o mesmo o
+    ano inteiro, então juntar competições junta de fato; numa split-year a virada do rótulo cai
+    dentro da janela congelada (16/06 a 04/08), e o histórico doméstico do time fica sob a
+    temporada ANTERIOR — o filtro `l.season = a.season`, que o eixo de escopo não toca, corta o
+    que o escopo juntou. É por isso que só a célula `ambos` alcança esse caso.
+
+    ⚠️ Isto é específico da virada de temporada, não verdade geral: em janeiro um time de
+    Bundesliga tem o campeonato nacional e a Champions sob o MESMO rótulo, e `escopo` junta os
+    dois normalmente.
+
+    POR QUE DERIVADA, E NÃO UMA LISTA DE SLUGS. Uma lista digitada envelhece: a Onda 2 acrescentou
+    cinco ligas em três semanas e nada obrigaria a lista a andar junto — e o erro seria mudo, com
+    a liga nova caindo na família errada e o número saindo com cara de certo. O critério é
+    observável no próprio calendário: uma competição é split-year quando a MESMA `season`
+    atravessa a virada do ano civil.
+
+    ⚠️ A CLASSIFICAÇÃO LÊ TODO O `fact_fixtures`, JAMAIS A JANELA CONGELADA. Dentro dela a
+    Champions só tem as qualificatórias de julho e agosto de 2026 e sairia classificada como
+    ano-calendário — exatamente o contrário do que ela é. O sinal vem das temporadas inteiras,
+    incluídas as backfilladas de 24/25 e os jogos FUTUROS já agendados. E basta UMA temporada
+    atravessar para a competição ser split-year (`LOGICAL_OR`, não maioria): uma temporada
+    truncada por ainda estar em curso não tem como rebaixar a classificação de uma competição
+    cujo histórico já mostrou a virada.
+
+    A evidência sai junto do rótulo — `temporadas_observadas`, `temporadas_atravessando` e as duas
+    pontas do calendário — para que quem lê a tabela publicada possa conferir a classificação em
+    vez de acreditar nela.
+
+    Emite UMA CTE no escopo do chamador, `familia_competicao`, com uma linha por competição. Uma
+    CTE do chamador com esse nome a sombreia em silêncio.
+
+    Uso:
+
+        WITH {{ taskf_familia_competicao() }}
+        SELECT familia, COUNT(*) FROM ... JOIN familia_competicao USING (competition_id) ...
+#}
+
+{% macro taskf_familia_competicao() %}
+
+fam_por_temporada AS (
+    SELECT
+        competition_id,
+        competition,
+        season,
+        COUNT(*)          AS n_fixtures,
+        MIN(kickoff_utc)  AS primeiro_kickoff,
+        MAX(kickoff_utc)  AS ultimo_kickoff,
+        EXTRACT(YEAR FROM MAX(kickoff_utc)) > EXTRACT(YEAR FROM MIN(kickoff_utc))
+                          AS atravessa_a_virada
+    FROM {{ ref('fact_fixtures') }}
+    GROUP BY competition_id, competition, season
+),
+
+familia_competicao AS (
+    SELECT
+        competition_id,
+        competition,
+        IF(LOGICAL_OR(atravessa_a_virada), 'split_year', 'ano_calendario') AS familia,
+        COUNT(*)                    AS temporadas_observadas,
+        COUNTIF(atravessa_a_virada) AS temporadas_atravessando,
+        SUM(n_fixtures)             AS fixtures_observados,
+        MIN(primeiro_kickoff)       AS primeiro_kickoff,
+        MAX(ultimo_kickoff)         AS ultimo_kickoff
+    FROM fam_por_temporada
+    GROUP BY competition_id, competition
+)
+
+{% endmacro %}

--- a/dbt_futebol/macros/taskf_familia_competicao.sql
+++ b/dbt_futebol/macros/taskf_familia_competicao.sql
@@ -32,8 +32,17 @@
     pontas do calendário — para que quem lê a tabela publicada possa conferir a classificação em
     vez de acreditar nela.
 
-    Emite UMA CTE no escopo do chamador, `familia_competicao`, com uma linha por competição. Uma
-    CTE do chamador com esse nome a sombreia em silêncio.
+    ⚠️ O GRÃO É O SLUG (`competition`), NÃO O `competition_id`, e isso é deliberado. Quem consome
+    a classificação junta pelo que tem na mão, e o `apostas` do task01_base() carrega só o slug —
+    é ele, portanto, que precisa ser único aqui. O slug sai de um CASE sobre o league_id no
+    `fact_fixtures`, então nada impede que dois IDs passem a cair no mesmo slug (uma fase
+    classificatória cadastrada à parte, por exemplo); com o grão em (id, slug), esse dia
+    duplicaria as linhas do consumidor em silêncio. Medido hoje: 13 competições, 1 para 1.
+    `n_competition_ids` sai junto para que a hipótese continue conferível em vez de suposta.
+
+    Emite DUAS CTEs no escopo do chamador — `fam_por_temporada` (o insumo) e `familia_competicao`
+    (o resultado, uma linha por competição). Uma CTE do chamador com qualquer um dos dois nomes as
+    sombreia em silêncio.
 
     Uso:
 
@@ -59,16 +68,17 @@ fam_por_temporada AS (
 
 familia_competicao AS (
     SELECT
-        competition_id,
         competition,
+        MIN(competition_id)               AS competition_id,
+        COUNT(DISTINCT competition_id)    AS n_competition_ids,
         IF(LOGICAL_OR(atravessa_a_virada), 'split_year', 'ano_calendario') AS familia,
-        COUNT(*)                    AS temporadas_observadas,
-        COUNTIF(atravessa_a_virada) AS temporadas_atravessando,
+        COUNT(DISTINCT season)      AS temporadas_observadas,
+        COUNT(DISTINCT IF(atravessa_a_virada, season, NULL)) AS temporadas_atravessando,
         SUM(n_fixtures)             AS fixtures_observados,
         MIN(primeiro_kickoff)       AS primeiro_kickoff,
         MAX(ultimo_kickoff)         AS ultimo_kickoff
     FROM fam_por_temporada
-    GROUP BY competition_id, competition
+    GROUP BY competition
 )
 
 {% endmacro %}

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -592,3 +592,24 @@ sources:
               derivada p/ Dupla Chance; consenso p/ BTTS). As de consenso do Handicap e do Gols
               vêm FALSE: não pesam, mas ficam visíveis porque o ROI muito pior delas é informação
               sobre quais jogos a Pinnacle escolhe precificar.
+
+      - name: taskf_pit_por_celula
+        description: >
+          A contagem de partidas anteriores do int_futebol_team_form_pit, uma linha por (célula,
+          fixture, time). Acumulativa como o taskf_teste2: cada execução de
+          analyses/taskf_pit_por_celula.sql substitui SÓ a sua célula. Existe porque o PIT é uma
+          tabela só no dataset de medição — cada célula sobrescreve a anterior —, e a invariante
+          de monotonicidade da #53 ("escopo >= base em todo par") é uma comparação ENTRE células.
+          Guarda o PIT inteiro, sem recorte de universo: fan-out e perda de linha são defeitos do
+          mecanismo e não se limitam à janela medida.
+        columns:
+          - name: celula
+            description: >
+              base | escopo | recorte | ambos. DERIVADA dos eixos por taskf_celula() em tempo de
+              compilação. ⚠️ O rótulo vem das vars e o DADO vem do que está materializado: o
+              carimbo tem de rodar DEPOIS do build da mesma célula. Rodar fora de ordem é pego
+              pelo veredito de não-vacuidade da analyses/taskf_monotonicidade_escopo.sql.
+          - name: played_total
+            description: >
+              Partidas anteriores do time no escopo/recorte da célula, no instante do kickoff.
+              É o insumo do `min_jogos` do jogo, que é o MENOR played_total entre os dois times.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -407,6 +407,17 @@ Consequência aritmética, não interpretação: a coluna `ano_calendario` da qu
 inteira das 39 premissas, campo a campo, porque a partição contém 100% das linhas. A coluna
 `split_year` é **vazia**.
 
+⚠️ **E isso vale para as QUATRO células, não só para esta.** A partição por família é propriedade
+do UNIVERSO, e o universo é o mesmo nas quatro por construção — é a primeira invariante da Costura
+B. Os eixos mudam o histórico que cada jogo carrega, nunca quais jogos são medidos. Então
+`split_year = 0` já está decidido para `recorte` e `ambos` (#54) e para o entregável (#59) no
+universo primário: **não há por que construir máquina de quebra por família por premissa**, ela
+teria uma coluna cheia e uma vazia em qualquer célula. A família só volta a ser uma dimensão com
+duas pontas no **universo estendido** (#56), que alcança o presente e onde as europeias já jogaram.
+
+(A classificação é por slug de competição, e `n_competition_ids = 1` nas 13 — nenhum slug agrega
+dois IDs hoje, então a quebra não tem como duplicar jogo.)
+
 **E a família split-year não entra nem como FONTE de histórico.** Medido: dos times que disputam
 os 169 jogos do universo, **zero** têm qualquer partida numa competição split-year sob o mesmo
 rótulo de `season`. Não é só que não há jogo split-year medido — não há jogo split-year que o
@@ -444,12 +455,34 @@ muda nelas é só o piso de amostra:
 | `linha_subindo`, `linha_descendo` (Gols) | leem preço, não histórico |
 | `desfalque_adversario` (1X2) | lê o boletim de desfalques |
 
+⚠️ **Reusar fonte imune não dá imunidade, e `adversario_limitado` é o caso.** Ela é a única
+premissa das 39 que consome o `fact_h2h` de segunda mão, e a expectativa de partida — escrita no
+cabeçalho da análise antes de rodar — era que ela acompanhasse o `h2h_favoravel` na lista acima.
+**Não acompanha:** `n_p0` vai de 160 para 165 e `diferenca_p0` de +0,7 para +1,2. A definição é
+`o_aproveitamento < 45 OR x_h2h_favoravel`, e `o_aproveitamento` sai de
+`wins_total/draws_total/played_total` do PIT — o OR basta para o eixo alcançá-la. A regra geral,
+para a [B] e para o resto da [F]: uma premissa só herda imunidade se **todos** os seus insumos
+forem imunes. `lado_coberto_forte` (DC) tem a mesma forma e também se mexe.
+
 **A ADR 0008 está implementada como diz.** As três premissas de tabela têm `n_p0` e `diferenca_p0`
 idênticos entre as células (98/98, 301/301, 188/188). ⚠️ Mas elas **mudam** nos pisos maiores, e
 isso é a própria ADR: o `min_jogos` segue a célula inclusive nas linhas delas, porque o piso é
 propriedade do jogo. `superioridade_tabela` vai de n=35 para n=47 no piso 5; `supremacia`, de 95
 para 121. `sem_rodizio` é a exceção dentro da exceção — 188 nos quatro pisos nas duas células —,
 assinatura de uma premissa que só acende em jogo com histórico longo.
+
+⚠️ **Para quem escrever a Costura B (#55).** A segunda invariante que a spec #49 enuncia — "as
+quatro premissas de tabela com números idênticos nas quatro células" — fica vermelha se for
+implementada ao pé da letra, e por dois motivos já conhecidos e medidos, nenhum deles um defeito:
+
+- são **três** premissas no catálogo medido, não quatro. A quarta que a ADR 0008 nomeia,
+  `x_superioridade_tabela`, é coluna interna do `int_futebol_premissas_1x2` que a Dupla Chance
+  reusa dentro do `lado_coberto_forte` — e este também lê `forca_mismatch`, então segue o eixo;
+- a identidade é **no piso 0**. Nos demais pisos elas mudam porque o `min_jogos` segue a célula,
+  que é a seção *Consequences* da própria ADR 0008.
+
+A ADR 0008 foi atualizada com essa leitura e os números. O enunciado da spec não foi editado — ele
+é o registro do que se sabia antes de medir.
 
 **As outras 32 se mexem**, que é o esperado: as fontes de histórico competição-scoped próprias dos
 cinco modelos (os `last5` de Gols/BTTS/DC, o `margin_stats` do Handicap, o spine de xG/ritmo)

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -255,3 +255,269 @@ da ancestria da medição e por isso não existe no dataset. Nenhum modelo falha
 `success`, e passam a Costura A, as guardas de grão dos cinco modelos de premissas — soltar
 `competition_id` de um join é o caminho natural para fan-out, e é isso que elas pegam — e as duas
 guardas do conjunto de saídas do de-vig.
+
+---
+
+## Ticket #53 — Célula `escopo`: todas as competições, temporada mantida
+
+`analyses/taskf_teste2.sql` + `taskf_pit_por_celula.sql` + `taskf_monotonicidade_escopo.sql` +
+`taskf_familia_e_mecanismo.sql` + `taskf_delta_celulas.sql` · execução 2026-08-12 16:50 a 16:59
+UTC · commit `09328b0` · dataset `futebol_taskF`
+
+A primeira célula que produz número novo. O escopo do histórico solta a competição do jogo e
+passa a contar todas as competições do time; o recorte continua sendo a temporada corrente. As
+duas células — `base` e `escopo` — foram materializadas e medidas nesta mesma execução, sobre a
+mesma construção dos fatos.
+
+### Veredito
+
+O eixo de escopo funciona e o efeito é grande. **30,6% dos pares (jogo, time) ganham histórico**,
+com média de 8,1 partidas a mais quando ganham e máximo de 48. O universo que satisfaz o piso de
+5 sobe de **69 para 92 jogos** sem descartar nada, e a amostra curta média das 39 premissas cai de
+**45,5% para 34,5%**. Zero violações de monotonicidade, zero divergência de chave, grão verde nas
+duas células.
+
+A quebra por família é **degenerada por composição do universo, e isso é o achado**: as 169
+partidas da janela congelada são 100% de competições de ano-calendário. A família split-year não
+tem uma única partida medida — nem, como se mediu abaixo, um único jogo que pudesse servir de
+FONTE de histórico. Ela está **sem amostra**, e não com efeito nulo.
+
+### As duas células, na mesma execução e no mesmo universo
+
+| célula | eixos | jogos | linhas | janela | carimbo do PIT | Teste 2 |
+|---|---|---|---|---|---|---|
+| `base` | da_competicao / temporada | 169 | 8.567 | 16/06 → 04/08 | 16:50:12 | 16:52:24 |
+| `escopo` | todas / temporada | 169 | 8.567 | 16/06 → 04/08 | 16:58:51 | 16:59:04 |
+
+"Mesma execução" aqui é o que a #51 definiu como forma verificável: o
+`fact_odds_snapshot.dbt_loaded_at` é **13:24:15**, anterior aos quatro carimbos. As duas células
+leram a MESMA construção dos fatos — a ancestria não foi reconstruída entre elas, e nenhum build
+de célula usou `+`.
+
+⚠️ A `base` foi **re-medida**, e não reaproveitada da #51. A spec proíbe reaproveitar baseline, e
+havia motivo extra: a #52 alterou os cinco modelos de premissas entre uma medição e outra.
+
+### A re-medição da `base` reproduz a #51, e as três exceções são empates de arredondamento
+
+Das 60 linhas × ~40 campos, **três campos divergiram**, todos de 0,1 pp:
+
+| premissa | campo | #51 | #53 | valor exato |
+|---|---|---|---|---|
+| `adversario_limitado` (DC) | `aconteceu_p5` e `aconteceu_p10` | 68,8 | 68,7 | 55/80 = **68,75%** |
+| `raramente_perde_por_2` (AH consenso) | `aconteceu_p10` | 96,2 | 96,3 | 308/320 = **96,25%** |
+
+Os dois são **empates exatos** de `ROUND(·, 1)` — medidos em aritmética inteira, não inferidos. O
+`AVG` do BigQuery acumula em ponto flutuante e a ordem da acumulação depende do layout físico da
+tabela, que mudou quando os modelos foram reconstruídos; num empate, o último bit decide o lado.
+Duas execuções consecutivas do mesmo script, sem rebuild no meio, dão resultado **idêntico** — a
+variação não é do motor, é da reconstrução.
+
+Isso não é a deriva de odds da tolerância declarada na #51 (aquela continua valendo zero nesta
+janela) nem mudança de comportamento da #52. A #52 foi verificada como no-op de forma direta: o
+SQL **compilado** dos seis modelos no default é byte a byte idêntico ao do commit `fa98ceb`, que
+produziu os números da #51.
+
+**Para quem for medir as células da #54:** diferenças de 0,1 pp em `aconteceu`/`a_odd_dava` cujo
+valor exato caia num empate `x,x5` não são evidência de nada. Elas não alcançam a `diferenca`, que
+é calculada dos valores não arredondados.
+
+### A invariante: soltar a competição só acrescenta
+
+`analyses/taskf_monotonicidade_escopo.sql` · veredito **OK**
+
+| | |
+|---|---|
+| pares (jogo, time) em cada célula | **21.054 = 21.054** |
+| só na `base` / só na `escopo` | **0 / 0** |
+| pares com `escopo` < `base` (violações) | **0** |
+| pares com ganho | **6.434 (30,6%)** |
+| ganho médio quando ganha / máximo | **8,13 / 48** |
+| `played_total` médio | 11,29 → **13,77** |
+| `base` conferida contra o baseline congelado | 20.846 pares, **0 divergências** |
+
+As três conferências são independentes e cada uma fecha um buraco diferente:
+
+- **Chaves nos dois sentidos.** A guarda de grão dos modelos pega fan-out e **não** pega perda de
+  linha — um par que sumiu deixa a tabela mais única, não menos. Aqui as duas pontas são contadas.
+- **Não-vacuidade.** 6.434 pares com ganho é o que separa "o eixo funcionou" de "as duas linhas do
+  carimbo contêm o mesmo dado porque a ordem de execução errou". Zero ganho seria erro de ordem, e
+  não efeito nulo.
+- **Contra o baseline.** O lado `base` do carimbo bate, par a par, com a saída congelada ANTES de
+  as vars existirem, nas 20.846 linhas cujas partições têm insumo idêntico ao do congelamento
+  (mesma restrição da Costura A).
+
+### Onde o histórico aparece, competição a competição
+
+`analyses/taskf_familia_e_mecanismo.sql` — pares dos 169 jogos do universo congelado
+
+| competição | família | jogos | pares | com ganho | ganho médio | ganho máx |
+|---|---|---|---|---|---|---|
+| copa_mundo | ano-calendário | 79 | 158 | **0 (0%)** | 0,00 | 0 |
+| serie_b | ano-calendário | 39 | 78 | 55 (70,5%) | 2,23 | 5 |
+| brasileirao | ano-calendário | 28 | 56 | 56 (100%) | 5,75 | 12 |
+| sudamericana | ano-calendário | 15 | 30 | 24 (80%) | 9,17 | 22 |
+| copa_do_brasil | ano-calendário | 8 | 16 | 16 (100%) | **24,25** | 28 |
+| **total** | | **169** | **338** | **151 (44,7%)** | 3,43 | 28 |
+
+O gradiente é o mecanismo inteiro numa coluna: quanto menor a competição no calendário do time,
+maior o que ela ganha. A Copa do Brasil empresta 24 partidas por par; o Brasileirão, que já é a
+competição principal, ganha ~6 (as copas dele); e a **Copa do Mundo ganha exatamente zero** — o
+deserto dela é real, seleções não jogam outra coisa na base. Ela é 46,7% do universo.
+
+### O piso de amostra: 69 → 92 jogos, sem jogar nada fora
+
+| piso | `base` | `escopo` | jogos que passam a satisfazer |
+|---|---|---|---|
+| 3 | 90 | **113** | +23 |
+| 5 | **69** | **92** | **+23** |
+| 10 | 67 | 76 | +9 |
+
+Os 23 que cruzam o piso 5 são exatamente **as 15 partidas de Sudamericana e as 8 de Copa do
+Brasil** — as duas competições que o piso removia inteiras. É o número que a spec #49 estimava
+("cerca de 24 jogos"). A Copa do Mundo continua com 2 jogos acima do piso 5, os mesmos de antes.
+
+⚠️ **Isto não resolve a amostra curta, e o número diz quanto.** No piso 5 o universo vai de 41%
+para 54% dos 169 jogos. Os 77 que continuam de fora são 79 da Copa do Mundo menos os 2 que já
+passavam — ou seja, o resto do universo é **a Copa do Mundo inteira**.
+
+A célula `base` reproduz aqui, competição a competição, a tabela de piso publicada na [0.1]
+(`docs/TASK01_RESULTADOS.md`): piso 5 = 69 jogos (Brasileirão 28, Série B 39, Copa do Mundo 2) e
+piso 10 = 67 (Brasileirão 28, Série B 39). ⚠️ A spec #49 trata esses dois números como divergência
+entre o ticket e o doc ("o ticket diz 69; o número publicado é 67") — **não é divergência**: são
+duas linhas da mesma tabela publicada, o 69 é do piso 5 e o 67 é do piso 10, e as duas se
+reproduzem exatamente. Quem executar a [B] não precisa reabrir isso.
+
+E o `min_jogos` derivado do carimbo bate com o do próprio pipeline: contado em `apostas` na célula
+`escopo`, dá os mesmos 113 / 92 / 76.
+
+### A quebra por família — e por que ela é degenerada nesta janela
+
+A classificação não é uma lista digitada; sai do calendário (`macros/taskf_familia_competicao.sql`):
+uma competição é split-year quando a MESMA `season` atravessa a virada do ano civil, em qualquer
+das temporadas observadas. Ela lê **todo** o `fact_fixtures` — dentro da janela congelada a
+Champions só tem as qualificatórias de julho/agosto e sairia classificada como ano-calendário,
+exatamente ao contrário.
+
+| família | competições | jogos no universo | linhas |
+|---|---|---|---|
+| ano-calendário | brasileirao, copa_do_brasil, copa_mundo, libertadores, serie_b, sudamericana | **169 (100%)** | 8.567 |
+| split-year | bundesliga, champions_league, la_liga, ligue_1, premier_league, primeira_liga, serie_a_ita | **0** | **0** |
+
+Consequência aritmética, não interpretação: a coluna `ano_calendario` da quebra **é** a tabela
+inteira das 39 premissas, campo a campo, porque a partição contém 100% das linhas. A coluna
+`split_year` é **vazia**.
+
+**E a família split-year não entra nem como FONTE de histórico.** Medido: dos times que disputam
+os 169 jogos do universo, **zero** têm qualquer partida numa competição split-year sob o mesmo
+rótulo de `season`. Não é só que não há jogo split-year medido — não há jogo split-year que o
+merge pudesse emprestar.
+
+### ⚠️ Sem amostra não é efeito nulo (e a janela é o pior lugar possível para medir isto)
+
+A leitura que **não** pode ser tirada daqui é "juntar campeonato não faz nada pelas europeias". A
+janela congelada é 16/06 a 04/08 e cai **inteira na virada de temporada**: nas split-year o rótulo
+de `season` muda no meio do ano, e o eixo de escopo não toca o filtro `l.season = a.season` — o
+histórico doméstico do time continua cortado por temporada mesmo com a competição solta. Só a
+célula `ambos` (#54) alcança esse caso.
+
+Em janeiro isso não vale: um time de Bundesliga tem o campeonato nacional e a Champions sob o
+mesmo rótulo, e `escopo` junta os dois normalmente. **A [B] não deve herdar "escopo sozinho nunca
+ajuda a Europa" como regra** — o que esta medição mostra é que, nesta janela, não há como
+verificar.
+
+Some-se a isso o que a #51 já registrou: os únicos jogos de Champions do período são os 8 de 04/08
+à noite, removidos pelo teto do universo congelado. A pergunta da spec sobre a fase
+classificatória da Champions (user story 24) segue sem amostra no universo primário.
+
+### O que mudou nas 39 premissas
+
+`analyses/taskf_delta_celulas.sql` · 39 linhas no benchmark preferido (mais 21 de consenso em
+anexo)
+
+**Sete premissas não se mexem no piso 0** — a premissa acende exatamente nas mesmas linhas; o que
+muda nelas é só o piso de amostra:
+
+| premissa | por que é imóvel |
+|---|---|
+| `superioridade_tabela` (1X2), `supremacia`, `sem_rodizio` (AH) | premissas de tabela: rank/ppg/n_teams saem do agregado competição-scoped do PIT em qualquer célula (ADR 0008) |
+| `h2h_favoravel` (1X2) | o `fact_h2h` já cruza campeonatos hoje; a spec o deixa como está |
+| `linha_subindo`, `linha_descendo` (Gols) | leem preço, não histórico |
+| `desfalque_adversario` (1X2) | lê o boletim de desfalques |
+
+**A ADR 0008 está implementada como diz.** As três premissas de tabela têm `n_p0` e `diferenca_p0`
+idênticos entre as células (98/98, 301/301, 188/188). ⚠️ Mas elas **mudam** nos pisos maiores, e
+isso é a própria ADR: o `min_jogos` segue a célula inclusive nas linhas delas, porque o piso é
+propriedade do jogo. `superioridade_tabela` vai de n=35 para n=47 no piso 5; `supremacia`, de 95
+para 121. `sem_rodizio` é a exceção dentro da exceção — 188 nos quatro pisos nas duas células —,
+assinatura de uma premissa que só acende em jogo com histórico longo.
+
+**As outras 32 se mexem**, que é o esperado: as fontes de histórico competição-scoped próprias dos
+cinco modelos (os `last5` de Gols/BTTS/DC, o `margin_stats` do Handicap, o spine de xG/ritmo)
+seguem o mesmo eixo desde a #52. Se elas **não** tivessem mexido, a célula estaria misturada.
+
+As quatro que a spec aponta como "muito sinal, pouca amostra" — as de maior peso aparente hoje:
+
+| premissa | amostra curta | diferença piso 0 | diferença piso 5 (n) | peso p5 |
+|---|---|---|---|---|
+| `clean_sheets_altos` | 77,1% → 62,4% | +17,1 → +14,9 | **−1,7 → +6,3** (24 → 35) | 0,00 → **2,58** |
+| `defesa_forte` | 82,9% → 60,6% | +2,8 → +1,9 | **−3,3 → +10,3** (12 → 28) | 0,00 → **3,69** |
+| `superioridade_xg` | 71,6% → 61,1% | +5,2 → +4,3 | −8,9 → −4,1 (31 → 44) | 0,00 → 0,00 |
+| `tende_golear` | 88,3% → 83,6% | +3,9 → +5,7 | −18,5 → **−22,7** (18 → 21) | 0,00 → 0,00 |
+
+Duas delas — `clean_sheets_altos` e `defesa_forte` — **viram de negativas para positivas no piso
+5** com o histórico junto, com a amostra quase dobrando. As outras duas continuam sem evidência, e
+`tende_golear` piora: com 83,6% de amostra curta mesmo depois do merge, ela é a que menos se
+beneficia.
+
+⚠️ Isto **não** é recomendação de peso. A [0.1] já mostrou que ganho de premissa medido
+in-sample não se replica out-of-sample (+10,0% virou −6,2%), e a spec #49 põe peso fora de escopo
+explicitamente. O que estas linhas dizem é que a evidência que a [B] vai ler muda de forma
+material quando o histórico deixa de ser artificialmente curto.
+
+No agregado das 39: amostra curta média 45,5% → 34,5%, jogos médios 10,5 → 12,9, e o número de
+premissas com peso positivo no piso 5 cai de 15 para 11 — o merge **não** infla o catálogo, ele
+recompõe quem tem evidência.
+
+Os maiores movimentos no piso 5, para quem for ler a tabela: `historico_btts` (−15,5, mas com
+n=15), `ataque_dos_dois` (−15,0), `defesa_forte` (+13,6), `invicto_recente` (+12,0),
+`clean_sheets_altos` (+8,0).
+
+### Reprodução
+
+```bash
+cd dbt_futebol
+
+# a ancestria da #51 continua servindo — NÃO reconstruir entre células (nada de `+`)
+
+# célula base: build (sem exclusão nenhuma) -> carimbo -> Teste 2
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
+  --select int_futebol_team_form_pit int_futebol_premissas_1x2 int_futebol_premissas_ou \
+           int_futebol_premissas_ah int_futebol_premissas_btts int_futebol_premissas_dc
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+  --select taskf_pit_por_celula taskf_teste2 --vars '{taskf_git_sha: 09328b0}'
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_pit_por_celula.sql
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_teste2.sql
+
+# célula escopo: idem, com a var e excluindo SÓ a Costura A
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
+  --select int_futebol_team_form_pit int_futebol_premissas_1x2 int_futebol_premissas_ou \
+           int_futebol_premissas_ah int_futebol_premissas_btts int_futebol_premissas_dc \
+  --exclude assert_taskf_pit_default_igual_baseline --vars '{pit_escopo: todas}'
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+  --select taskf_pit_por_celula taskf_teste2 \
+  --vars '{taskf_git_sha: 09328b0, pit_escopo: todas}'
+# ... os dois bq query de novo
+
+# as três leituras (não dependem de qual célula está materializada, exceto o universo do familia)
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+  --select taskf_monotonicidade_escopo taskf_familia_e_mecanismo taskf_delta_celulas
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
+```
+
+Os dois `dbt build` fecham **43/43** (base) e **42/42** (escopo), com `ERROR=0` e `SKIP=0`. Na
+`base` isso inclui a Costura A; na `escopo`, o guard de look-ahead
+`assert_pit_first_game_has_no_history` e as seis guardas de grão passam — a partição do guard
+segue os eixos da célula desde a #52, e ele **não** deve ser excluído.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -521,3 +521,9 @@ Os dois `dbt build` fecham **43/43** (base) e **42/42** (escopo), com `ERROR=0` 
 `base` isso inclui a Costura A; na `escopo`, o guard de look-ahead
 `assert_pit_first_game_has_no_history` e as seis guardas de grão passam — a partição do guard
 segue os eixos da célula desde a #52, e ele **não** deve ser excluído.
+
+⚠️ **Para a #54:** as células `recorte` e `ambos` entram na mesma tabela e serão comparadas com
+estas duas. Se qualquer coisa reconstruir a ancestria antes disso — um build com `+`, um rebuild
+do `fact_odds_snapshot` —, a `base` e a `escopo` têm de ser re-medidas na mesma execução das duas
+novas. A Costura B (#55) pega a violação pelo `dbt_loaded_at` posterior a um `medido_em`, então
+isto é para economizar uma rodada, não para evitar um erro silencioso.


### PR DESCRIPTION
A célula `escopo` — todas as competições do time no histórico, temporada mantida — materializada e
medida na mesma execução que a `base`, sobre o mesmo universo congelado de 169 jogos.

Resultados completos em `docs/TASKF_RESULTADOS.md`, seção "Ticket #53".

## O que a medição diz

- **30,6% dos pares (jogo, time) ganham histórico** — 6.434 de 21.054, média de 8,1 partidas
  quando ganham, máximo de 48.
- **O piso de 5 vai de 69 para 92 jogos sem descartar nada.** Os 23 que cruzam são exatamente as
  15 partidas de Sudamericana e as 8 de Copa do Brasil, as duas competições que o piso removia
  inteiras.
- Amostra curta média das 39 premissas: **45,5% → 34,5%**.
- **A Copa do Mundo ganha exatamente zero** e é 46,7% do universo — o deserto dela é real.
  `clean_sheets_altos` e `defesa_forte` viram de negativas para positivas no piso 5.

## Os critérios de aceite

| | |
|---|---|
| medida na mesma execução, mesmo universo | `fact_odds_snapshot` construído 13:24:15, anterior aos quatro carimbos; 169 jogos e 8.567 linhas nas duas; nenhum build com `+` |
| `escopo` >= `base` em todo par | 21.054 = 21.054 pares, 0 chaves divergentes nos dois sentidos, **0 violações**, e o lado `base` bate par a par com o baseline congelado (0 de 20.846) |
| grão verde | 43/43 na `base` (Costura A dentro), 42/42 na `escopo` (guard de look-ahead + 6 guardas de grão), `ERROR=0 SKIP=0` |
| efeito quebrado por família | entregue, e **degenerado por composição**: os 169 jogos são 100% ano-calendário |
| leitura das split-year | **SEM AMOSTRA, não efeito nulo** — a janela cai inteira na virada de temporada |

A quebra por família tem um resultado mais forte do que "não há jogo split-year medido": dos times
que disputam os 169 jogos, **nenhum tem uma única partida em competição split-year sob o mesmo
rótulo de season**. A família não entra nem como FONTE de histórico. E como a partição é
propriedade do universo — o mesmo nas quatro células —, isso já está decidido para a #54 e a #59:
não há por que construir máquina de quebra por família por premissa no universo primário.

## Achados de método que valem para os tickets seguintes

- **Empates de arredondamento são o piso de ruído da comparação entre células.** Re-medir a `base`
  reproduziu a #51 em 57 de 60 linhas; os 3 campos que diferiram são 0,1 pp e são empates exatos
  (55/80 = 68,75%, 308/320 = 96,25%), medidos em aritmética inteira. Não é deriva de odds nem
  mudança da #52 — esta foi verificada como no-op direto, compilando os seis modelos em `fa98ceb`
  e comparando byte a byte.
- **Reusar fonte imune não dá imunidade.** `adversario_limitado` reusa o `fact_h2h` mas o combina
  com `o_aproveitamento`, que vem do PIT: `n_p0` 160 → 165. Uma premissa só herda imunidade se
  todos os seus insumos forem imunes.
- **Para a #55:** a segunda invariante da Costura B, lida ao pé da letra da spec, vai vermelha —
  são três premissas de tabela no catálogo medido, não quatro, e a identidade é no piso 0. Medido
  e documentado na ADR 0008 e no doc de resultados.
- **Para a [B]:** o "69 vs 67" que a spec trata como divergência entre o ticket e o doc da [0.1]
  não é divergência — são as linhas de piso 5 e piso 10 da mesma tabela publicada, e a `base`
  reproduz as duas exatamente, competição a competição.

## Correção de rota herdada

`analyses/taskf_teste2.sql` ainda mandava excluir o `assert_pit_first_game_has_no_history` junto da
Costura A. O `6c5ac14` corrigiu essa instrução no cabeçalho do teste e deixou a cópia da receita —
que é justamente a que este ticket seguiria, e que faria a célula rodar sem guarda de look-ahead.

## Revisão

Rodada nos dois eixos (standards e spec) antes do merge. Os achados foram corrigidos no
`5097985` — relação hardcoded na leitura do carimbo (o `source()` era declarado neste mesmo diff e
não era usado), vocabulário das células duplicado, grão do classificador de família, e a
expectativa falsificada acima. As três análises foram re-executadas depois: nenhum número mudou.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)
