### PR TITLE
[F-6] Costura B: as invariantes sobre a saída das quatro células viram guarda

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -296,7 +296,10 @@ _Avoid_: janela — that word is taken by the odds collection window, and the tw
 **Célula de medição**:
 One combination of escopo and recorte under which the whole premissa layer is rematerialised
 and remeasured. Two cells are comparable only if computed in the same run over the same frozen
-universe. The four are `base`, `escopo`, `recorte` and `ambos`, named for the axis each releases.
+universe — since #55 that condition is a guard, not a discipline: `dbt test --target taskF
+--select tag:costura_b` fails if the cells read different builds of `fact_odds_snapshot` (each
+cell stamps the one it read in `odds_loaded_at`) or if any of the four is missing. The four are
+`base`, `escopo`, `recorte` and `ambos`, named for the axis each releases.
 _Avoid_: C1–C4 (C1, C2 and C3 already name subtasks of the [C] Coleta task)
 
 **Universo congelado**:

--- a/dbt_futebol/analyses/taskf_remedicao.sql
+++ b/dbt_futebol/analyses/taskf_remedicao.sql
@@ -1,0 +1,164 @@
+/*
+    [F-6] A RE-MEDIÇÃO REPRODUZ A ANTERIOR? — as quatro células de hoje contra as quatro da
+    execução passada, campo a campo.
+
+    Por que existe. Mudar o schema da tabela acumulativa obriga a dropá-la e re-medir as quatro
+    células (ver o cabeçalho de analyses/taskf_teste2.sql, FASE 0). Isso já aconteceu duas vezes —
+    na #54 e na #55 — e vai acontecer de novo. Toda vez, a mesma pergunta: a re-medição devolveu
+    os mesmos números, ou alguma coisa andou junto?
+
+    A #54 respondeu essa pergunta com uma cópia tratada como RASCUNHO — copiou as células da #53
+    para uma tabela temporária, comparou, apagou a cópia. O resultado (119 de 120 linhas exatas)
+    ficou verdadeiro e não re-derivável: quem quiser conferir hoje não tem contra o quê. O próprio
+    doc de resultados registra a lição, e esta análise é ela cumprida: a cópia vira tabela
+    declarada em `sources.yml` e a comparação vira arquivo.
+
+    ⚠️ O QUE ESTA ANÁLISE **NÃO** É. Ela não confere que a medição está certa — para isso existem
+    a reconciliação contra a [0.1] (analyses/taskf_reconciliacao_01.sql) e as três guardas da
+    Costura B. Ela confere que a medição é ESTÁVEL: que reconstruir os seis modelos e rodar de
+    novo, sobre os mesmos fatos, devolve o mesmo número. Duas execuções idênticas e ambas erradas
+    passariam aqui.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O QUE É COMPARADO, E O QUE NÃO É
+
+    Todos os campos de MEDIÇÃO, nos quatro pisos, mais os do universo. Ficam de fora, e só eles:
+
+      celula, mercado, premissa, benchmark   são a CHAVE da comparação.
+      pit_escopo, pit_recorte                são função da célula.
+      medido_em, git_sha                     mudam por definição entre duas execuções.
+      odds_loaded_at                         não existe do lado antigo quando a re-medição foi
+                                             causada justamente pela criação dessa coluna. Ele é
+                                             cobrado pela primeira invariante da Costura B, que é
+                                             onde a pergunta dele mora.
+
+    A comparação passa por TO_JSON_STRING campo a campo: DATE, BOOL, INT64 e FLOAT64 convivem no
+    mesmo formato longo, e NULL vira o texto `null` em vez de sumir da comparação — que é o modo
+    de falha de quem compara com `=`.
+
+    ⚠️ EMPATE DE ARREDONDAMENTO É A DIVERGÊNCIA ESPERADA, e não sinal de defeito. O `AVG` do
+    BigQuery acumula em ponto flutuante e a ordem depende do layout físico da tabela, que muda
+    quando os modelos são reconstruídos. Um valor exatamente em cima do meio da grade de
+    `ROUND(·, 1)` — como uma fração de 51/400 = 12,75% — cai para 12,7 numa execução e 12,8 na
+    seguinte. A #53 mediu três casos assim e a #54 mediu um. Quem ler um número divergente aqui
+    deve primeiro conferir se ele é múltiplo da grade do `n` daquela linha; só depois procurar bug.
+
+    COMO RODAR (do dbt_futebol/), depois das quatro células:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_remedicao \
+        --vars '{taskf_remedicao_anterior: taskf_teste2_54}'
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_remedicao.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set campos = [
+    'janela_ini', 'janela_fim', 'jogos_no_universo', 'linhas_no_universo',
+    'usado_para_peso', 'fator_encolhimento',
+    'jogos_medios_disp', 'jogos_medios_usado', 'pct_amostra_curta', 'peso_p0_k0'
+] -%}
+{%- for piso in taskf_pisos() -%}
+    {%- set _ = campos.extend([
+        'n_p' ~ piso, 'a_odd_dava_p' ~ piso, 'aconteceu_p' ~ piso,
+        'diferenca_p' ~ piso, 'peso_p' ~ piso
+    ]) -%}
+{%- endfor -%}
+
+{#- Qual execução anterior. É var e não nome fixo porque a próxima mudança de schema vai comparar
+    contra uma cópia nova — o padrão é `taskf_teste2_<ticket>`, declarada em sources.yml. -#}
+{%- set anterior = var('taskf_remedicao_anterior', 'taskf_teste2_54') -%}
+
+WITH agora AS (
+    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+),
+
+antes AS (
+    SELECT * FROM {{ source('futebol_taskF', anterior) }}
+),
+
+{#- FULL OUTER: linha que existe só de um lado é achado, não ausência de achado. -#}
+juntado AS (
+    SELECT
+        COALESCE(a.celula, b.celula)       AS celula,
+        COALESCE(a.mercado, b.mercado)     AS mercado,
+        COALESCE(a.premissa, b.premissa)   AS premissa,
+        COALESCE(a.benchmark, b.benchmark) AS benchmark,
+        a.celula IS NULL AS so_no_anterior,
+        b.celula IS NULL AS so_no_atual,
+        a, b
+    FROM agora AS a
+    FULL OUTER JOIN antes AS b
+      ON  b.celula    = a.celula
+      AND b.mercado   = a.mercado
+      AND b.premissa  = a.premissa
+      AND b.benchmark = a.benchmark
+),
+
+por_campo AS (
+    SELECT
+        j.celula, j.mercado, j.premissa, j.benchmark,
+        c.campo, c.agora, c.antes
+    FROM juntado AS j,
+    UNNEST([
+        {%- for campo in campos %}
+        STRUCT('{{ campo }}'               AS campo,
+               TO_JSON_STRING(j.a.{{ campo }}) AS agora,
+               TO_JSON_STRING(j.b.{{ campo }}) AS antes){{ ',' if not loop.last }}
+        {%- endfor %}
+    ]) AS c
+    WHERE NOT j.so_no_atual AND NOT j.so_no_anterior
+),
+
+divergencias AS (
+    SELECT * FROM por_campo WHERE agora IS DISTINCT FROM antes
+),
+
+resumo AS (
+    SELECT
+        'resumo' AS bloco,
+        j.celula,
+        CAST(NULL AS STRING) AS mercado,
+        CAST(NULL AS STRING) AS premissa,
+        CAST(NULL AS STRING) AS benchmark,
+        CAST(NULL AS STRING) AS campo,
+        CAST(NULL AS STRING) AS agora,
+        CAST(NULL AS STRING) AS antes,
+        COUNT(*)                                        AS linhas,
+        COUNTIF(j.so_no_atual OR j.so_no_anterior)      AS sem_contraparte,
+        (SELECT COUNT(DISTINCT FORMAT('%s|%s|%s', mercado, premissa, benchmark))
+         FROM divergencias AS d WHERE d.celula = j.celula) AS linhas_divergentes,
+        (SELECT COUNT(*) FROM divergencias AS d WHERE d.celula = j.celula) AS campos_divergentes,
+        {{ campos | length }} * COUNTIF(NOT j.so_no_atual AND NOT j.so_no_anterior)
+                                                        AS campos_comparados
+    FROM juntado AS j
+    GROUP BY j.celula
+),
+
+detalhe AS (
+    SELECT
+        IF(j.so_no_atual, 'so_no_atual', 'so_no_anterior') AS bloco,
+        j.celula, j.mercado, j.premissa, j.benchmark,
+        CAST(NULL AS STRING) AS campo,
+        CAST(NULL AS STRING) AS agora,
+        CAST(NULL AS STRING) AS antes,
+        NULL AS linhas, NULL AS sem_contraparte, NULL AS linhas_divergentes,
+        NULL AS campos_divergentes, NULL AS campos_comparados
+    FROM juntado AS j
+    WHERE j.so_no_atual OR j.so_no_anterior
+
+    UNION ALL
+
+    SELECT
+        'campo_divergente' AS bloco,
+        celula, mercado, premissa, benchmark, campo, agora, antes,
+        NULL, NULL, NULL, NULL, NULL
+    FROM divergencias
+)
+
+SELECT * FROM resumo
+UNION ALL
+SELECT * FROM detalhe
+ORDER BY bloco, celula, mercado, premissa, benchmark, campo

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -27,7 +27,7 @@
     referência, com o risco de reconciliar a medição contra um bug meu.
 
     ────────────────────────────────────────────────────────────────────────────────
-    O QUE MUDA EM RELAÇÃO AO ORIGINAL — quatro coisas, e só quatro:
+    O QUE MUDA EM RELAÇÃO AO ORIGINAL — cinco coisas, e só cinco:
 
     1. UNIVERSO CONGELADO. `apostas` é recortada por taskf_universo_filtro(). O original rodou sem
        corte (a janela dele é o instante da execução). Ver macros/taskf_universo.sql: o teto é um
@@ -42,6 +42,9 @@
        publicou.
     4. AS DUAS CONTAGENS DE AMOSTRA (#54), `jogos_medios_disp` e `jogos_medios_usado`. Ver a
        seção abaixo — é a mudança que faz o piso significar a mesma coisa nas quatro células.
+    5. O CARIMBO DA CONSTRUÇÃO DOS FATOS (#55), `odds_loaded_at`. Ver a CTE `fatos`: é ele que
+       tira "as quatro rodaram na mesma execução" da disciplina e põe na linha, onde a Costura B
+       consegue cobrar.
 
     ────────────────────────────────────────────────────────────────────────────────
     AS DUAS CONTAGENS DE AMOSTRA, E QUAL DELAS O PISO CORTA (#54)
@@ -83,24 +86,34 @@
 
     ⚠️ E É POR ISSO QUE MUDAR O SCHEMA EXIGE DROPAR A TABELA. `CREATE TABLE IF NOT EXISTS` não
     acrescenta coluna a uma tabela que já existe: com o schema novo, o INSERT de lista explícita
-    falha na primeira célula. A #54 mudou o schema (as duas contagens de amostra), então a tabela
-    foi dropada uma vez antes da primeira célula — o que só é seguro porque as quatro células são
-    re-medidas na mesma execução, que é o que a spec exige de qualquer jeito. Se um ticket futuro
-    mudar o schema de novo, é o mesmo passo, e ele NÃO é rotina: dropar sem re-medir as quatro
-    deixa a tabela com células de formatos diferentes de execuções diferentes.
+    falha na primeira célula. Aconteceu duas vezes — a #54 (as duas contagens de amostra) e a #55
+    (o `odds_loaded_at`) —, e nas duas a tabela foi dropada antes da primeira célula, o que só é
+    seguro porque as quatro são re-medidas na mesma execução, que é o que a spec exige de qualquer
+    jeito. Se um ticket futuro mudar o schema de novo, é o mesmo passo, e ele NÃO é rotina: dropar
+    sem re-medir as quatro deixa a tabela com células de formatos diferentes de execuções
+    diferentes.
 
-    ⚠️ `medido_em` existe porque a spec exige que as quatro células rodem na MESMA EXECUÇÃO — o
-    baseline não é reaproveitado justamente porque `linha_subindo`/`linha_descendo` leem odds ao
-    vivo e viram sozinhas entre builds. Com o carimbo, "mesma execução" é conferível na tabela; sem
-    ele, é confiança. Quem escreve a Costura B (#55) precisa dele, e a forma verificável é:
-    `fact_odds_snapshot.dbt_loaded_at` ANTERIOR aos quatro `medido_em`. Isso prova o que de fato
-    importa — que as quatro leram a MESMA construção dos fatos —, que é mais forte do que os
+    ⚠️ `medido_em` e `odds_loaded_at` existem porque a spec exige que as quatro células rodem na
+    MESMA EXECUÇÃO — o baseline não é reaproveitado justamente porque `linha_subindo`/
+    `linha_descendo` leem odds ao vivo e viram sozinhas entre builds. Com os dois carimbos, "mesma
+    execução" é conferível na tabela; sem eles, é confiança. A forma verificável que a #51 definiu
+    é `fact_odds_snapshot.dbt_loaded_at` ANTERIOR aos quatro `medido_em` — porque o que de fato
+    importa é que as quatro tenham lido a MESMA construção dos fatos, o que é mais forte do que os
     quatro carimbos serem próximos entre si.
 
-    ────────────────────────────────────────────────────────────────────────────────
-    COMO RODAR (do dbt_futebol/) — DUAS FASES, e a separação não é economia, é correção.
+    A #55 levou isso um passo adiante: o `dbt_loaded_at` é gravado NA LINHA de cada célula, em vez
+    de conferido ao vivo depois. Lido ao vivo ele decai — um rebuild posterior no dataset de
+    medição deixaria a conferência vermelha sem que as quatro tivessem deixado de ser comparáveis
+    —, e a guarda passaria a depender do target com que roda. Carimbado, ele responde a pergunta
+    certa ("as quatro leram a mesma construção?") para sempre. Ver a CTE `fatos`.
 
-    FASE 0, só quando o schema de uma das duas tabelas acumulativas muda (foi o caso na #54):
+    ────────────────────────────────────────────────────────────────────────────────
+    COMO RODAR (do dbt_futebol/) — EM FASES, e a separação não é economia, é correção.
+
+    FASE 0, só quando o schema de uma das duas tabelas acumulativas muda (foi o caso na #54 e na
+    #55). Dropar só a que mudou de formato basta — a outra é reescrita célula a célula pelo
+    DELETE + INSERT da fase 2, e a fase 2 roda inteira nas quatro de qualquer forma, então as duas
+    terminam carregando a mesma execução:
 
       bq rm -f -t smartbetting-dados:futebol_taskF.taskf_teste2
       bq rm -f -t smartbetting-dados:futebol_taskF.taskf_pit_por_celula
@@ -131,6 +144,14 @@
         --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', pit_escopo: todas}'
       bq query --use_legacy_sql=false --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_teste2.sql
+
+    FASE 3, uma vez DEPOIS DAS QUATRO: a Costura B (#55), que é o portão. Enquanto ela não
+    estiver verde, as quatro células são quatro medições, e não um 2×2 comparável:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt test --target taskF --select tag:costura_b
+
+    As três guardas leem SÓ a tabela acumulativa (por `source()`), não penduram em modelo nenhum
+    e por isso não entram nas fases 1 e 2 de carona.
 
     ⚠️ O CARIMBO DO PIT vem DEPOIS do build da mesma célula, sempre. O rótulo dele sai das vars em
     tempo de compilação e o dado sai do que está materializado: fora de ordem, uma célula é
@@ -175,7 +196,7 @@
     número errado. -#}
 {%- set colunas = [
     'celula STRING', 'pit_escopo STRING', 'pit_recorte STRING',
-    'medido_em TIMESTAMP', 'git_sha STRING',
+    'medido_em TIMESTAMP', 'git_sha STRING', 'odds_loaded_at TIMESTAMP',
     'janela_ini DATE', 'janela_fim DATE',
     'jogos_no_universo INT64', 'linhas_no_universo INT64',
     'mercado STRING', 'premissa STRING', 'benchmark STRING', 'usado_para_peso BOOL',
@@ -290,6 +311,27 @@ janela AS (
     FROM apostas_congeladas
 ),
 
+{#- QUAL CONSTRUÇÃO DOS FATOS ESTA CÉLULA LEU (#55). O `fact_odds_snapshot` é `materialized:
+    table` e carimba `CURRENT_TIMESTAMP()` em `dbt_loaded_at`, então o valor é o mesmo em toda a
+    tabela e identifica o build que a produziu.
+
+    Por que ele entra na LINHA da célula, e não é conferido depois contra a tabela viva: o que a
+    Costura B (#55) precisa afirmar é que as quatro células leram a MESMA construção dos fatos, e
+    isso é propriedade das quatro linhas no instante em que foram medidas. Lido ao vivo, o mesmo
+    número decai — um rebuild posterior no dataset de medição deixaria a conferência vermelha sem
+    que as quatro tivessem deixado de ser comparáveis entre si. Carimbado, ele fica verdadeiro
+    para sempre e, junto com `medido_em`, fecha a forma verificável que a #51 definiu.
+
+    E há um efeito de grafo, que é o motivo de a coluna existir em vez de o teste ler o
+    `fact_odds_snapshot` por `ref()`: com o carimbo, as três guardas da Costura B leem SÓ
+    `source('futebol_taskF', ...)` e não penduram em modelo nenhum — então elas não são
+    arrastadas para dentro dos builds das fases 1 e 2 por seleção indireta, e a Costura A segue
+    sendo a única exclusão que a medição precisa. -#}
+fatos AS (
+    SELECT MAX(dbt_loaded_at) AS odds_loaded_at
+    FROM {{ ref('fact_odds_snapshot') }}
+),
+
 {#- `preferido` calculado UMA vez, não repetido em cada coluna que depende dele. -#}
 rotulado AS (
     SELECT
@@ -313,6 +355,9 @@ SELECT
     '{{ c.recorte }}'                                       AS pit_recorte,
     CURRENT_TIMESTAMP()                                     AS medido_em,
     '{{ var("taskf_git_sha", "desconhecido") }}'            AS git_sha,
+    -- A construção dos fatos que esta célula leu; ver a CTE `fatos`. É o que deixa "as quatro
+    -- rodaram na mesma execução" ser conferível na tabela em vez de acreditado.
+    f.odds_loaded_at,
     j.janela_ini,
     j.janela_fim,
     j.jogos_no_universo,
@@ -351,3 +396,4 @@ SELECT
        NULL)                                                AS peso_p0_k0
 FROM rotulado AS r
 CROSS JOIN janela AS j
+CROSS JOIN fatos AS f

--- a/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
+++ b/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
@@ -55,3 +55,9 @@ A quarta premissa que esta ADR nomeia, `x_superioridade_tabela`, **não é uma d
 coluna interna do `int_futebol_premissas_1x2` que a Dupla Chance reusa dentro do
 `lado_coberto_forte`, o qual também lê `forca_mismatch` e portanto segue o eixo. Quem for conferir
 a ADR na tabela do entregável procura três linhas, não quatro.
+
+Desde a #55 essa conferência não é manual: `tests/assert_taskf_premissas_de_tabela_identicas.sql`
+cobra as três, no piso 0, no grão (mercado, premissa, benchmark) — com as duas leituras acima
+escritas no cabeçalho e com guarda de não-vacuidade, para "idêntico" nunca significar "não havia o
+que comparar". Roda com `dbt test --target taskF --select tag:costura_b`, depois das quatro
+células.

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -229,7 +229,12 @@ odds AS (
         -- Mantido também para que a próxima análise VEJA que esta exclusão existe, em vez
         -- de herdá-la em silêncio.
         COALESCE(n_outcomes_valor < 2, TRUE) AS conjunto_incompleto
-    {#- ⚠️ REDUZIDO À JANELA CORRENTE (#37). O de-vig passou a emitir uma avaliação por
+    {# ⚠️ O `{#` ABRE SEM TRAÇO DE PROPÓSITO. Com `{#-`, o Jinja come a quebra de linha
+        acima e o SQL compilado sai `... AS conjunto_incompletoFROM (`, que não é SQL. Foi o
+        que aconteceu entre a #37 e a #55: as análises que chamam este macro pararam de
+        compilar e ninguém viu, porque nenhuma delas roda no agendado.
+
+        ⚠️ REDUZIDO À JANELA CORRENTE (#37). O de-vig passou a emitir uma avaliação por
         janela coletada; ler sem reduzir faria cada aposta entrar no backtest até 4 vezes,
         uma por preço, todas liquidadas pelo mesmo placar. É EXATAMENTE o erro que a ADR
         0001 e a ADR 0004 existem para impedir: o ROI esperado não se move e o intervalo de

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -582,6 +582,16 @@ sources:
               entre builds. Com o carimbo, "mesma execução" é conferível; sem ele, é confiança.
           - name: git_sha
             description: "Commit de onde a célula foi medida (var taskf_git_sha)"
+          - name: odds_loaded_at
+            description: >
+              O `dbt_loaded_at` do fact_odds_snapshot que ESTA célula leu — qual construção dos
+              fatos alimentou a medição. Carimbado na linha, e não conferido ao vivo depois, por
+              duas razões: lido ao vivo ele decai (um rebuild posterior no dataset de medição
+              deixaria a conferência vermelha sem que as quatro células tivessem deixado de ser
+              comparáveis), e um ref() penduraria a guarda no grafo do fact_odds_snapshot, que a
+              arrastaria para dentro dos builds da medição por seleção indireta. Com ele, a
+              primeira invariante da Costura B cobra as duas pontas: idêntico nas quatro (mesma
+              construção) e anterior ao `medido_em` de cada uma (os fatos vieram antes).
           - name: jogos_no_universo
             description: >
               Jogos distintos do universo congelado (169). Idêntico nas quatro células por

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -558,6 +558,21 @@ sources:
           Quando o baseline foi congelado, de qual commit, e com quantas linhas/partições.
           Uma linha só.
 
+      - name: taskf_teste2_54
+        description: >
+          As quatro células como a #54 as mediu (execução de 12/08 18:29–18:32, commit d40634d),
+          copiadas ANTES de a #55 dropar a acumulativa para acrescentar `odds_loaded_at`. Não tem
+          essa coluna, e é a única diferença de schema.
+
+          Existe porque a #54 aprendeu a lição do jeito caro: ela fez a mesma comparação com uma
+          cópia tratada como rascunho, removida em seguida, e os números daquele parágrafo do doc
+          de resultados não são re-deriváveis de `analyses/` até hoje. Declarada aqui, a
+          comparação da re-medição (analyses/taskf_remedicao.sql) continua rodando amanhã.
+
+          ⚠️ É um registro histórico, como os baselines acima: não se escreve nela. Quando uma
+          mudança de schema futura exigir outra re-medição, o caminho é copiar a acumulativa para
+          uma tabela nova com o número do ticket, não sobrescrever esta.
+
       - name: taskf_teste2
         description: >
           A saída do Teste 2 da medição, uma linha por (célula, mercado, premissa, benchmark).

--- a/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+++ b/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
@@ -49,6 +49,22 @@
 -- `INVESTIGAR`. A guarda é deliberadamente a mais frouxa das duas leituras: ela protege o
 -- caminho da medição, não a explicação do resíduo.
 --
+-- ⚠️ O MODO DE FALHA CONHECIDO DESTA GUARDA É O EMPATE DE ARREDONDAMENTO, e quem a vir vermelha
+-- deve descartá-lo ANTES de procurar bug. O `AVG` do BigQuery acumula em ponto flutuante e a
+-- ordem depende do layout físico da tabela, que muda quando os modelos são reconstruídos; um valor
+-- exatamente no meio da grade de `ROUND(·, 1)` cai para um lado numa medição e para o outro na
+-- seguinte. A própria #55 mediu isso: entre duas medições sobre os MESMOS fatos, 5 campos de 7.200
+-- viraram 0,1 — e um deles era `aconteceu_p10` da `base`, que só não bate aqui porque a linha é de
+-- consenso e o `usado_para_peso` a deixa de fora. Numa linha de benchmark preferido o mesmo empate
+-- deixa esta guarda VERMELHA sem defeito nenhum por trás.
+--
+-- Ela continua EXATA assim mesmo, e a escolha é deliberada: uma folga de 0,1 em todos os campos
+-- engoliria divergência real de 0,1 pp, que é a ordem de grandeza do que esta task mede. O
+-- diagnóstico é aritmético e fechado, não opinião — pegue o `n` da linha, veja se o valor cai em
+-- cima de um múltiplo de meia unidade da grade (51/400 = 12,75; 308/320 = 96,25; 492/48 = 10,25) e,
+-- se cair, é empate. `analyses/taskf_remedicao.sql` faz essa comparação entre duas medições e é
+-- onde o caso se confirma.
+--
 -- ────────────────────────────────────────────────────────────────────────────────
 -- O QUE É COMPARÁVEL. O doc da [0.1] publica três recortes diferentes (ver
 -- macros/taskf_publicado_01.sql), então nem toda linha tem todo campo — NULL ali significa NÃO

--- a/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+++ b/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
@@ -1,0 +1,205 @@
+{{ config(tags=['taskf', 'costura_b']) }}
+-- COSTURA B da task [F] (issue #49, ticket #55), invariante 3 de 3 — A CÉLULA `base` REPRODUZ O
+-- TESTE 2 PUBLICADO DA TASK [0.1].
+--
+-- `base` é a célula que não muda nada: escopo na competição do jogo, recorte na temporada
+-- corrente, que é o que roda hoje. Se ela não reproduz o número publicado, o caminho inteiro da
+-- medição — var → target → dataset → Teste 2 — está errado em algum ponto, e as outras três
+-- células não têm como significar coisa alguma. É a única das três invariantes que compara a
+-- medição contra algo de FORA dela.
+--
+-- ⚠️ ESTA GUARDA NÃO SUBSTITUI A `analyses/taskf_reconciliacao_01.sql`, e as duas não são cópia
+-- uma da outra. A reconciliação EXPLICA a divergência: mede se o mecanismo de deriva de odds
+-- existe na janela (`capturas_apos_o_teto`), se a correção da spec #22 alcança o benchmark
+-- preferido, e classifica cada linha em `deriva_de_odds` / `correcao_22` / `investigar`. Ela é
+-- leitura humana, e produz o texto de `docs/TASKF_RESULTADOS.md`. Esta aqui só responde
+-- vermelho/verde contra a régua declarada, que é o que uma guarda faz — e é por isso que ela é
+-- muito menor.
+--
+-- ────────────────────────────────────────────────────────────────────────────────
+-- A RÉGUA, E POR QUE ELA VALE PARA DUAS PREMISSAS E NÃO PARA AS 39
+--
+--   as 37 restantes    IGUALDADE EXATA em todo campo publicado. Elas leem fixture, estatística
+--                      ou tabela — insumos determinísticos sobre um universo congelado. Não há
+--                      deriva legítima para acomodar, e acomodar assim mesmo seria a régua
+--                      virando desculpa.
+--   linha_subindo e    `taskf_tolerancia_pp` (0,5 pp) nos campos medidos EM PONTOS PERCENTUAIS.
+--   linha_descendo     São as duas únicas que comparam preço com preço: acendem quando a média
+--                      das probabilidades implícitas de todas as casas sobe de t24h para t15m, e
+--                      o fechamento é a última janela disponível no momento do build.
+--
+-- O valor 0,5 pp foi declarado ANTES de medir, calibrado pelo que o repositório já sabia (o
+-- mercado de Gols anda 0,2–0,4 pp entre execuções sem que nada mude — `docs/TASK01_RESULTADOS.md`).
+-- Ele mora em `taskf_tolerancia_pp`, o MESMO var da reconciliação: a régua existe uma vez.
+--
+-- ⚠️ NOS CAMPOS FORA DA ESCALA EM PP (`n_p0`, `n_p5`, `jogos_medios`, os dois pesos) essas duas
+-- premissas NÃO são cobradas, e isso é decisão consciente, não esquecimento. A régua declarada é
+-- em pp; inventar aqui um segundo limite para contagem seria calibrar um número até a medição
+-- passar, que é o vício que esta task inteira existe para não cometer. O que esses campos fazem
+-- quando divergem é aparecer na reconciliação, em `campos_divergentes_fora_da_regua`, com o
+-- número ao lado — e o resíduo conhecido (as 2 linhas de aposta de 405 que `linha_descendo`
+-- perdeu, ≤ 0,2 pp) está documentado e delimitado em `docs/TASKF_RESULTADOS.md`.
+--
+-- ⚠️ E A JUSTIFICATIVA DA TOLERÂNCIA NÃO SE APLICA A UMA JANELA CONGELADA — achado da #51. A
+-- coleta de odds é forward-only e para no apito: para os 169 jogos do universo congelado há ZERO
+-- capturas posteriores ao teto, então o insumo dessas duas é imóvel e a folga de 0,5 pp está
+-- cobrindo um mecanismo que ali não existe. Ela continua declarada porque volta a ter mordida no
+-- universo estendido da spec, que alcança o presente. Quem quiser o veredito honesto sobre a
+-- divergência de hoje lê a reconciliação, que se recusa a chamá-la de deriva e a marca
+-- `INVESTIGAR`. A guarda é deliberadamente a mais frouxa das duas leituras: ela protege o
+-- caminho da medição, não a explicação do resíduo.
+--
+-- ────────────────────────────────────────────────────────────────────────────────
+-- O QUE É COMPARÁVEL. O doc da [0.1] publica três recortes diferentes (ver
+-- macros/taskf_publicado_01.sql), então nem toda linha tem todo campo — NULL ali significa NÃO
+-- PUBLICADO, nunca zero, e campo não publicado não é comparado. Só o benchmark PREFERIDO de cada
+-- mercado entra (`usado_para_peso`), que é o recorte que o doc publica; as linhas de consenso do
+-- Handicap e do Gols não têm contraparte e ficam fora de propósito.
+--
+-- NÃO-VACUIDADE, porque "não achei divergência" é o veredito natural de quem não comparou nada:
+--
+--   sem_contraparte    FULL OUTER JOIN, 39 de cada lado. Uma premissa renomeada, um `base` que
+--                      não foi medido ou um filtro que zerou a leitura caem aqui, e não em
+--                      silêncio verde.
+--   linha_sem_campo    nenhuma linha comparada pode ter ZERO campos comparáveis.
+--
+-- QUEM RODA: a FASE 3 da receita do analyses/taskf_teste2.sql, depois das quatro células —
+-- `dbt test --target taskF --select tag:costura_b`. Não é o agendado (tag `guarda`).
+--
+-- Falsificada de propósito com `--vars '{taskf_tolerancia_pp: 0}'`, que tira a folga e deixa a
+-- divergência de `linha_descendo` vermelha; o comando e o resultado estão em
+-- `docs/TASKF_RESULTADOS.md`, seção do ticket #55.
+
+{% set tol = var('taskf_tolerancia_pp', 0.5) %}
+
+{#- As duas que leem odds ao vivo. Não é lista de exceção conveniente: é o conjunto exato das que
+    comparam preço com preço, e é a MESMA lista da analyses/taskf_reconciliacao_01.sql. -#}
+{% set premissas_de_odds = ['linha_subindo', 'linha_descendo'] %}
+
+{#- Os campos publicados, com a coluna medida que corresponde a cada um e a escala em que ele
+    está. `em_pp` é o que decide qual régua vale para as duas premissas de odds — e ele é
+    propriedade do CAMPO (o que a unidade dele é), não da premissa.
+
+    O único que muda de nome entre os dois lados é `jogos_medios`: a [0.1] publicou UM número e a
+    #54 desdobrou a coluna em duas. Vale a DISPONÍVEL, e a escolha não muda nada aqui — a célula é
+    a `base`, cujo recorte é `temporada`, e sem teto as duas contagens são o mesmo número por
+    construção. Mesma leitura da analyses/taskf_reconciliacao_01.sql. -#}
+{%- set campos = [
+    {'nome': 'n_p0',              'medido': 'n_p0',              'em_pp': false},
+    {'nome': 'a_odd_dava_p0',     'medido': 'a_odd_dava_p0',     'em_pp': true},
+    {'nome': 'aconteceu_p0',      'medido': 'aconteceu_p0',      'em_pp': true},
+    {'nome': 'diferenca_p0',      'medido': 'diferenca_p0',      'em_pp': true},
+    {'nome': 'jogos_medios',      'medido': 'jogos_medios_disp', 'em_pp': false},
+    {'nome': 'pct_amostra_curta', 'medido': 'pct_amostra_curta', 'em_pp': true},
+    {'nome': 'peso_p0',           'medido': 'peso_p0',           'em_pp': false},
+    {'nome': 'peso_p0_k0',        'medido': 'peso_p0_k0',        'em_pp': false},
+    {'nome': 'n_p5',              'medido': 'n_p5',              'em_pp': false},
+    {'nome': 'diferenca_p5',      'medido': 'diferenca_p5',      'em_pp': true},
+    {'nome': 'diferenca_p10',     'medido': 'diferenca_p10',     'em_pp': true}
+] -%}
+
+WITH {{ taskf_publicado_01() }},
+
+medido AS (
+    SELECT
+        mercado, premissa,
+        {%- for campo in campos %}
+        {{ campo.medido }}{{ ' AS ' ~ campo.nome if campo.medido != campo.nome }}{{ ',' if not loop.last }}
+        {%- endfor %}
+    FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    WHERE celula = 'base'
+      AND usado_para_peso
+),
+
+-- FULL OUTER para que a linha sem contraparte apareça de qualquer um dos dois lados.
+juntado AS (
+    SELECT
+        COALESCE(m.mercado,  p.mercado)  AS mercado,
+        COALESCE(m.premissa, p.premissa) AS premissa,
+        m.mercado IS NULL AS so_no_publicado,
+        p.mercado IS NULL AS so_no_medido,
+        {%- for campo in campos %}
+        m.{{ campo.nome }} AS {{ campo.nome }}_medido,
+        p.{{ campo.nome }} AS {{ campo.nome }}_pub{{ ',' if not loop.last }}
+        {%- endfor %}
+    FROM medido AS m
+    FULL OUTER JOIN publicado_01 AS p
+      ON  p.mercado  = m.mercado
+      AND p.premissa = m.premissa
+),
+
+-- Um registro por (linha, campo), para a comparação ser escrita UMA vez em vez de onze. CAST para
+-- FLOAT64 porque `n_p0`/`n_p5` são INT64 e a régua é a mesma conta nos dois casos.
+por_campo AS (
+    SELECT
+        j.mercado,
+        j.premissa,
+        j.premissa IN ({{ premissas_de_odds | map('tojson') | join(', ') }}) AS premissa_de_odds,
+        c.*
+    FROM juntado AS j,
+    UNNEST([
+        {%- for campo in campos %}
+        STRUCT('{{ campo.nome }}'                        AS campo,
+               {{ campo.em_pp | lower }}                 AS em_pp,
+               CAST(j.{{ campo.nome }}_medido AS FLOAT64) AS medido,
+               CAST(j.{{ campo.nome }}_pub    AS FLOAT64) AS publicado){{ ',' if not loop.last }}
+        {%- endfor %}
+    ]) AS c
+    WHERE NOT j.so_no_medido AND NOT j.so_no_publicado
+),
+
+divergencias AS (
+    SELECT
+        'campo_divergente' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            mercado, premissa, campo, premissa_de_odds, em_pp,
+            publicado, medido,
+            ROUND(medido - publicado, 2) AS delta,
+            IF(premissa_de_odds, {{ tol }}, 0.0) AS regua
+        )) AS linha
+    FROM por_campo
+    WHERE publicado IS NOT NULL
+      AND CASE
+              -- As 37 determinísticas: exato, em todo campo publicado.
+              WHEN NOT premissa_de_odds THEN medido IS DISTINCT FROM publicado
+              -- As duas de odds, campo em pp: a régua declarada.
+              WHEN em_pp THEN medido IS NULL OR ABS(medido - publicado) > {{ tol }}
+              -- As duas de odds, campo fora da escala em pp: não cobrado. Ver o cabeçalho.
+              ELSE FALSE
+          END
+),
+
+-- NÃO-VACUIDADE 1: 39 de cada lado, nenhum órfão.
+sem_contraparte AS (
+    SELECT
+        'sem_contraparte' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            mercado, premissa, so_no_medido, so_no_publicado,
+            (SELECT COUNT(*) FROM medido)       AS linhas_medidas,
+            (SELECT COUNT(*) FROM publicado_01) AS linhas_publicadas
+        )) AS linha
+    FROM juntado
+    WHERE so_no_medido OR so_no_publicado
+),
+
+-- NÃO-VACUIDADE 2: toda linha comparada tem pelo menos um campo comparável. No macro publicado
+-- isso é verdade por construção (toda linha publica ao menos a diferença no piso 0), e é
+-- justamente por isso que vale conferir: se deixar de ser, a linha some da comparação sem sumir
+-- da contagem.
+linha_sem_campo AS (
+    SELECT
+        'linha_sem_campo' AS motivo,
+        TO_JSON_STRING(STRUCT(mercado, premissa, campos_comparaveis)) AS linha
+    FROM (
+        SELECT mercado, premissa, COUNTIF(publicado IS NOT NULL) AS campos_comparaveis
+        FROM por_campo
+        GROUP BY mercado, premissa
+    )
+    WHERE campos_comparaveis = 0
+)
+
+SELECT motivo, linha FROM divergencias
+UNION ALL
+SELECT motivo, linha FROM sem_contraparte
+UNION ALL
+SELECT motivo, linha FROM linha_sem_campo

--- a/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
+++ b/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
@@ -1,0 +1,170 @@
+{{ config(tags=['taskf', 'costura_b']) }}
+-- COSTURA B da task [F] (issue #49, ticket #55), invariante 1 de 3 — AS QUATRO CÉLULAS SÃO O
+-- MESMO UNIVERSO, MEDIDO NA MESMA EXECUÇÃO.
+--
+-- A [F] inteira é uma comparação ENTRE células: o efeito de cada eixo é a diferença entre duas
+-- delas. Isso só significa alguma coisa se as duas mediram os mesmos jogos lendo a mesma
+-- construção dos fatos — senão a diferença carrega dentro dela um jogo a mais, uma odd que mudou
+-- de valor entre builds, e nada no número denuncia. Até a #54 isso era disciplina de execução
+-- (a receita do analyses/taskf_teste2.sql); aqui vira cobrança.
+--
+-- O QUE É COBRADO, em quatro blocos, e cada um tem um modo de falha próprio:
+--
+--   celulas_faltando     as quatro células existem, com os nomes que taskf_nomes_de_celula()
+--                        define. É também a guarda de NÃO-VACUIDADE de tudo o que vem abaixo:
+--                        uma comparação "todas iguais" sobre uma tabela com uma célula só passa
+--                        em branco, e é exatamente esse o estado da tabela no meio de uma
+--                        medição interrompida.
+--   universo_divergente  jogos, linhas e as duas pontas da janela idênticos nas quatro.
+--   jogos_fora_do_gabarito  e os jogos são os 169 que o universo congelado declara
+--                        (taskf_universo().jogos_esperados). Sem isto, quatro células medidas
+--                        sobre o mesmo universo ERRADO passariam juntas.
+--   execucao_divergente  as quatro leram a MESMA construção dos fatos, e leram ANTES de medir.
+--
+-- ⚠️ AS QUATRO CÉLULAS NÃO PRECISAM TER O MESMO NÚMERO DE LINHAS DE PREMISSA, e por isso isso não
+-- é cobrado. Uma premissa entra na tabela quando acende pelo menos uma vez (`HAVING
+-- COUNTIF(acesa) > 0` no Teste 2), e quais acendem depende do histórico que a célula enxerga.
+-- Que hoje sejam 60 em todas as quatro é resultado medido, não invariante de construção — cobrar
+-- isso seria congelar um dado como se fosse regra.
+--
+-- POR QUE `odds_loaded_at` É UMA COLUNA DA TABELA, E NÃO UMA LEITURA AO VIVO DO
+-- `fact_odds_snapshot`. Duas razões, e a segunda é a que decide:
+--
+--   1. lida ao vivo, a resposta DECAI. Qualquer rebuild posterior no dataset de medição deixaria
+--      a guarda vermelha sem que as quatro células tivessem deixado de ser comparáveis entre si —
+--      e o que se quer afirmar é sobre elas, não sobre o estado atual do dataset;
+--   2. um `ref()` aqui penduraria esta guarda no grafo do `fact_odds_snapshot`, e ela passaria a
+--      ser arrastada por seleção indireta para dentro dos builds das fases 1 e 2 da medição —
+--      onde ela é vermelha por construção, porque as células ainda não foram (re)medidas. Isso
+--      obrigaria uma segunda `--exclude` na receita, e "a Costura A é a única exclusão que a
+--      medição precisa" é promessa escrita em três lugares (#52). Lendo só `source()`, as três
+--      guardas da Costura B ficam fora do grafo dos modelos e o problema não existe.
+--
+-- A forma verificável de "mesma execução" é a que a #51 definiu e a #54 usou: o `dbt_loaded_at`
+-- do `fact_odds_snapshot` ANTERIOR aos `medido_em`. O que ela prova é que as quatro leram a mesma
+-- construção dos fatos — mais forte do que os quatro carimbos serem próximos entre si, que é o
+-- que uma régua de "rodou tudo na mesma meia hora" checaria.
+--
+-- QUEM RODA. Não é o agendado: as tags são `taskf`/`costura_b`, o pipeline horário executa
+-- `dbt test --select tag:guarda`, e esta guarda fala de um dataset de medição que produção não
+-- lê. Quem roda é a FASE 3 da receita do Teste 2, depois das quatro células:
+--
+--   dbt test --target taskF --select tag:costura_b
+--
+-- Falsificada de propósito trocando o `odds_loaded_at` de uma célula (e desfazendo em seguida);
+-- os comandos e o resultado estão em `docs/TASKF_RESULTADOS.md`, seção do ticket #55.
+
+{% set j = taskf_universo() %}
+{% set nomes = taskf_nomes_de_celula().values() | list %}
+-- Os 169 jogos e os quatro nomes de célula acima saem de macro (macros/taskf_universo.sql e
+-- macros/taskf_celula.sql): esta guarda não tem número nem rótulo digitado.
+
+WITH celulas AS (
+    SELECT
+        celula,
+        ANY_VALUE(jogos_no_universo)  AS jogos_no_universo,
+        ANY_VALUE(linhas_no_universo) AS linhas_no_universo,
+        ANY_VALUE(janela_ini)         AS janela_ini,
+        ANY_VALUE(janela_fim)         AS janela_fim,
+        ANY_VALUE(odds_loaded_at)     AS odds_loaded_at,
+        MIN(medido_em)                AS medido_em,
+        -- Dentro de UMA célula os cinco campos acima são constantes por construção (saem de um
+        -- CROSS JOIN de CTE de uma linha só). COUNT(DISTINCT) confere isso em vez de supor: se um
+        -- INSERT parcial misturar duas execuções sob o mesmo rótulo, o ANY_VALUE acima escolheria
+        -- uma delas em silêncio. TO_JSON_STRING e não FORMAT: FORMAT devolve NULL se QUALQUER
+        -- argumento for NULL, e a linha NULL sai do COUNT(DISTINCT) — uma célula com metade das
+        -- linhas sem carimbo contaria 1 e passaria.
+        COUNT(DISTINCT TO_JSON_STRING(STRUCT(
+            jogos_no_universo, linhas_no_universo,
+            janela_ini, janela_fim, odds_loaded_at))) AS versoes_na_celula
+    FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    GROUP BY celula
+),
+
+esperadas AS (
+    SELECT nome FROM UNNEST({{ nomes | tojson }}) AS nome
+),
+
+-- 1. AS QUATRO EXISTEM. Nos dois sentidos: célula que falta e célula com nome que o 2×2 não
+--    define (que só aparece se alguém escrever na tabela por fora do taskf_celula()).
+presenca AS (
+    SELECT
+        'celulas_faltando' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            e.nome                                              AS celula_esperada,
+            c.celula                                            AS celula_encontrada,
+            (SELECT COUNT(*) FROM celulas)                      AS celulas_na_tabela,
+            {{ nomes | length }}                                AS celulas_esperadas
+        )) AS linha
+    FROM esperadas AS e
+    FULL OUTER JOIN celulas AS c ON c.celula = e.nome
+    WHERE e.nome IS NULL OR c.celula IS NULL
+),
+
+-- 2. O MESMO UNIVERSO. Comparação contra a primeira célula em ordem alfabética — um par por
+--    célula divergente, e não um produto cartesiano de reclamações sobre a mesma diferença.
+referencia AS (
+    SELECT * FROM celulas ORDER BY celula LIMIT 1
+),
+
+universo AS (
+    SELECT
+        'universo_divergente' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            c.celula, r.celula AS referencia,
+            c.jogos_no_universo,  r.jogos_no_universo  AS jogos_ref,
+            c.linhas_no_universo, r.linhas_no_universo AS linhas_ref,
+            c.janela_ini, r.janela_ini AS janela_ini_ref,
+            c.janela_fim, r.janela_fim AS janela_fim_ref,
+            c.versoes_na_celula
+        )) AS linha
+    FROM celulas AS c
+    CROSS JOIN referencia AS r
+    WHERE c.jogos_no_universo  IS DISTINCT FROM r.jogos_no_universo
+       OR c.linhas_no_universo IS DISTINCT FROM r.linhas_no_universo
+       OR c.janela_ini         IS DISTINCT FROM r.janela_ini
+       OR c.janela_fim         IS DISTINCT FROM r.janela_fim
+       OR c.versoes_na_celula  <> 1
+),
+
+-- 3. E É O UNIVERSO DECLARADO. `jogos_esperados` mora em macros/taskf_universo.sql, junto do
+--    predicado que produz o recorte — as duas pontas não têm como divergir.
+gabarito AS (
+    SELECT
+        'jogos_fora_do_gabarito' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            celula, jogos_no_universo, {{ j.jogos_esperados }} AS jogos_esperados,
+            '{{ j.ini }}' AS universo_ini, '{{ j.teto_utc }}' AS universo_teto_utc
+        )) AS linha
+    FROM celulas
+    WHERE jogos_no_universo IS DISTINCT FROM {{ j.jogos_esperados }}
+),
+
+-- 4. A MESMA EXECUÇÃO, nas duas pontas: mesma construção dos fatos nas quatro, e os fatos
+--    construídos ANTES de a célula ser medida. A segunda ponta é o que pega o caso em que alguém
+--    rebuilda a ancestria e esquece de re-medir — ali as quatro continuariam com o mesmo
+--    `odds_loaded_at` entre si, mas ele seria posterior aos `medido_em`.
+execucao AS (
+    SELECT
+        'execucao_divergente' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            c.celula, r.celula AS referencia,
+            c.odds_loaded_at, r.odds_loaded_at AS odds_loaded_at_ref,
+            c.medido_em,
+            c.odds_loaded_at IS DISTINCT FROM r.odds_loaded_at AS leu_outra_construcao,
+            NOT (c.odds_loaded_at < c.medido_em)                AS medida_antes_dos_fatos
+        )) AS linha
+    FROM celulas AS c
+    CROSS JOIN referencia AS r
+    WHERE c.odds_loaded_at IS DISTINCT FROM r.odds_loaded_at
+       OR c.odds_loaded_at IS NULL
+       OR NOT (c.odds_loaded_at < c.medido_em)
+)
+
+SELECT motivo, linha FROM presenca
+UNION ALL
+SELECT motivo, linha FROM universo
+UNION ALL
+SELECT motivo, linha FROM gabarito
+UNION ALL
+SELECT motivo, linha FROM execucao

--- a/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
+++ b/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
@@ -16,11 +16,12 @@
 --                        em branco, e é exatamente esse o estado da tabela no meio de uma
 --                        medição interrompida.
 --   rotulo_nao_casa_...  e o nome de cada célula casa com o par de eixos gravado ao lado dele.
---   universo_divergente  jogos, linhas e as duas pontas da janela idênticos nas quatro.
+--   universo_divergente  jogos, linhas e as duas pontas do corte idênticos nas quatro.
 --   jogos_fora_do_gabarito  e os jogos são os 169 que o universo congelado declara
 --                        (taskf_universo().jogos_esperados). Sem isto, quatro células medidas
 --                        sobre o mesmo universo ERRADO passariam juntas.
---   execucao_divergente  as quatro leram a MESMA construção dos fatos, e leram ANTES de medir.
+--   execucao_divergente  as quatro leram a MESMA construção dos fatos, leram ANTES de medir, e
+--                        saíram do MESMO commit (com procedência declarada).
 --
 -- ⚠️ AS QUATRO CÉLULAS NÃO PRECISAM TER O MESMO NÚMERO DE LINHAS DE PREMISSA, e por isso isso não
 -- é cobrado. Uma premissa entra na tabela quando acende pelo menos uma vez (`HAVING
@@ -68,16 +69,22 @@ WITH celulas AS (
         ANY_VALUE(janela_ini)         AS janela_ini,
         ANY_VALUE(janela_fim)         AS janela_fim,
         ANY_VALUE(odds_loaded_at)     AS odds_loaded_at,
+        ANY_VALUE(git_sha)            AS git_sha,
         MIN(medido_em)                AS medido_em,
-        -- Dentro de UMA célula os cinco campos acima são constantes por construção (saem de um
+        -- Dentro de UMA célula os seis campos acima são constantes por construção (saem de um
         -- CROSS JOIN de CTE de uma linha só). COUNT(DISTINCT) confere isso em vez de supor: se um
         -- INSERT parcial misturar duas execuções sob o mesmo rótulo, o ANY_VALUE acima escolheria
         -- uma delas em silêncio. TO_JSON_STRING e não FORMAT: FORMAT devolve NULL se QUALQUER
         -- argumento for NULL, e a linha NULL sai do COUNT(DISTINCT) — uma célula com metade das
         -- linhas sem carimbo contaria 1 e passaria.
+        --
+        -- ⚠️ `git_sha` PRECISA estar nesta lista, e o motivo é o pior caso dela: uma célula cujas
+        -- linhas carreguem DOIS commits é achatada pelo ANY_VALUE antes de a terceira ponta da
+        -- conferência de execução comparar coisa alguma — ou seja, a cobrança de "mesmo commit"
+        -- passaria justamente no caso para o qual foi escrita.
         COUNT(DISTINCT TO_JSON_STRING(STRUCT(
             jogos_no_universo, linhas_no_universo,
-            janela_ini, janela_fim, odds_loaded_at))) AS versoes_na_celula
+            janela_ini, janela_fim, odds_loaded_at, git_sha))) AS versoes_na_celula
     FROM {{ source('futebol_taskF', 'taskf_teste2') }}
     GROUP BY celula
 ),
@@ -162,25 +169,47 @@ gabarito AS (
     WHERE jogos_no_universo IS DISTINCT FROM {{ j.jogos_esperados }}
 ),
 
--- 4. A MESMA EXECUÇÃO, nas duas pontas: mesma construção dos fatos nas quatro, e os fatos
---    construídos ANTES de a célula ser medida. A segunda ponta é o que pega o caso em que alguém
---    rebuilda a ancestria e esquece de re-medir — ali as quatro continuariam com o mesmo
---    `odds_loaded_at` entre si, mas ele seria posterior aos `medido_em`.
+-- 4. A MESMA EXECUÇÃO, em TRÊS pontas: mesma construção dos fatos nas quatro, fatos construídos
+--    ANTES de a célula ser medida, e as quatro medidas do MESMO COMMIT.
+--
+--    A segunda ponta pega quem rebuilda a ancestria e esquece de re-medir — ali as quatro
+--    continuariam com o mesmo `odds_loaded_at` entre si, mas ele seria posterior aos `medido_em`.
+--
+--    A terceira fecha o buraco que sobrava: dois fatos idênticos não impedem que o CÓDIGO que os
+--    leu tenha mudado entre uma célula e outra. Medir a `base` num commit e a `ambos` noutro, sobre
+--    os mesmos fatos, passaria pelas duas primeiras pontas e ainda assim compararia duas coisas
+--    diferentes. `git_sha` é o único eixo de "mesma execução" que não precisa de régua arbitrária:
+--    ou é o mesmo commit, ou não é. Um carimbo `desconhecido` (a var não foi passada) também cai —
+--    célula sem procedência não sustenta afirmação nenhuma sobre execução, e é o mesmo argumento
+--    do carimbo de procedência da imagem dbt (ADR 0001 do repo raiz).
+--
+--    ⚠️ O QUE ESTAS TRÊS PONTAS **NÃO** ALCANÇAM, e está medido: re-medir uma célula depois, sobre
+--    fatos intocados e do mesmo commit, sai VERDE — e é o comportamento pretendido, porque a
+--    definição de "mesma execução" que a #51 fixou é "as quatro leram a mesma construção dos
+--    fatos". O que escapa aí é a deriva de reconstrução dos modelos: a própria #55 mediu 5 campos
+--    em 7.200 mudando entre duas medições sobre os mesmos fatos, todos empates de arredondamento
+--    do `AVG`. Nenhuma guarda distingue esse empate de um efeito real de 0,1 — quem quiser a
+--    diferença mede com `analyses/taskf_remedicao.sql`, que é onde ela é visível.
 execucao AS (
     SELECT
         'execucao_divergente' AS motivo,
         TO_JSON_STRING(STRUCT(
             c.celula, r.celula AS referencia,
             c.odds_loaded_at, r.odds_loaded_at AS odds_loaded_at_ref,
-            c.medido_em,
+            c.medido_em, c.git_sha, r.git_sha AS git_sha_ref,
             c.odds_loaded_at IS DISTINCT FROM r.odds_loaded_at AS leu_outra_construcao,
-            NOT (c.odds_loaded_at < c.medido_em)                AS medida_antes_dos_fatos
+            NOT (c.odds_loaded_at < c.medido_em)                AS medida_antes_dos_fatos,
+            c.git_sha IS DISTINCT FROM r.git_sha                AS outro_commit,
+            c.git_sha = 'desconhecido'                          AS sem_procedencia
         )) AS linha
     FROM celulas AS c
     CROSS JOIN referencia AS r
     WHERE c.odds_loaded_at IS DISTINCT FROM r.odds_loaded_at
        OR c.odds_loaded_at IS NULL
        OR NOT (c.odds_loaded_at < c.medido_em)
+       OR c.git_sha IS DISTINCT FROM r.git_sha
+       OR c.git_sha = 'desconhecido'
+       OR c.git_sha IS NULL
 )
 
 SELECT motivo, linha FROM presenca

--- a/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
+++ b/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
@@ -15,6 +15,7 @@
 --                        uma comparação "todas iguais" sobre uma tabela com uma célula só passa
 --                        em branco, e é exatamente esse o estado da tabela no meio de uma
 --                        medição interrompida.
+--   rotulo_nao_casa_...  e o nome de cada célula casa com o par de eixos gravado ao lado dele.
 --   universo_divergente  jogos, linhas e as duas pontas da janela idênticos nas quatro.
 --   jogos_fora_do_gabarito  e os jogos são os 169 que o universo congelado declara
 --                        (taskf_universo().jogos_esperados). Sem isto, quatro células medidas
@@ -101,6 +102,27 @@ presenca AS (
     WHERE e.nome IS NULL OR c.celula IS NULL
 ),
 
+-- 1b. E O RÓTULO CASA COM OS EIXOS. Quem escreve pelo taskf_teste2.sql não consegue errar isto —
+--     o nome é DERIVADO dos eixos por taskf_celula(). Mas a tabela é DDL num dataset onde um
+--     UPDATE à mão cabe (a própria falsificação desta Costura B usou um), e a partir daí o
+--     dicionário do 2×2 deixa de ser garantia e vira afirmação. Custa uma linha conferir.
+rotulos AS (
+    SELECT
+        'rotulo_nao_casa_com_os_eixos' AS motivo,
+        TO_JSON_STRING(STRUCT(celula, pit_escopo, pit_recorte, linhas)) AS linha
+    FROM (
+        SELECT celula, pit_escopo, pit_recorte, COUNT(*) AS linhas
+        FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+        GROUP BY celula, pit_escopo, pit_recorte
+    )
+    WHERE celula IS DISTINCT FROM CASE
+        {%- for chave, nome in taskf_nomes_de_celula().items() %}
+        WHEN pit_escopo = '{{ chave.split('|')[0] }}' AND pit_recorte = '{{ chave.split('|')[1] }}'
+            THEN '{{ nome }}'
+        {%- endfor %}
+    END
+),
+
 -- 2. O MESMO UNIVERSO. Comparação contra a primeira célula em ordem alfabética — um par por
 --    célula divergente, e não um produto cartesiano de reclamações sobre a mesma diferença.
 referencia AS (
@@ -162,6 +184,8 @@ execucao AS (
 )
 
 SELECT motivo, linha FROM presenca
+UNION ALL
+SELECT motivo, linha FROM rotulos
 UNION ALL
 SELECT motivo, linha FROM universo
 UNION ALL

--- a/dbt_futebol/tests/assert_taskf_contagens_por_recorte.sql
+++ b/dbt_futebol/tests/assert_taskf_contagens_por_recorte.sql
@@ -1,0 +1,87 @@
+{{ config(tags=['taskf', 'costura_b']) }}
+-- COSTURA B da task [F] (issue #49, ticket #55), a invariante que a #54 deixou encomendada — AS
+-- DUAS CONTAGENS DE AMOSTRA SE COMPORTAM CONFORME O RECORTE DA CÉLULA, DOS DOIS LADOS.
+--
+-- `min_jogos` sai da tabela em duas colunas: `jogos_medios_disp` (quantas partidas anteriores
+-- EXISTEM no escopo, sem teto) e `jogos_medios_usado` (quantas alimentaram as médias). Sob
+-- recorte `temporada` as duas são o MESMO número por construção — sem teto, tudo que existe é
+-- usado. Sob `ultimos_10` a segunda satura em 10 e as duas se separam.
+--
+-- ⚠️ ESCRITA COM AS DUAS PONTAS, e é isso que a distingue de uma guarda decorativa. Exigir só a
+-- igualdade nas células de `temporada` passaria em branco se as quatro células virassem
+-- `temporada` por engano — todas iguais, tudo verde, e o eixo de recorte simplesmente não teria
+-- sido medido. Por isso o outro lado é cobrado junto: numa célula de `ultimos_10`, ALGUMA linha
+-- tem de divergir.
+--
+--   temporada_com_teto     célula de recorte `temporada` com qualquer linha em que disponível ≠
+--                          usado. Não deveria existir: o modelo não emite coluna com teto ali.
+--   ultimos_10_sem_teto    célula de recorte `ultimos_10` em que NENHUMA linha diverge. Não é
+--                          "ninguém tinha mais de 10 partidas" — medido, o disponível chega a
+--                          149 —, é o carimbo ter rodado fora de ordem e o dado ser de outra
+--                          célula.
+--
+-- ⚠️ O LADO `ultimos_10` É COBRADO COMO "ALGUMA LINHA DIVERGE", E NÃO "TODAS DIVERGEM". Hoje as
+-- 60 linhas divergem nas duas células com teto, mas isso é medição, não construção: uma premissa
+-- que só acendesse em jogo de time novo teria disponível < 10 em todas as suas linhas e as duas
+-- médias sairiam iguais, legitimamente. Cobrar 60/60 seria congelar o dado de hoje como se fosse
+-- regra — o mesmo erro que esta task existe para não cometer.
+--
+-- ⚠️ NÃO É A MESMA CONFERÊNCIA DA `analyses/taskf_saturacao_recorte.sql`, e as duas não se
+-- substituem. Aquela mede a identidade `usado = LEAST(disponível, 10)` PAR A PAR, nos 21.054
+-- pares de (jogo, time) do carimbo do PIT; esta cobra o comportamento das duas colunas na tabela
+-- do ENTREGÁVEL, que é o artefato que a [B] vai ler. Um erro na agregação do Teste 2 — a média
+-- lendo a coluna errada, por exemplo — passa incólume pela primeira e cai nesta.
+--
+-- QUEM RODA: a FASE 3 da receita do analyses/taskf_teste2.sql, depois das quatro células —
+-- `dbt test --target taskF --select tag:costura_b`. Não é o agendado (tag `guarda`).
+--
+-- Falsificada de propósito trocando o `pit_recorte` de uma célula (e desfazendo em seguida); os
+-- comandos e o resultado estão em `docs/TASKF_RESULTADOS.md`, seção do ticket #55.
+
+WITH por_celula AS (
+    SELECT
+        celula,
+        ANY_VALUE(pit_recorte) AS pit_recorte,
+        COUNT(*)               AS linhas,
+        COUNTIF(jogos_medios_disp IS DISTINCT FROM jogos_medios_usado) AS linhas_com_teto,
+        COUNT(DISTINCT pit_recorte) AS recortes_na_celula
+    FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    GROUP BY celula
+),
+
+divergencias AS (
+    SELECT
+        CASE
+            WHEN pit_recorte = 'temporada'  THEN 'temporada_com_teto'
+            WHEN pit_recorte = 'ultimos_10' THEN 'ultimos_10_sem_teto'
+            ELSE                                 'recorte_desconhecido'
+        END AS motivo,
+        TO_JSON_STRING(STRUCT(
+            celula, pit_recorte, linhas, linhas_com_teto, recortes_na_celula
+        )) AS linha
+    FROM por_celula
+    WHERE (pit_recorte = 'temporada'  AND linhas_com_teto > 0)
+       OR (pit_recorte = 'ultimos_10' AND linhas_com_teto = 0)
+       OR  pit_recorte NOT IN ('temporada', 'ultimos_10')
+       OR  recortes_na_celula <> 1
+),
+
+-- O detalhe das linhas que quebraram o lado `temporada`, que é o caso em que saber QUAL linha
+-- diverge é o começo da investigação. No outro lado não há linha para mostrar: o defeito é a
+-- ausência delas.
+detalhe AS (
+    SELECT
+        'temporada_com_teto_detalhe' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            t.celula, t.mercado, t.premissa, t.benchmark,
+            t.jogos_medios_disp, t.jogos_medios_usado
+        )) AS linha
+    FROM {{ source('futebol_taskF', 'taskf_teste2') }} AS t
+    JOIN por_celula AS c USING (celula)
+    WHERE c.pit_recorte = 'temporada'
+      AND t.jogos_medios_disp IS DISTINCT FROM t.jogos_medios_usado
+)
+
+SELECT motivo, linha FROM divergencias
+UNION ALL
+SELECT motivo, linha FROM detalhe

--- a/dbt_futebol/tests/assert_taskf_premissas_de_tabela_identicas.sql
+++ b/dbt_futebol/tests/assert_taskf_premissas_de_tabela_identicas.sql
@@ -1,0 +1,158 @@
+{{ config(tags=['taskf', 'costura_b']) }}
+-- COSTURA B da task [F] (issue #49, ticket #55), invariante 2 de 3 — AS PREMISSAS DE TABELA NÃO
+-- SE MEXEM ENTRE AS CÉLULAS.
+--
+-- A ADR 0008 decidiu que as premissas que leem CLASSIFICAÇÃO (`rank`, `ppg`, `n_teams`) ficam
+-- competição-scoped nas quatro células, porque não existe tabela de um campeonato juntado —
+-- `sem_rodizio` chega a comparar o rank contra o tamanho da liga. E afirma que, por isso, o
+-- número delas é "idêntico por construção". Esta guarda é o que transforma essa afirmação em
+-- verificação: enquanto ela passar, a imobilidade dessas linhas é fato conferido, e não a
+-- promessa de que ninguém deixou o escopo vazar para dentro delas.
+--
+-- Falha = ou o eixo de escopo alcançou uma premissa que a ADR diz que ele não alcança, ou a
+-- célula foi gravada com o rótulo de outra. As duas são graves e nenhuma se vê no número.
+--
+-- ────────────────────────────────────────────────────────────────────────────────
+-- SÃO TRÊS PREMISSAS, E A IDENTIDADE É NO PISO 0. As duas coisas divergem do enunciado literal
+-- do critério de aceite da #55, que fala em quatro premissas sem qualificar o piso — e as duas
+-- estão registradas na ADR 0008 (seção final e Consequences), medidas antes desta guarda existir:
+--
+--   TRÊS, NÃO QUATRO. `x_superioridade_tabela` não é uma das 39 premissas medidas: é coluna
+--   interna do int_futebol_premissas_1x2 que a Dupla Chance reusa dentro do `lado_coberto_forte`
+--   — e este também lê `forca_mismatch`, que segue o eixo. Cobrá-la aqui daria zero linha
+--   comparada, que é o modo de falha silencioso que a lista explícita abaixo fecha.
+--
+--   PISO 0, NÃO TODOS. `min_jogos` segue a célula inclusive nas linhas destas premissas (o piso é
+--   propriedade do JOGO, não da premissa — Consequences da ADR 0008). Nos pisos maiores elas
+--   mudam de número legitimamente, porque cada célula corta um conjunto diferente de jogos:
+--   `superioridade_tabela` vai de n=35 na `base` para n=47 na `escopo` no piso 5. Cobrar
+--   igualdade lá seria cobrar que a decisão da ADR não valesse.
+--
+-- Pelo mesmo motivo, `jogos_medios_disp`, `jogos_medios_usado` e `pct_amostra_curta` ficam FORA
+-- da comparação mesmo no piso 0: são médias do histórico do jogo, não da premissa, e elas se
+-- mexem de propósito (`supremacia` mede 7,0 partidas na `base` e 29,1 na `ambos`). O que é
+-- cobrado são os campos que descrevem a MEDIÇÃO da premissa — quantas vezes acendeu, o que a odd
+-- dava, o que aconteceu, a diferença e os dois pesos.
+--
+-- ────────────────────────────────────────────────────────────────────────────────
+-- O GRÃO É (mercado, premissa, benchmark), nunca a premissa sozinha: `supremacia` e `sem_rodizio`
+-- saem em duas linhas cada (sharp e consenso do Handicap), com números diferentes, e comparar
+-- premissa a premissa juntaria as duas.
+--
+-- NÃO-VACUIDADE em duas frentes, porque "todos os números batem" é o veredito natural de uma
+-- comparação que não comparou nada:
+--
+--   premissa_ausente     cada uma das três aparece em pelo menos uma célula. Uma renomeada no
+--                        catálogo sumiria daqui sem deixar rastro.
+--   grao_incompleto      cada linha de grão existe nas QUATRO células. Uma premissa medida em
+--                        duas células e comparada só ali passaria dizendo o mesmo que uma medida
+--                        nas quatro.
+--
+-- QUEM RODA: a FASE 3 da receita do analyses/taskf_teste2.sql, depois das quatro células —
+-- `dbt test --target taskF --select tag:costura_b`. Não é o agendado (tag `guarda`).
+--
+-- Falsificada de propósito alterando o `n_p0` de uma célula (e desfazendo em seguida); os
+-- comandos e o resultado estão em `docs/TASKF_RESULTADOS.md`, seção do ticket #55.
+
+{#- As três do catálogo medido. Escritas aqui e não derivadas de nada: é a lista que a ADR 0008
+    nomeia, e uma guarda que descobrisse sozinha "quais premissas são de tabela" acabaria
+    concordando com o que quer que o código estivesse fazendo. -#}
+{% set premissas_de_tabela = ['superioridade_tabela', 'supremacia', 'sem_rodizio'] %}
+
+{#- Os campos do piso 0 que descrevem a medição da premissa. `fator_encolhimento` entra porque é
+    função de `n_p0` e denunciaria um n que mudou sem a linha inteira mudar junto. -#}
+{%- set campos = [
+    'n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'diferenca_p0', 'peso_p0', 'peso_p0_k0',
+    'fator_encolhimento'
+] %}
+-- As duas listas acima são o contrato desta guarda: as premissas que a ADR 0008 nomeia e os
+-- campos que descrevem a medição delas. O cabeçalho diz o que ficou de fora, e por quê.
+
+WITH medido AS (
+    SELECT
+        celula, mercado, premissa, benchmark, usado_para_peso,
+        {{ campos | join(', ') }}
+    FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    WHERE premissa IN ({{ premissas_de_tabela | map('tojson') | join(', ') }})
+),
+
+-- A referência é a célula base do 2×2 quando ela existe (é a que não muda nada); na falta dela, a
+-- primeira em ordem alfabética, para a guarda não passar em branco por causa da ausência.
+referencia AS (
+    SELECT * FROM medido
+    -- `WHERE TRUE` não é enfeite: o BigQuery só aceita QUALIFY quando há WHERE, GROUP BY ou
+    -- HAVING na mesma query — sem ele, o parser lê `QUALIFY` como alias da tabela e o erro sai
+    -- várias linhas adiante.
+    WHERE TRUE
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY mercado, premissa, benchmark
+        ORDER BY IF(celula = 'base', 0, 1), celula
+    ) = 1
+),
+
+divergencias AS (
+    SELECT
+        'numero_divergente' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            m.mercado, m.premissa, m.benchmark, m.usado_para_peso,
+            m.celula, r.celula AS referencia,
+            {%- for campo in campos %}
+            m.{{ campo }}, r.{{ campo }} AS {{ campo }}_ref{{ ',' if not loop.last }}
+            {%- endfor %}
+        )) AS linha
+    FROM medido AS m
+    JOIN referencia AS r
+      ON  r.mercado   = m.mercado
+      AND r.premissa  = m.premissa
+      AND r.benchmark = m.benchmark
+    WHERE {% for campo in campos -%}
+          m.{{ campo }} IS DISTINCT FROM r.{{ campo }}
+          {%- if not loop.last %}
+       OR {% endif %}
+          {%- endfor %}
+),
+
+-- NÃO-VACUIDADE 1: as três estão na tabela.
+ausentes AS (
+    SELECT
+        'premissa_ausente' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            p AS premissa,
+            (SELECT COUNT(*) FROM medido WHERE premissa = p) AS linhas_encontradas
+        )) AS linha
+    FROM UNNEST({{ premissas_de_tabela | tojson }}) AS p
+    WHERE NOT EXISTS (SELECT 1 FROM medido WHERE premissa = p)
+),
+
+-- NÃO-VACUIDADE 2: cada linha de grão existe nas quatro células. Compara-se contra a contagem de
+-- células que a tabela de fato tem (que a invariante 1 cobra ser 4), e não contra um 4 digitado:
+-- as duas guardas ficam com um dono cada, e esta não repete a cobrança da outra com número solto.
+celulas_na_tabela AS (
+    SELECT COUNT(DISTINCT celula) AS n FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+),
+
+grao_incompleto AS (
+    SELECT
+        'grao_incompleto' AS motivo,
+        TO_JSON_STRING(STRUCT(
+            g.mercado, g.premissa, g.benchmark,
+            g.celulas_com_a_linha, t.n AS celulas_na_tabela,
+            g.quais_celulas
+        )) AS linha
+    FROM (
+        SELECT
+            mercado, premissa, benchmark,
+            COUNT(DISTINCT celula) AS celulas_com_a_linha,
+            STRING_AGG(DISTINCT celula, ', ' ORDER BY celula) AS quais_celulas
+        FROM medido
+        GROUP BY mercado, premissa, benchmark
+    ) AS g
+    CROSS JOIN celulas_na_tabela AS t
+    WHERE g.celulas_com_a_linha <> t.n
+)
+
+SELECT motivo, linha FROM divergencias
+UNION ALL
+SELECT motivo, linha FROM ausentes
+UNION ALL
+SELECT motivo, linha FROM grao_incompleto

--- a/dbt_futebol/tests/assert_taskf_premissas_de_tabela_identicas.sql
+++ b/dbt_futebol/tests/assert_taskf_premissas_de_tabela_identicas.sql
@@ -77,7 +77,8 @@ WITH medido AS (
 ),
 
 -- A referência é a célula base do 2×2 quando ela existe (é a que não muda nada); na falta dela, a
--- primeira em ordem alfabética, para a guarda não passar em branco por causa da ausência.
+-- primeira em ordem alfabética, para a guarda não passar em branco por causa da ausência. O nome
+-- vem de taskf_nomes_de_celula(), como em toda parte: rótulo de célula não se digita.
 referencia AS (
     SELECT * FROM medido
     -- `WHERE TRUE` não é enfeite: o BigQuery só aceita QUALIFY quando há WHERE, GROUP BY ou
@@ -86,7 +87,7 @@ referencia AS (
     WHERE TRUE
     QUALIFY ROW_NUMBER() OVER (
         PARTITION BY mercado, premissa, benchmark
-        ORDER BY IF(celula = 'base', 0, 1), celula
+        ORDER BY IF(celula = '{{ taskf_nomes_de_celula()['da_competicao|temporada'] }}', 0, 1), celula
     ) = 1
 ),
 

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -946,7 +946,7 @@ são empates de arredondamento comprovados aritmeticamente.
 
 | guarda | o que cobra | cobertura hoje |
 |---|---|---|
-| `assert_taskf_celulas_mesmo_universo` | as quatro células existem, o rótulo casa com os eixos, universo idêntico e igual ao declarado, mesma construção dos fatos e fatos anteriores à medição | 4 células, 169 jogos / 8.567 linhas, `odds_loaded_at` 13:24:15 nas quatro |
+| `assert_taskf_celulas_mesmo_universo` | as quatro células existem, o rótulo casa com os eixos, universo idêntico e igual ao declarado, mesma construção dos fatos, fatos anteriores à medição e mesmo commit nas quatro | 4 células, 169 jogos / 8.567 linhas, `odds_loaded_at` 13:24:15 e `git_sha` `b535130` nas quatro |
 | `assert_taskf_premissas_de_tabela_identicas` | as três premissas de tabela têm números idênticos no piso 0 entre as células | 5 linhas de grão × 4 células, 7 campos — 105 comparações |
 | `assert_taskf_base_reproduz_01` | a `base` reproduz o Teste 2 publicado da [0.1] sob a régua declarada | 39 linhas, **225 campos publicados** comparados |
 | `assert_taskf_contagens_por_recorte` | disponível = usado sob `temporada`, e **alguma** linha diverge sob `ultimos_10` | 60/60 linhas iguais em `base` e `escopo`; 60/60 divergentes em `recorte` e `ambos` |
@@ -997,6 +997,14 @@ O critério de aceite pede que as guardas falhem **de verdade**. Cada uma foi qu
 restaurada; a integridade da tabela foi reconferida no fim contra a cópia da #54 — as mesmas 5
 divergências de arredondamento de antes, nem uma a mais.
 
+⚠️ **A quebra 8 é a que justifica a existência das outras.** Ela veio da revisão de standards, que
+achou um buraco no código antes de qualquer teste rodar: o `git_sha` tinha entrado no `ANY_VALUE`
+da CTE mas **não** na chave de `versoes_na_celula`, então uma célula com duas procedências dentro
+dela era achatada antes de a conferência de commit comparar coisa alguma — a cobrança passava
+justamente no caso para o qual foi escrita. Corrigido, a quebra 8 devolve `versoes_na_celula: 2`.
+Vale como aviso ao próximo: acrescentar campo à CTE de agregação **e** à chave de versão são dois
+passos, e esquecer o segundo é silencioso.
+
 | # | quebra | guarda que caiu | saída |
 |---|---|---|---|
 | 1 | `--vars '{taskf_tolerancia_pp: 0}'` (não toca no dado) | `base_reproduz_01` | **6 linhas**, todas os campos em pp de `linha_descendo` — o resíduo conhecido, e mais nada |
@@ -1004,16 +1012,35 @@ divergências de arredondamento de antes, nem uma a mais.
 | 3 | `SET odds_loaded_at = TIMESTAMP_ADD(odds_loaded_at, INTERVAL 1 SECOND) WHERE celula='ambos'` | `celulas_mesmo_universo` | **3 linhas**, `leu_outra_construcao: true` — a assinatura exata de quem reconstruiu a ancestria no meio da medição |
 | 4 | `SET odds_loaded_at = TIMESTAMP '2026-08-13 00:00:00 UTC'` (as quatro) | `celulas_mesmo_universo` | **4 linhas**, `medida_antes_dos_fatos: true` e `leu_outra_construcao: false` — a outra ponta: quem rebuildou os fatos e esqueceu de re-medir |
 | 5 | `SET pit_recorte='temporada' WHERE celula='ambos'` | `contagens_por_recorte` **e** `celulas_mesmo_universo` | **61 linhas** (resumo + as 60 com teto) e **1 linha** (`rotulo_nao_casa_com_os_eixos`) |
+| 6 | `SET git_sha='cafebabe' WHERE celula='recorte'` | `celulas_mesmo_universo` | **1 linha**, `outro_commit: true` com os fatos iguais — a célula medida de outro código |
+| 7 | `SET git_sha='desconhecido'` (as quatro) | `celulas_mesmo_universo` | **4 linhas**, `sem_procedencia: true` — as quatro concordam entre si e nenhuma diz de onde veio |
+| 8 | `SET git_sha='cafebabe' WHERE celula='base' AND mercado='Gols'` | `celulas_mesmo_universo` | **1 linha**, `versoes_na_celula: 2` — duas procedências DENTRO de uma célula |
 
 ⚠️ **A quebra 1 é a mais informativa das cinco.** Zerar a tolerância derruba exatamente 6 campos,
 todos da mesma premissa, e nenhum outro dos 225. Isso mede duas coisas de uma vez: a régua está
 cobrindo uma coisa só, e as outras 38 premissas reproduzem o publicado **exatamente**, sem folga
 nenhuma sustentando o verde.
 
-⚠️ **As quebras 3 e 4 são as que respondem ao critério ao pé da letra** ("falham se alguém
-materializar as células em execuções separadas"). As outras duas guardas não caem nesse cenário, e
-não deveriam: a das premissas de tabela fala de escopo vazando, a da reprodução fala da [0.1]. Quem
-cobra "mesma execução" é a primeira, pelas duas pontas.
+⚠️ **O critério de aceite pede que "os três" falhem se as células forem materializadas em execuções
+separadas, e isso não é o que acontece — nem deveria ser.** Quem cobra "mesma execução" é a
+primeira guarda, sozinha, pelas três pontas (mesma construção dos fatos, fatos antes da medição,
+mesmo commit). As outras não caem nesse cenário porque falam de outra coisa: a das premissas de
+tabela fala de escopo vazando, a da reprodução fala da [0.1], a das contagens fala do recorte.
+Espalhar a mesma cobrança pelas quatro daria redundância, não cobertura.
+
+⚠️ **E o que nenhuma das quatro alcança, dito antes que alguém descubra do jeito caro.** As quatro
+células são sempre materializadas por quatro `dbt build` separados — isso é da receita, não um
+desvio. O que a #51 fixou como "mesma execução" é **as quatro terem lido a mesma construção dos
+fatos**, e é isso que a guarda cobra. Logo: re-medir uma célula amanhã, sobre fatos intocados e do
+mesmo commit, sai **verde**.
+
+O que escapa nesse caso é a **deriva de reconstrução dos modelos** — e ela é real e está medida
+aqui mesmo: 5 campos em 7.200 mudaram entre duas medições sobre os mesmos fatos, todos empates de
+arredondamento do `AVG`. Nenhuma guarda distingue esse empate de um efeito de 0,1 pp, porque no
+número eles são idênticos. Quem quiser a diferença mede com `analyses/taskf_remedicao.sql`, que é
+onde ela é visível — e é por isso que a comparação da re-medição virou arquivo em vez de rascunho.
+O carimbo `git_sha` fecha a parte disso que **é** decidível sem régua arbitrária: duas células do
+mesmo commit ou não.
 
 ### O carimbo `odds_loaded_at`, e o que ele custou
 

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -913,3 +913,210 @@ vale a pena escrever: `jogos_medios_disp = jogos_medios_usado` em toda linha de 
 em `escopo`, **0/60** em `recorte` e em `ambos`. Uma guarda que exigisse só a igualdade passaria em
 branco se as quatro células virassem `temporada` por engano; exigir a desigualdade do outro lado
 fecha isso.
+
+---
+
+## Ticket #55 — Costura B: as invariantes deixam de ser afirmação
+
+`tests/assert_taskf_celulas_mesmo_universo.sql` + `assert_taskf_premissas_de_tabela_identicas.sql`
++ `assert_taskf_base_reproduz_01.sql` + `assert_taskf_contagens_por_recorte.sql` +
+`analyses/taskf_remedicao.sql` · execução 2026-08-12 19:55 a 20:05 UTC · commit `b535130` ·
+dataset `futebol_taskF`
+
+O que as três seções anteriores afirmam sobre a saída das quatro células vira cobrança automática.
+Antes deste ticket, "as quatro rodaram na mesma execução", "as premissas de tabela não se mexem" e
+"a `base` reproduz a [0.1]" eram disciplina de quem executou e parágrafo de quem leu. Depois dele,
+são quatro guardas com nome, tag e vermelho.
+
+### Veredito
+
+**Quatro guardas, quatro verdes**, sobre as quatro células re-medidas na mesma execução. As quatro
+foram **quebradas de propósito** — cinco quebras diferentes, cada uma desfeita em seguida e
+reconferida — e nenhuma delas passa em branco.
+
+```
+dbt test --target taskF --select tag:costura_b     →  PASS=4 ERROR=0
+```
+
+A tabela acumulativa mudou de schema (ganhou `odds_loaded_at`), o que obrigou a dropá-la e re-medir
+as quatro células. A re-medição reproduz a #54 em **7.195 de 7.200 campos**, e os 5 que divergem
+são empates de arredondamento comprovados aritmeticamente.
+
+### As quatro guardas, e o que cada uma cobra
+
+| guarda | o que cobra | cobertura hoje |
+|---|---|---|
+| `assert_taskf_celulas_mesmo_universo` | as quatro células existem, o rótulo casa com os eixos, universo idêntico e igual ao declarado, mesma construção dos fatos e fatos anteriores à medição | 4 células, 169 jogos / 8.567 linhas, `odds_loaded_at` 13:24:15 nas quatro |
+| `assert_taskf_premissas_de_tabela_identicas` | as três premissas de tabela têm números idênticos no piso 0 entre as células | 5 linhas de grão × 4 células, 7 campos — 105 comparações |
+| `assert_taskf_base_reproduz_01` | a `base` reproduz o Teste 2 publicado da [0.1] sob a régua declarada | 39 linhas, **225 campos publicados** comparados |
+| `assert_taskf_contagens_por_recorte` | disponível = usado sob `temporada`, e **alguma** linha diverge sob `ultimos_10` | 60/60 linhas iguais em `base` e `escopo`; 60/60 divergentes em `recorte` e `ambos` |
+
+As quatro leem **só `source('futebol_taskF', ...)`** — nenhuma faz `ref()` de modelo. Isso não é
+detalhe de estilo: um `ref()` as penduraria no grafo do `fact_odds_snapshot` e a seleção indireta
+do dbt as arrastaria para dentro dos `dbt build` das fases 1 e 2, onde elas são vermelhas por
+construção (as células ainda não foram medidas). Seria uma segunda `--exclude` na receita, e "a
+Costura A é a única exclusão que a medição precisa" é promessa escrita em três lugares desde a #52.
+Conferido no manifest: as quatro dependem de um nó só, a source.
+
+### Duas leituras do critério de aceite, já corrigidas antes desta guarda existir
+
+O critério da #55 pede "as **quatro** premissas de tabela com números **idênticos**". Implementado
+ao pé da letra, ele nasce vermelho — e as duas correções não são deste ticket, são da ADR 0008,
+medidas na #53 e na #54:
+
+- **três, não quatro.** `x_superioridade_tabela` não é uma das 39 medidas: é coluna interna do
+  `int_futebol_premissas_1x2` que a Dupla Chance reusa dentro do `lado_coberto_forte` — e este
+  também lê `forca_mismatch`, então segue o eixo. Cobrá-la daria zero linha comparada, que é
+  exatamente o silêncio verde que a guarda existe para não produzir;
+- **a identidade é no piso 0.** Nos pisos maiores as três mudam de número legitimamente, porque o
+  `min_jogos` segue a célula (o piso é propriedade do jogo, não da premissa):
+  `superioridade_tabela` vai de n=35 na `base` para n=47 na `escopo` no piso 5. Pelo mesmo motivo
+  `jogos_medios_disp`, `jogos_medios_usado` e `pct_amostra_curta` ficam fora da comparação mesmo no
+  piso 0 — `supremacia` mede 7,0 partidas médias na `base` e 29,1 na `ambos`, e isso é o resultado,
+  não um defeito.
+
+O enunciado da spec continua como está de propósito: ele é o registro do que se sabia antes de
+medir. O cabeçalho da guarda carrega as duas leituras por escrito.
+
+### A quarta guarda, que a #54 encomendou
+
+A #54 fechou pedindo uma invariante sobre as duas contagens de amostra, **escrita com as duas
+pontas**. Ela existe: sob recorte `temporada` toda linha tem disponível = usado (sem teto, tudo que
+existe é usado); sob `ultimos_10`, **alguma** linha tem de divergir. A segunda ponta é o que impede
+o silêncio verde — se as quatro células virassem `temporada` por engano, a igualdade sozinha
+passaria em todas e o eixo de recorte simplesmente não teria sido medido.
+
+⚠️ O lado `ultimos_10` é cobrado como "alguma linha diverge", e **não** como 60/60. Que hoje sejam
+60 de 60 é medição, não construção: uma premissa que só acendesse em jogo de time novo teria
+disponível < 10 em todas as suas linhas e as duas médias sairiam iguais, legitimamente. Cobrar o
+número de hoje seria congelar dado como se fosse regra.
+
+### A falsificação: cinco quebras, cinco vermelhos, cinco desfeitas
+
+O critério de aceite pede que as guardas falhem **de verdade**. Cada uma foi quebrada, conferida e
+restaurada; a integridade da tabela foi reconferida no fim contra a cópia da #54 — as mesmas 5
+divergências de arredondamento de antes, nem uma a mais.
+
+| # | quebra | guarda que caiu | saída |
+|---|---|---|---|
+| 1 | `--vars '{taskf_tolerancia_pp: 0}'` (não toca no dado) | `base_reproduz_01` | **6 linhas**, todas os campos em pp de `linha_descendo` — o resíduo conhecido, e mais nada |
+| 2 | `SET n_p0 = n_p0 + 1 WHERE celula='escopo' AND premissa='supremacia' AND benchmark='sharp'` | `premissas_de_tabela_identicas` | **1 linha**: n_p0 302 contra 301 na referência |
+| 3 | `SET odds_loaded_at = TIMESTAMP_ADD(odds_loaded_at, INTERVAL 1 SECOND) WHERE celula='ambos'` | `celulas_mesmo_universo` | **3 linhas**, `leu_outra_construcao: true` — a assinatura exata de quem reconstruiu a ancestria no meio da medição |
+| 4 | `SET odds_loaded_at = TIMESTAMP '2026-08-13 00:00:00 UTC'` (as quatro) | `celulas_mesmo_universo` | **4 linhas**, `medida_antes_dos_fatos: true` e `leu_outra_construcao: false` — a outra ponta: quem rebuildou os fatos e esqueceu de re-medir |
+| 5 | `SET pit_recorte='temporada' WHERE celula='ambos'` | `contagens_por_recorte` **e** `celulas_mesmo_universo` | **61 linhas** (resumo + as 60 com teto) e **1 linha** (`rotulo_nao_casa_com_os_eixos`) |
+
+⚠️ **A quebra 1 é a mais informativa das cinco.** Zerar a tolerância derruba exatamente 6 campos,
+todos da mesma premissa, e nenhum outro dos 225. Isso mede duas coisas de uma vez: a régua está
+cobrindo uma coisa só, e as outras 38 premissas reproduzem o publicado **exatamente**, sem folga
+nenhuma sustentando o verde.
+
+⚠️ **As quebras 3 e 4 são as que respondem ao critério ao pé da letra** ("falham se alguém
+materializar as células em execuções separadas"). As outras duas guardas não caem nesse cenário, e
+não deveriam: a das premissas de tabela fala de escopo vazando, a da reprodução fala da [0.1]. Quem
+cobra "mesma execução" é a primeira, pelas duas pontas.
+
+### O carimbo `odds_loaded_at`, e o que ele custou
+
+A forma verificável de "mesma execução" que a #51 definiu era ler o
+`fact_odds_snapshot.dbt_loaded_at` **ao vivo** e conferir que é anterior aos quatro `medido_em`. A
+#55 gravou esse valor **na linha de cada célula**, e a mudança tem duas razões:
+
+1. lido ao vivo, o veredito **decai**: qualquer rebuild posterior no dataset de medição deixaria a
+   guarda vermelha sem que as quatro células tivessem deixado de ser comparáveis entre si — que é a
+   única coisa que a guarda quer afirmar;
+2. lido ao vivo, ele exige `ref()`, e o `ref()` traz o problema de grafo descrito acima.
+
+Carimbado, ele responde a pergunta certa para sempre — e responde **mais forte**: não é "os quatro
+carimbos são próximos", é "as quatro leram a MESMA construção", com o valor na linha.
+
+O preço é o que a #54 já tinha documentado: mudar o schema da acumulativa obriga a `bq rm` e
+re-medir as quatro células. Foi feito, e a `taskf_pit_por_celula` foi reescrita junto — as duas
+tabelas carregam a mesma execução.
+
+### A re-medição reproduz a #54: 5 campos em 7.200
+
+`analyses/taskf_remedicao.sql` — e desta vez a comparação **é re-derivável**. A #54 fez a mesma
+conferência com uma cópia tratada como rascunho e apagada em seguida, e registrou a lição; aqui a
+cópia é a tabela `futebol_taskF.taskf_teste2_54`, declarada em `sources.yml`, e a comparação é um
+arquivo.
+
+| célula | linhas | sem contraparte | linhas divergentes | campos divergentes | campos comparados |
+|---|---|---|---|---|---|
+| `base` | 60 | 0 | 1 | **1** | 1.800 |
+| `escopo` | 60 | 0 | 2 | **3** | 1.800 |
+| `recorte` | 60 | 0 | 0 | **0** | 1.800 |
+| `ambos` | 60 | 0 | 1 | **1** | 1.800 |
+
+Os cinco campos, e a prova de que os três casos são **empate de arredondamento** e não deriva —
+cada um cai exatamente no meio da grade de `ROUND(·, 1)`:
+
+| célula | linha | campo | antes → agora | grade | veredito |
+|---|---|---|---|---|---|
+| `base` | Handicap · `raramente_perde_por_2` · consenso | `aconteceu_p10` | 96,2 → 96,3 | n=320, 308/320 = **96,25** | empate exato |
+| `escopo` | Dupla Chance · `invicto_recente` · derivada | `jogos_medios_disp` e `_usado` | 10,2 → 10,3 | n=48, soma 492 → **10,25** | empate exato |
+| `escopo` e `ambos` | Gols · `historico_under` · consenso | `pct_amostra_curta` | 12,8 → 12,7 | n=400, 51/400 = **12,75** | empate exato |
+
+É o mesmo fenômeno que a #53 mediu em três casos e a #54 em um: o `AVG` do BigQuery acumula em
+ponto flutuante e a ordem depende do layout físico da tabela, que muda quando os modelos são
+reconstruídos. Nenhuma das cinco linhas é de benchmark preferido em mercado de peso — três das
+cinco são de consenso, que não pesa.
+
+E as conferências de fora não se moveram:
+
+- **reconciliação contra a [0.1]**: 38 `EXATO` / 1 `INVESTIGAR`, com `linha_descendo` nos mesmos
+  −2 de `n` e +0,1/+0,2 pp;
+- **saturação, piso, monotonicidade e chaves**: `OK` nos quatro blocos, 0 violações — 15.150 e
+  16.435 pares saturados, piso 5 em 69 / 92 / 81 / 92, 21.054 pares idênticos nas quatro.
+
+### ⚠️ E o que apareceu no caminho: o `task01_base()` estava quebrado em master
+
+Ao re-medir a primeira célula, o `taskf_teste2` compilado não era SQL válido. A causa não é da [F]:
+o PR #48 (spec #37, mergeado às **14:53** de 12/08) inseriu um bloco `{#- ... -#}` entre a última
+coluna do CTE `odds` e o `FROM`. O traço de abertura faz o Jinja comer a quebra de linha anterior, e
+o compilado saía `... AS conjunto_incompletoFROM (`.
+
+**Todas as 12 análises que chamam `task01_base()`** — as 8 da [0.1]/[A] e as 4 da [F] — pararam de
+compilar em master naquele merge. Ninguém viu por dois motivos que valem para a próxima vez:
+
+- nenhuma delas roda no agendado, que executa `dbt test --select tag:guarda`. Análise quebrada é
+  **muda** até alguém rodar;
+- a medição da #54 rodou às 15:29 do mesmo dia **de dentro do worktree dela**, que não continha o
+  merge. O isolamento que o `CLAUDE.md` exige protege de clobber de arquivo e, de brinde, esconde
+  regressão de master até o próximo branch novo.
+
+Corrigido no commit `b535130` (abre com `{#`, sem traço), com as quatro análises da [F] e a
+`task01_teste2` validadas no dry-run do BigQuery depois do fix.
+
+### Reprodução
+
+```bash
+cd dbt_futebol
+
+# FASE 0 — só porque a #55 mudou o schema da acumulativa (o odds_loaded_at)
+bq cp -f smartbetting-dados:futebol_taskF.taskf_teste2 \
+         smartbetting-dados:futebol_taskF.taskf_teste2_54   # a cópia que sobrevive
+bq rm -f -t smartbetting-dados:futebol_taskF.taskf_teste2
+
+# as quatro células, cada uma com build -> carimbo -> Teste 2 e as MESMAS vars. Nada de `+`.
+# (a ancestria não foi reconstruída: ela já estava no dataset e nenhum modelo dela mudou)
+# base    : --vars '{}'                                        (sem exclusão: a Costura A roda)
+# escopo  : --vars '{pit_escopo: todas}'                       --exclude assert_taskf_pit_default_igual_baseline
+# recorte : --vars '{pit_recorte: ultimos_10}'                 idem
+# ambos   : --vars '{pit_escopo: todas, pit_recorte: ultimos_10}' idem
+
+# FASE 3 — o portão. Enquanto não estiver verde, são quatro medições, e não um 2x2 comparável.
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt test --target taskF --select tag:costura_b
+
+# a re-medição contra a execução anterior
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_remedicao \
+  --vars '{taskf_remedicao_anterior: taskf_teste2_54}'
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_remedicao.sql
+
+# a falsificação que não toca no dado
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt test --target taskF \
+  --select assert_taskf_base_reproduz_01 --vars '{taskf_tolerancia_pp: 0}'
+```
+
+Os quatro `dbt build` fecham **43/43** (`base`, incluindo a Costura A) e **42/42** (as outras
+três), com `ERROR=0` e `SKIP=0` — iguais aos da #54.


### PR DESCRIPTION
Closes #55

O que a #51, a #53 e a #54 **afirmam** sobre a saída das quatro células vira cobrança automática. Antes deste ticket, "as quatro rodaram na mesma execução", "as premissas de tabela não se mexem" e "a `base` reproduz a [0.1]" eram disciplina de quem executou e parágrafo de quem leu.

```
dbt test --target taskF --select tag:costura_b     →  PASS=4 ERROR=0
```

## As quatro guardas

| guarda | o que cobra | cobertura |
|---|---|---|
| `assert_taskf_celulas_mesmo_universo` | as quatro existem, o rótulo casa com os eixos, universo idêntico e igual ao declarado, e **mesma execução por três pontas**: mesma construção dos fatos, fatos anteriores à medição, mesmo commit | 4 células, 169 jogos / 8.567 linhas |
| `assert_taskf_premissas_de_tabela_identicas` | as três premissas de tabela idênticas no piso 0 | 105 comparações |
| `assert_taskf_base_reproduz_01` | a `base` reproduz o Teste 2 publicado da [0.1] sob a régua declarada | 39 linhas, 225 campos publicados |
| `assert_taskf_contagens_por_recorte` | disponível = usado sob `temporada`, e **alguma** linha divergindo sob `ultimos_10` | a quarta, encomendada pela #54 |

As quatro leem **só `source('futebol_taskF', ...)`**, sem `ref()` de modelo. Não é estilo: um `ref()` as penduraria no grafo do `fact_odds_snapshot`, a seleção indireta as arrastaria para dentro dos builds das fases 1 e 2 (onde são vermelhas por construção) e isso obrigaria uma segunda `--exclude` na receita. "A Costura A é a única exclusão que a medição precisa" segue verdade.

## Duas leituras do critério de aceite

O critério pede "as **quatro** premissas de tabela com números **idênticos**". Ao pé da letra ele nasce vermelho, e as duas correções já estavam medidas na ADR 0008: são **três** no catálogo medido (`x_superioridade_tabela` é coluna interna, não uma das 39) e a identidade é **no piso 0** (nos demais o `min_jogos` segue a célula, de propósito). Está no cabeçalho da guarda, na ADR e no doc de resultados.

## Falsificação: oito quebras, oito vermelhos, oito desfeitas

Cada uma conferida e revertida; a integridade da tabela reconferida no fim contra a cópia da #54. Destaques:

- **zerar a tolerância** derruba exatamente 6 campos, todos de `linha_descendo`, e nenhum dos outros 225 — ou seja, as outras 38 premissas reproduzem o publicado **sem folga nenhuma** sustentando o verde;
- **duas procedências dentro de uma célula** devolve `versoes_na_celula: 2`. Esse caso passava até a revisão de standards achar que o `git_sha` tinha entrado no `ANY_VALUE` mas não na chave de versão — a cobrança passava justamente no caso para o qual foi escrita.

## O carimbo, e o que ele custou

`odds_loaded_at` (o `dbt_loaded_at` do `fact_odds_snapshot` que cada célula leu) virou **coluna** da acumulativa em vez de leitura ao vivo: lido ao vivo o veredito decai — qualquer rebuild posterior deixaria a guarda vermelha sem que as células deixassem de ser comparáveis.

O preço é o que a #54 já tinha documentado: drop + re-medir as quatro. Feito, e **a re-medição reproduz a #54 em 7.195 de 7.200 campos**; os 5 restantes são empates exatos de arredondamento (51/400 = 12,75; 308/320 = 96,25; 492/48 = 10,25). Reconciliação segue 38 EXATO / 1 INVESTIGAR; saturação, piso, monotonicidade e chaves seguem OK.

Desta vez a comparação **é re-derivável**: `analyses/taskf_remedicao.sql` contra `taskf_teste2_54`, declarada em `sources.yml` — a lição que a #54 deixou escrita depois de tratar a própria cópia como rascunho.

## O que as guardas NÃO alcançam

Dito aqui e no doc antes que alguém descubra do jeito caro: re-medir uma célula depois, sobre fatos intocados e do mesmo commit, sai **verde por desenho** — "mesma execução" é *mesma construção dos fatos*, e as quatro células são sempre quatro `dbt build`. O que escapa é a deriva de reconstrução dos modelos (os tais 5 campos em 7.200), indistinguível de um efeito real de 0,1 pp. Quem quiser essa diferença mede com `taskf_remedicao.sql`.

## Nada disso roda no agendado

Tags `taskf`/`costura_b`; o pipeline horário executa `tag:guarda`, que segue com 16 testes. O dataset `futebol_taskF` produção não lê.

## Depende do #68

Traz o mesmo fix do `task01_base()` (as 12 análises não compilam em master sem ele). Se o #68 mergear antes, o patch é idêntico e o merge resolve sozinho.

→ Números completos em `docs/TASKF_RESULTADOS.md`, seção do ticket #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
