### PR TITLE
fix(deriva): o profiles.yml entra no carimbo pelo bloco do projeto

### DIFF
--- a/docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md
+++ b/docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md
@@ -47,6 +47,18 @@ no master e não na imagem. Sintoma e detector desligados pela mesma causa.
    mudam comportamento: nos 30 dias anteriores foram 116 toques em `models` contra 28 nessas
    três — hashear a pasta inteira renderia ~28 alarmes falsos/mês, e um detector que grita por
    `CONTEXT.md` é ignorado em duas semanas.
+2b. **O `profiles.yml` entra pelo BLOCO do projeto, não como arquivo inteiro** (issue #65,
+   acrescentado em 12/08/2026). Ele é o único path compartilhado pelos dois alvos, e a decisão 2
+   original não tratou disso: hasheado inteiro, um target acrescentado para um projeto derruba o
+   carimbo do outro. Aconteceu no dia em que o target `taskF` (medição do futebol) pôs o
+   `dbt_nba` em deriva sem que uma linha de NBA tivesse mudado desde 26/06 — alarme falso da
+   mesma classe que a decisão 2 quis evitar, com o agravante de que o remédio sugerido era um
+   deploy num projeto dormente. Hasheando só o bloco `dbt_nba:`/`dbt_futebol:`, mudar o
+   `dev`/`prod` de um projeto continua sendo deriva DELE, que é a propriedade que importa.
+   ⚠️ A mudança **não é retrocompatível**: o valor do hash muda para os dois alvos de uma vez, e
+   o fix precisa estar no master **antes** do rebuild — o detector recalcula com o script do
+   master, então uma imagem carimbada com o script novo antes do merge sai vermelha.
+
 3. **O par `<path> <blob>` entra no hash, não só o blob.** No dbt o nome do arquivo É o nome
    do modelo: renomear sem mudar uma linha muda a tabela materializada.
 4. **`LC_ALL=C` na ordenação.** O build roda em macOS e o detector em ubuntu-latest;

--- a/scripts/procedencia.sh
+++ b/scripts/procedencia.sh
@@ -23,6 +23,16 @@
 # a imagem sem mudar o comportamento. Nos 30 dias anteriores a 2026-08-07 houve 116 toques
 # em `models` mas também 28 nessas três — hashear a pasta inteira produziria ~28 alarmes
 # falsos por mês, e um detector que grita por CONTEXT.md é ignorado em duas semanas.
+#
+# POR QUE O `profiles.yml` ENTRA PELO BLOCO DO PROJETO, e não como arquivo inteiro (issue #65):
+# ele é o único path COMPARTILHADO pelos dois alvos. Hasheado inteiro, um target acrescentado
+# para um projeto derruba o carimbo do outro — foi o que aconteceu em 12/08, quando o target
+# `taskF` (medição do futebol, PR #61) pôs o dbt_nba em deriva sem que uma linha de NBA tivesse
+# mudado desde 26/06. É a mesma classe de alarme falso do parágrafo acima, com o agravante de
+# que o remédio sugerido seria um deploy num projeto dormente para calar um alarme que não
+# descreve risco nenhum. Hasheando só o bloco `dbt_nba:`/`dbt_futebol:`, mudar o `dev`/`prod`
+# de um projeto continua sendo deriva DELE — que é a propriedade que a decisão 2 da ADR 0001
+# quis garantir — e o target do vizinho deixa de contar.
 
 set -euo pipefail
 
@@ -98,6 +108,39 @@ for p in "${PATHS[@]}"; do
     fi
 done
 
+# O `profiles.yml` sai da varredura por arquivo e entra pelo bloco do projeto (ver cabeçalho).
+# Ele continua declarado em PATHS para que `--paths` o liste e a checagem de existência acima
+# o cubra — o que muda é só COMO ele contribui para o hash.
+PATHS_VARRIDAS=()
+for p in "${PATHS[@]}"; do
+    [ "$p" = "profiles.yml" ] || PATHS_VARRIDAS+=("$p")
+done
+
+# Extração puramente textual: do `<projeto>:` na coluna 0 até a próxima chave (ou comentário) na
+# coluna 0. Sem PyYAML de propósito — o detector roda num ubuntu-latest pelado, e uma dependência
+# a mais é uma forma nova de o detector morrer sem falar do que devia falar.
+# Fail-closed: bloco ausente (chave renomeada) aborta. Hash de bloco vazio seria um detector
+# calado, que é o defeito que a ADR 0001 existe para corrigir.
+BLOCO_HASH=$(python3 -c '
+import sys
+
+projeto = sys.argv[1]
+dentro, bloco = False, []
+with open("profiles.yml", encoding="utf-8") as fh:
+    for linha in fh:
+        if linha.startswith(projeto + ":"):
+            dentro = True
+        elif dentro and linha[:1] not in (" ", "\t", "\n", "\r"):
+            break
+        if dentro:
+            bloco.append(linha)
+
+if not bloco:
+    sys.exit("ERROR: bloco `%s:` nao encontrado em profiles.yml" % projeto)
+
+sys.stdout.write("".join(bloco))
+' "$PROJECT_NAME" | git hash-object --stdin)
+
 # `-c` (rastreados) + `-o --exclude-standard` (não rastreados que o .gitignore não cobre):
 # juntos, é exatamente o conjunto que o `docker build` copiaria. Um arquivo de modelo novo
 # ainda não adicionado ao git entra na imagem e precisa entrar no hash.
@@ -106,10 +149,13 @@ done
 # o nome do modelo vem do nome do arquivo. Renomear `int_x.sql` para `int_y.sql` sem mudar
 # uma linha muda a tabela materializada, e uma lista de hashes soltos não veria isso.
 {
-    git ls-files -co --exclude-standard -- "${PATHS[@]}" | while IFS= read -r f; do
+    git ls-files -co --exclude-standard -- "${PATHS_VARRIDAS[@]}" | while IFS= read -r f; do
         # Arquivo rastreado mas apagado do disco: o `docker build` também não o copiaria.
         # Omiti-lo faz o hash refletir o disco, que é o invariante deste script.
         [ -f "$f" ] || continue
         printf '%s %s\n' "$f" "$(git hash-object "$f")"
     done
+    # O sufixo `:<projeto>` deixa explícito, para quem depurar o hash, que a entrada é o BLOCO
+    # e não o arquivo — os dois nunca dariam o mesmo valor, e a confusão custaria uma hora.
+    printf '%s %s\n' "profiles.yml:${PROJECT_NAME}" "$BLOCO_HASH"
 } | sort | git hash-object --stdin


### PR DESCRIPTION
O `profiles.yml` é o único path **compartilhado** pelos dois alvos do detector de deriva.
Hasheado inteiro, ele acopla os dois: em 12/08 o target `taskF` — medição do futebol, PR #61 —
pôs o `dbt_nba` em deriva sem que uma linha de NBA tivesse mudado desde **26/06**.

**Provado, não inferido:** restaurando o `profiles.yml` anterior ao `taskF`,
`scripts/procedencia.sh dbt_nba` devolve `1e97acbfbeaf64b53401853ca68725e3ed1404c9` — exatamente
o carimbo que o job `dbt-nba` carrega.

Agora o hash lê só o bloco `dbt_nba:` / `dbt_futebol:`. Mudar o `dev`/`prod` de um projeto
continua sendo deriva **dele** — a propriedade que a decisão 2 da ADR 0001 quis garantir — e o
target do vizinho deixa de contar.

## Testes

| | |
|---|---|
| **T1** target novo só no bloco do futebol | futebol MUDA, nba **INALTERADO** — é o bug, e o único teste que falharia antes |
| **T2** `dataset` do prod do nba alterado | nba MUDA, futebol INALTERADO — a propriedade que não pode se perder no caminho |
| **T3** bloco renomeado | sai `!=0` com mensagem, não hash vazio (fail-closed) |
| **T4** um modelo tocado | hash muda — o resto das paths segue contando |

Extração textual, **sem PyYAML de propósito**: o detector roda num `ubuntu-latest` pelado, e uma
dependência a mais é uma forma nova de ele morrer sem falar do que devia falar.

O `profiles.yml` **continua declarado em `PATHS`** — o `--paths` o lista, e tanto a checagem de
existência quanto o guard de árvore suja do `build-and-push.sh` (que consome `--paths`) seguem
cobrindo ele. O que mudou é só **como** ele contribui para o hash.

## ⚠️ Não é retrocompatível, e a ordem importa

O valor do hash muda para os **dois** alvos, então os dois carimbos ficam obsoletos de uma vez.
E o detector recalcula com o script **do master**: rebuildar antes deste PR mergear carimbaria um
hash que ele não reproduz. **Merge primeiro, `./build-and-push.sh` depois.**

Depois do merge, o plano combinado é rebuildar **só o `dbt_futebol`** (que já estava em deriva
real pelas merges da task [F]). O `dbt_nba` segue vermelho até alguém decidir rebuildar um
projeto dormente — o que agora é uma decisão sobre o NBA, e não um efeito colateral do futebol.

ADR 0001 ganhou a decisão **2b** com esse raciocínio e com o aviso de ordem.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
