### PR TITLE
fix(futebol): o comentário da #37 comia a quebra de linha e quebrava o task01_base

### DIFF
--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -229,7 +229,12 @@ odds AS (
         -- Mantido também para que a próxima análise VEJA que esta exclusão existe, em vez
         -- de herdá-la em silêncio.
         COALESCE(n_outcomes_valor < 2, TRUE) AS conjunto_incompleto
-    {#- ⚠️ REDUZIDO À JANELA CORRENTE (#37). O de-vig passou a emitir uma avaliação por
+    {# ⚠️ O `{#` ABRE SEM TRAÇO DE PROPÓSITO. Com `{#-`, o Jinja come a quebra de linha
+        acima e o SQL compilado sai `... AS conjunto_incompletoFROM (`, que não é SQL. Foi o
+        que aconteceu entre a #37 e a #55: as análises que chamam este macro pararam de
+        compilar e ninguém viu, porque nenhuma delas roda no agendado.
+
+        ⚠️ REDUZIDO À JANELA CORRENTE (#37). O de-vig passou a emitir uma avaliação por
         janela coletada; ler sem reduzir faria cada aposta entrar no backtest até 4 vezes,
         uma por preço, todas liquidadas pelo mesmo placar. É EXATAMENTE o erro que a ADR
         0001 e a ADR 0004 existem para impedir: o ROI esperado não se move e o intervalo de


### PR DESCRIPTION
## O que quebrou

O PR #48 (spec #37) inseriu um bloco `{#- ... -#}` entre a última coluna do CTE `odds` e o `FROM`, em `macros/task01_base.sql`. O traço de abertura faz o Jinja comer a quebra de linha **anterior**, e o SQL compilado sai assim:

```sql
COALESCE(n_outcomes_valor < 2, TRUE) AS conjunto_incompletoFROM (SELECT d.* EXCEPT ...
```

Que não é SQL. `Syntax error: Expected ")" but got "("`.

## O alcance

**As 12 análises que chamam `task01_base()`** — as 8 da [0.1]/[A] e as 4 da [F] — pararam de compilar em master a partir daquele merge (12/08, 14:53).

**Produção não é afetada:** `task01_base()` só é chamado por `analyses/`, que não materializa nada e não entra em `dbt run`/`dbt build` do agendado.

## Por que ninguém viu

- nenhuma dessas análises roda no agendado, que executa `dbt test --select tag:guarda`. **Análise quebrada é muda** até alguém rodar;
- a medição da #54 rodou no mesmo dia, às 15:29, **de dentro do worktree dela**, que não continha o merge. O worktree protege de clobber de arquivo e, de brinde, esconde regressão de master até o próximo branch novo. Foi a #55, ao ramificar de master, que esbarrou.

## O fix

O comentário abre com `{#` em vez de `{#-`, preservando a quebra de linha. O texto original está inteiro; junto vai um aviso explicando por que o traço não pode voltar.

## Verificação

Depois do fix, validam no dry-run do BigQuery: `taskf_teste2`, `taskf_saturacao_recorte`, `taskf_universo_congelado` e `task01_teste2`.

Sai à frente da #55 de propósito: enquanto não mergear, **todo worktree novo nasce com as 12 análises quebradas**, e o sintoma (erro de sintaxe apontando para uma CTE) não sugere a causa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)