### PR TITLE
[F-7] Reconciliação do diagnóstico de 180 dias: 15 dos 16 campos exatos

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -339,3 +339,12 @@ How a competition labels its seasons: *ano-calendário* (Brasileirão, Série B,
 Mundo) or *split-year* (the European leagues and the Champions, where season N means N/N+1). A
 team belongs to one family, and the family decides whether releasing escopo without releasing
 recorte does anything for it.
+
+**Diagnóstico de 180 dias**:
+The four-row table that opens the [F] source ticket — prior fixtures per team in Copa do Brasil,
+Sudamericana, Copa do Mundo and Champions. Reproduced from `fact_fixtures` in
+`analyses/taskf_reconciliacao_180d.sql`, 15 of its 16 fields exactly.
+⚠️ Its first two columns do **not** count the same stretch of the past: column 1 is the team's
+whole history in that competition, every season, unbounded; column 2 is every competition but only
+180 days back. That is why the Champions row reads 4,0 against 1,0, which no common window could
+produce — and why the two columns must never be compared to each other.

--- a/dbt_futebol/analyses/taskf_partida_da_fronteira.sql
+++ b/dbt_futebol/analyses/taskf_partida_da_fronteira.sql
@@ -1,0 +1,79 @@
+{#
+    [F-7] A PARTIDA QUE PRODUZ A ÚNICA DIVERGÊNCIA da reconciliação, nomeada.
+
+    A `taskf_reconciliacao_180d.sql` reproduz 15 dos 16 campos da tabela do ticket. O décimo sexto
+    — "Copa do Brasil, jogos em tudo em 180 dias" — sai 25,6 contra os 25,5 publicados, e a
+    diferença inteira é UMA partida contada a mais (409 contra 408, em 16 pares).
+
+    Esta análise mostra qual. Ela lista todo par (jogo-âncora, partida do histórico) em que as
+    duas réguas de fronteira discordam: a inclusiva por instante, que a reconciliação usa, e a
+    estrita por data, que devolve o número publicado. Discordar aqui é o mesmo que estar na
+    fronteira — a partida entra numa contagem e não na outra.
+
+    Existe porque a explicação da divergência é o entregável da #56 ("qualquer divergência é
+    explicada, não silenciada"), e uma explicação que só existe na prosa do doc não é conferível.
+    Duas linhas na saída — uma por régua discordante em cada sentido — e o `distancia_da_fronteira`
+    diz de quanto: hoje, meia hora.
+
+    Mesmo corte e mesmas âncoras da reconciliação (`taskf_universo()`, âncoras `FT`), pelo mesmo
+    motivo: uma partida de fronteira medida sobre outro conjunto de âncoras não é a partida que
+    produziu o resíduo.
+
+    Rodar com:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target dev --select taskf_partida_da_fronteira
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_partida_da_fronteira.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+#}
+
+WITH lados AS (
+    -- `mandante`/`visitante` seguem o jogo, e não o lado da linha: a partida sai impressa na
+    -- ordem em que foi disputada, não na ordem em que o UNION a produziu.
+    SELECT fixture_id, competition, competition_id, kickoff_utc, status_short,
+           home_team_id AS team_id, home_team_name AS team_name,
+           home_team_name AS mandante, away_team_name AS visitante
+    FROM {{ ref('fact_fixtures') }}
+    UNION ALL
+    SELECT fixture_id, competition, competition_id, kickoff_utc, status_short,
+           away_team_id, away_team_name,
+           home_team_name, away_team_name
+    FROM {{ ref('fact_fixtures') }}
+),
+
+ancoras AS (
+    SELECT * FROM lados l
+    WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
+)
+
+SELECT
+    a.competition                                        AS competicao_da_ancora,
+    a.fixture_id                                         AS ancora_fixture_id,
+    a.team_name                                          AS time,
+    FORMAT_TIMESTAMP('%F %H:%M', a.kickoff_utc)          AS ancora_kickoff_utc,
+    FORMAT_TIMESTAMP('%F %H:%M',
+        TIMESTAMP_SUB(a.kickoff_utc, INTERVAL 180 DAY))  AS fronteira_utc,
+
+    h.fixture_id                                         AS partida_fixture_id,
+    h.competition                                        AS partida_competicao,
+    h.mandante || ' × ' || h.visitante                   AS partida,
+    FORMAT_TIMESTAMP('%F %H:%M', h.kickoff_utc)          AS partida_kickoff_utc,
+
+    -- De quanto ela está dentro (positivo) ou fora (negativo) da fronteira por instante.
+    TIMESTAMP_DIFF(h.kickoff_utc,
+        TIMESTAMP_SUB(a.kickoff_utc, INTERVAL 180 DAY), MINUTE) AS distancia_da_fronteira_min,
+
+    -- Qual régua conta esta partida. As duas colunas discordam por construção: só aparecem aqui
+    -- as linhas em que discordam.
+    h.kickoff_utc >= TIMESTAMP_SUB(a.kickoff_utc, INTERVAL 180 DAY)          AS conta_por_instante,
+    DATE(h.kickoff_utc) >  DATE_SUB(DATE(a.kickoff_utc), INTERVAL 180 DAY)   AS conta_por_data_estrita
+
+FROM ancoras a
+JOIN lados h
+    ON  h.team_id        = a.team_id
+    AND h.kickoff_utc    < a.kickoff_utc
+    AND h.status_short   = 'FT'
+WHERE (h.kickoff_utc >= TIMESTAMP_SUB(a.kickoff_utc, INTERVAL 180 DAY))
+   != (DATE(h.kickoff_utc) > DATE_SUB(DATE(a.kickoff_utc), INTERVAL 180 DAY))
+ORDER BY a.kickoff_utc, h.kickoff_utc

--- a/dbt_futebol/analyses/taskf_partida_da_fronteira.sql
+++ b/dbt_futebol/analyses/taskf_partida_da_fronteira.sql
@@ -50,6 +50,7 @@ ancoras AS (
 SELECT
     a.competition                                        AS competicao_da_ancora,
     a.fixture_id                                         AS ancora_fixture_id,
+    a.mandante || ' × ' || a.visitante                   AS ancora_partida,
     a.team_name                                          AS time,
     FORMAT_TIMESTAMP('%F %H:%M', a.kickoff_utc)          AS ancora_kickoff_utc,
     FORMAT_TIMESTAMP('%F %H:%M',

--- a/dbt_futebol/analyses/taskf_reconciliacao_180d.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_180d.sql
@@ -13,8 +13,8 @@
     existe para conferir a máquina, e uma conferência que passasse pela máquina conferida não
     conferiria coisa alguma. A duplicação do idioma `team_log` é deliberada.
 
-    ⚠️ AS DUAS COLUNAS DO TICKET NÃO TÊM O MESMO RECORTE DE TEMPO — e é isso que explica a linha
-    da Champions. "Jogos na própria competição" conta o histórico INTEIRO do time naquela
+    ⚠️ AS DUAS COLUNAS DO TICKET NÃO CONTAM O MESMO TRECHO DO PASSADO — e é isso que explica a
+    linha da Champions. "Jogos na própria competição" conta o histórico INTEIRO do time naquela
     competição, todas as temporadas, sem limite de tempo; "Jogos em tudo, 180 dias" conta todas as
     competições mas só nos 180 dias anteriores ao jogo. Sob um recorte comum, `tudo` ⊇ `própria` e
     a segunda coluna nunca poderia ser MENOR que a primeira — mas a Champions aparece com 4,0 e
@@ -24,42 +24,60 @@
     sustenta é comparar os dois números entre si.
 
     A UNIDADE É O PAR (jogo, time), não o time distinto. O cabeçalho do ticket diz "times com < 5
-    jogos", mas um time entra na conta uma vez por jogo que disputa no recorte, e é assim que a
-    reprodução fecha. Medido dos dois jeitos: por time distinto a Champions vai a 74% e a Copa do
-    Mundo a 100%, e a tabela deixa de reproduzir.
+    jogos", mas um time entra na conta uma vez por jogo que disputa, e é assim que a reprodução
+    fecha. A variante `F` mede o outro jeito, e lá só 5 dos 16 campos continuam batendo.
 
-    AS ÂNCORAS SÃO SÓ OS JOGOS ENCERRADOS do recorte congelado. O ticket diz "contando só partidas
+    AS ÂNCORAS SÃO SÓ OS JOGOS ENCERRADOS do corte congelado. O ticket diz "contando só partidas
     encerradas" a respeito do que é contado; aplicar a mesma régua ao jogo-âncora é o que faz a
     Copa do Mundo sair 2,0/96% em vez de 2,1/94% — os 9 jogos de mata-mata decididos na
     prorrogação ou nos pênaltis ficam de fora por não terem `status_short = 'FT'`.
 
-    O RECORTE DE TEMPO É O UNIVERSO CONGELADO (`taskf_universo()`), e o teto de 04/08 12:00 UTC
-    reproduz o instante em que o autor rodou: o ticket foi aberto às 22:52 UTC daquele dia, e
-    entre ~02:00 e 16:00 UTC não há jogo nenhum na base — qualquer instante do vão devolve o mesmo
-    conjunto. É o mesmo argumento de "instante, não dia" que a macro do universo já faz.
+    O CORTE DE TEMPO DAS ÂNCORAS É O UNIVERSO CONGELADO (`taskf_universo()`), e o teto de 04/08
+    12:00 UTC reproduz o instante em que o autor rodou: o ticket foi aberto às 22:52 UTC daquele
+    dia, e entre ~02:00 e 16:00 UTC não há jogo nenhum na base — qualquer instante do vão devolve
+    o mesmo conjunto. É o mesmo argumento de "instante, não dia" que a macro do universo já faz.
 
-    ⚠️ Mas aqui o recorte é aplicado a `fact_fixtures`, e NÃO ao universo de 169 jogos das
-    células. São dois conjuntos diferentes de propósito: as células medem jogo liquidado COM preço
-    nos 5 mercados do Motor, e a Champions não tem um único jogo lá dentro (a #53 mediu isso). A
-    tabela do ticket é sobre jogos, não sobre apostas — por isso a Champions aparece nesta análise
-    e não nas células, e por isso o `jogos_esperados = 169` da macro não se aplica a nada aqui.
+    ⚠️ Mas aqui o corte é aplicado a `fact_fixtures`, e NÃO ao universo de 169 jogos das células.
+    São dois conjuntos diferentes de propósito: as células medem jogo liquidado COM preço nos 5
+    mercados do Motor, e a Champions não tem um único jogo lá dentro (a #51 mediu isso). A tabela
+    do ticket é sobre jogos, não sobre apostas — por isso a Champions aparece nesta análise e não
+    nas células, e por isso o `jogos_esperados = 169` da macro não se aplica a nada aqui.
 
-    AS QUATRO VARIANTES, e o que cada uma isola:
+    AS SETE VARIANTES, e o que cada uma troca. Cada uma mexe em UMA coisa em relação à `A`, para
+    que a diferença que ela produzir seja atribuível — é a mesma disciplina das variantes do
+    taskf_universo_congelado.sql. Uma variante que mexesse em duas mediria a soma dos dois efeitos
+    e não serviria de falsificação de nenhum dos dois:
 
-      A_ticket              a receita acima. É a que reproduz.
-      B_fronteira_por_data  igual à A, com a fronteira dos 180 dias contada em DATA e não em
-                            instante. Existe porque a única divergência da tabela inteira mora
-                            nela — ver a seção do ticket #56 em docs/TASKF_RESULTADOS.md.
-      C_encerradas_literal  "partidas encerradas" ao pé da letra: AET e PEN entram, como âncora e
-                            como histórico. Não reproduz, e o desvio é o tamanho do que o
-                            pipeline joga fora ao filtrar `status_short = 'FT'`.
-      D_como_o_pit_conta    a contagem que o PIT de produção realmente faz: mesma competição E
-                            mesma temporada de um lado, todas as competições da mesma temporada
-                            do outro. É a ponte entre esta reconciliação e as células — mostra que
-                            a coluna 1 do ticket não é o que produção conta.
+      A_ticket                        a receita acima. É a que reproduz.
+      B_fronteira_estrita_por_data    a fronteira dos 180 dias em data e ESTRITA (`>`). A única
+                                      divergência da tabela inteira mora aqui.
+      C_fronteira_inclusiva_por_data  a fronteira em data e INCLUSIVA (`>=`). Existe para provar
+                                      que a granularidade não é a alavanca: `C` devolve os mesmos
+                                      números da `A`, campo a campo. O que exclui a partida da
+                                      fronteira é a ESTRITEZA da `B`, não o fato de ser data.
+      D_ancoras_com_pen_aet           AET e PEN entram como ÂNCORA, e só como âncora. Falsifica o
+                                      terceiro pedaço da receita: é o que a Copa do Mundo vira se
+                                      o jogo-âncora não precisar ser `FT`.
+      E_historico_com_pen_aet         AET e PEN entram no HISTÓRICO, e só nele. Mede o tamanho do
+                                      que o `team_log` de todo o pipeline joga fora ao filtrar
+                                      `status_short = 'FT'` — jogo decidido nos pênaltis não é
+                                      `FT`, e nas copas de mata-mata isso não é resíduo.
+      F_como_o_pit_conta              a contagem que o PIT de produção realmente faz: mesma
+                                      competição E mesma temporada de um lado, todas as
+                                      competições da mesma temporada do outro. É a ponte entre
+                                      esta reconciliação e as células — mostra que a coluna 1 do
+                                      ticket não é o que produção conta.
+      G_por_time_distinto             a contagem da `A` com o time distinto no lugar do par
+                                      (jogo, time). A unidade é um dos quatro pedaços da receita,
+                                      e pedaço não medido é pedaço afirmado.
 
-    Só a A tem gabarito para bater. As outras três são medidas contra o MESMO gabarito de
+    A leitura literal de "partidas encerradas" — AET e PEN dos DOIS lados ao mesmo tempo — é a
+    composição de `D` com `E`, e não tem variante própria justamente porque mexeria em duas coisas.
+
+    Só a `A` tem gabarito para bater. As outras seis são medidas contra o MESMO gabarito de
     propósito: a divergência delas é o número que explica por que a receita é a que é.
+
+    A partida que produz a única divergência sai nomeada em analyses/taskf_partida_da_fronteira.sql.
 
     Rodar com (o target é indiferente — `fact_fixtures` é a mesma tabela de produção nos dois, e
     esta análise não lê nada do dataset de medição):
@@ -84,16 +102,22 @@ WITH lados AS (
 ),
 
 ancoras AS (
-    SELECT 'A_ticket'             AS variante, l.* FROM lados l
+    SELECT 'A_ticket'                       AS variante, l.* FROM lados l
     WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
     UNION ALL
-    SELECT 'B_fronteira_por_data', l.* FROM lados l
+    SELECT 'B_fronteira_estrita_por_data',   l.* FROM lados l
     WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
     UNION ALL
-    SELECT 'C_encerradas_literal', l.* FROM lados l
+    SELECT 'C_fronteira_inclusiva_por_data', l.* FROM lados l
+    WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
+    UNION ALL
+    SELECT 'D_ancoras_com_pen_aet',          l.* FROM lados l
     WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short IN ('FT', 'AET', 'PEN')
     UNION ALL
-    SELECT 'D_como_o_pit_conta',   l.* FROM lados l
+    SELECT 'E_historico_com_pen_aet',        l.* FROM lados l
+    WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
+    UNION ALL
+    SELECT 'F_como_o_pit_conta',             l.* FROM lados l
     WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
 ),
 
@@ -105,20 +129,22 @@ pares AS (
         a.team_id,
 
         -- COLUNA 1 DO TICKET — "jogos na própria competição". Sem limite de tempo e sem limite de
-        -- temporada em A/B/C; a temporada só entra na D, que é como o PIT conta.
+        -- temporada em todas as variantes menos a F, que é como o PIT conta.
         COUNTIF(
             l.competition_id = a.competition_id
-            AND (a.variante != 'D_como_o_pit_conta' OR l.season = a.season)
+            AND (a.variante != 'F_como_o_pit_conta' OR l.season = a.season)
         ) AS propria,
 
         -- COLUNA 2 DO TICKET — "jogos em tudo, 180 dias". Qualquer competição do time. A
-        -- fronteira dos 180 dias é o que separa A de B; na D não há fronteira de dias, e sim a
+        -- fronteira dos 180 dias é o que separa A, B e C; na F não há fronteira de dias, e sim a
         -- temporada corrente, porque é essa a contagem que a célula `escopo` usa.
         COUNTIF(
             CASE a.variante
-                WHEN 'B_fronteira_por_data' THEN
-                    DATE(l.kickoff_utc) > DATE_SUB(DATE(a.kickoff_utc), INTERVAL 180 DAY)
-                WHEN 'D_como_o_pit_conta' THEN
+                WHEN 'B_fronteira_estrita_por_data' THEN
+                    DATE(l.kickoff_utc) >  DATE_SUB(DATE(a.kickoff_utc), INTERVAL 180 DAY)
+                WHEN 'C_fronteira_inclusiva_por_data' THEN
+                    DATE(l.kickoff_utc) >= DATE_SUB(DATE(a.kickoff_utc), INTERVAL 180 DAY)
+                WHEN 'F_como_o_pit_conta' THEN
                     l.season = a.season
                 ELSE
                     l.kickoff_utc >= TIMESTAMP_SUB(a.kickoff_utc, INTERVAL 180 DAY)
@@ -129,10 +155,28 @@ pares AS (
     LEFT JOIN lados l
         ON  l.team_id     = a.team_id
         AND l.kickoff_utc < a.kickoff_utc
-        -- O histórico segue a mesma régua de encerramento da âncora: AET e PEN só contam na C.
+        -- O histórico é `FT` em todas as variantes menos a E, onde AET e PEN entram — e entram
+        -- SÓ aqui: a régua da âncora é outra linha, na CTE acima, e é a D que a solta.
         AND (l.status_short = 'FT'
-             OR (a.variante = 'C_encerradas_literal' AND l.status_short IN ('AET', 'PEN')))
+             OR (a.variante = 'E_historico_com_pen_aet' AND l.status_short IN ('AET', 'PEN')))
     GROUP BY 1, 2, 3, 4
+),
+
+-- A variante G: a MESMA contagem da A, com a unidade trocada. Um time que joga três vezes no
+-- corte entra uma vez só, com a média das suas três contagens.
+por_time AS (
+    SELECT p.competition, p.team_id,
+           AVG(p.propria) AS propria,
+           AVG(p.tudo)    AS tudo
+    FROM pares p
+    WHERE p.variante = 'A_ticket'
+    GROUP BY 1, 2
+),
+jogos_ancora AS (
+    SELECT competition, COUNT(DISTINCT fixture_id) AS jogos
+    FROM pares
+    WHERE variante = 'A_ticket'
+    GROUP BY 1
 ),
 
 -- O GABARITO: os 16 números publicados no ticket, digitados. Ficam aqui, e não na prosa do doc,
@@ -151,8 +195,8 @@ medido AS (
     SELECT
         p.variante,
         p.competition,
-        COUNT(*)                                            AS pares,
         COUNT(DISTINCT p.fixture_id)                        AS jogos,
+        COUNT(*)                                            AS unidades,
         ROUND(AVG(p.propria), 1)                            AS propria,
         ROUND(AVG(p.tudo), 1)                               AS tudo,
         ROUND(100 * COUNTIF(p.propria < 5) / COUNT(*))      AS p5_propria,
@@ -164,13 +208,32 @@ medido AS (
         SUM(p.tudo)                                         AS soma_tudo
     FROM pares p
     GROUP BY 1, 2
+
+    UNION ALL
+
+    SELECT
+        'G_por_time_distinto',
+        t.competition,
+        j.jogos,
+        COUNT(*),
+        ROUND(AVG(t.propria), 1),
+        ROUND(AVG(t.tudo), 1),
+        ROUND(100 * COUNTIF(t.propria < 5) / COUNT(*)),
+        ROUND(100 * COUNTIF(t.tudo    < 5) / COUNT(*)),
+        -- Soma bruta não existe nesta unidade: somar média de time não conta partida nenhuma.
+        CAST(NULL AS INT64),
+        CAST(NULL AS INT64)
+    FROM por_time t
+    JOIN jogos_ancora j USING (competition)
+    GROUP BY 1, 2, 3
 )
 
 SELECT
     m.variante,
     m.competition                          AS competicao,
     m.jogos,
-    m.pares,
+    -- O denominador da variante: par (jogo, time) em A–F, time distinto na G.
+    m.unidades,
 
     m.propria,      g.propria_tkt,    ROUND(m.propria - g.propria_tkt, 1)  AS d_propria,
     m.tudo,         g.tudo_tkt,       ROUND(m.tudo    - g.tudo_tkt,    1)  AS d_tudo,
@@ -180,14 +243,14 @@ SELECT
     m.soma_propria,
     m.soma_tudo,
 
-    -- Quantas das quatro células da linha bateram. A tolerância é meia casa da última casa
+    -- Quantos dos quatro campos da linha bateram. A tolerância é meia casa da última casa
     -- publicada — não é folga para acomodar divergência, é o que separa igualdade de ruído de
     -- ponto flutuante depois do ROUND.
     CAST(ABS(m.propria    - g.propria_tkt)    < 0.05 AS INT64)
   + CAST(ABS(m.tudo       - g.tudo_tkt)       < 0.05 AS INT64)
   + CAST(ABS(m.p5_propria - g.p5_propria_tkt) < 0.5  AS INT64)
-  + CAST(ABS(m.p5_tudo    - g.p5_tudo_tkt)    < 0.5  AS INT64) AS celulas_exatas
+  + CAST(ABS(m.p5_tudo    - g.p5_tudo_tkt)    < 0.5  AS INT64) AS campos_exatos
 
 FROM medido m
 JOIN gabarito g USING (competition)
-ORDER BY m.variante, m.pares DESC
+ORDER BY m.variante, m.unidades DESC

--- a/dbt_futebol/analyses/taskf_reconciliacao_180d.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_180d.sql
@@ -1,0 +1,193 @@
+{#
+    [F-7] A TABELA DE DIAGNÓSTICO DE 180 DIAS DO TICKET, reproduzida da nossa base.
+
+    O ticket de origem (ClickUp `wdx6zevnhy`, transcrito na issue #49) abre com uma tabela de
+    quatro linhas — Copa do Brasil, Sudamericana, Copa do Mundo e Champions — e é dela que sai a
+    tese inteira: "a escassez é artefato de escopo". Tudo o que as quatro células mediram depois
+    se apoia nessa leitura. Se os 25,5 jogos da Copa do Brasil não saem da nossa base, nada do
+    que veio depois merece crédito; se saem, o autor tem motivo para confiar no resto dos números.
+
+    Esta análise NÃO LÊ CÉLULA NENHUMA — nem `int_futebol_team_form_pit`, nem a camada de
+    premissas, nem `task01_base()`. Ela desce até `fact_fixtures` e reconstrói a contagem de
+    partidas anteriores por conta própria, e isso é critério de aceite (#56): a reconciliação
+    existe para conferir a máquina, e uma conferência que passasse pela máquina conferida não
+    conferiria coisa alguma. A duplicação do idioma `team_log` é deliberada.
+
+    ⚠️ AS DUAS COLUNAS DO TICKET NÃO TÊM O MESMO RECORTE DE TEMPO — e é isso que explica a linha
+    da Champions. "Jogos na própria competição" conta o histórico INTEIRO do time naquela
+    competição, todas as temporadas, sem limite de tempo; "Jogos em tudo, 180 dias" conta todas as
+    competições mas só nos 180 dias anteriores ao jogo. Sob um recorte comum, `tudo` ⊇ `própria` e
+    a segunda coluna nunca poderia ser MENOR que a primeira — mas a Champions aparece com 4,0 e
+    1,0. Não é erro de medição do autor nem falha de reprodução nossa: são dois recortes
+    diferentes, e a inversão é a assinatura disso. A leitura que o ticket tira dali ("é pior do
+    que a conta por competição sugere") continua de pé pelo lado do 1,0, que é real; o que não se
+    sustenta é comparar os dois números entre si.
+
+    A UNIDADE É O PAR (jogo, time), não o time distinto. O cabeçalho do ticket diz "times com < 5
+    jogos", mas um time entra na conta uma vez por jogo que disputa no recorte, e é assim que a
+    reprodução fecha. Medido dos dois jeitos: por time distinto a Champions vai a 74% e a Copa do
+    Mundo a 100%, e a tabela deixa de reproduzir.
+
+    AS ÂNCORAS SÃO SÓ OS JOGOS ENCERRADOS do recorte congelado. O ticket diz "contando só partidas
+    encerradas" a respeito do que é contado; aplicar a mesma régua ao jogo-âncora é o que faz a
+    Copa do Mundo sair 2,0/96% em vez de 2,1/94% — os 9 jogos de mata-mata decididos na
+    prorrogação ou nos pênaltis ficam de fora por não terem `status_short = 'FT'`.
+
+    O RECORTE DE TEMPO É O UNIVERSO CONGELADO (`taskf_universo()`), e o teto de 04/08 12:00 UTC
+    reproduz o instante em que o autor rodou: o ticket foi aberto às 22:52 UTC daquele dia, e
+    entre ~02:00 e 16:00 UTC não há jogo nenhum na base — qualquer instante do vão devolve o mesmo
+    conjunto. É o mesmo argumento de "instante, não dia" que a macro do universo já faz.
+
+    ⚠️ Mas aqui o recorte é aplicado a `fact_fixtures`, e NÃO ao universo de 169 jogos das
+    células. São dois conjuntos diferentes de propósito: as células medem jogo liquidado COM preço
+    nos 5 mercados do Motor, e a Champions não tem um único jogo lá dentro (a #53 mediu isso). A
+    tabela do ticket é sobre jogos, não sobre apostas — por isso a Champions aparece nesta análise
+    e não nas células, e por isso o `jogos_esperados = 169` da macro não se aplica a nada aqui.
+
+    AS QUATRO VARIANTES, e o que cada uma isola:
+
+      A_ticket              a receita acima. É a que reproduz.
+      B_fronteira_por_data  igual à A, com a fronteira dos 180 dias contada em DATA e não em
+                            instante. Existe porque a única divergência da tabela inteira mora
+                            nela — ver a seção do ticket #56 em docs/TASKF_RESULTADOS.md.
+      C_encerradas_literal  "partidas encerradas" ao pé da letra: AET e PEN entram, como âncora e
+                            como histórico. Não reproduz, e o desvio é o tamanho do que o
+                            pipeline joga fora ao filtrar `status_short = 'FT'`.
+      D_como_o_pit_conta    a contagem que o PIT de produção realmente faz: mesma competição E
+                            mesma temporada de um lado, todas as competições da mesma temporada
+                            do outro. É a ponte entre esta reconciliação e as células — mostra que
+                            a coluna 1 do ticket não é o que produção conta.
+
+    Só a A tem gabarito para bater. As outras três são medidas contra o MESMO gabarito de
+    propósito: a divergência delas é o número que explica por que a receita é a que é.
+
+    Rodar com (o target é indiferente — `fact_fixtures` é a mesma tabela de produção nos dois, e
+    esta análise não lê nada do dataset de medição):
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target dev --select taskf_reconciliacao_180d
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_reconciliacao_180d.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+#}
+
+WITH lados AS (
+    -- Um par (jogo, time) por lado de cada jogo. Serve de âncora e de histórico ao mesmo tempo:
+    -- o que separa um do outro é o predicado de tempo lá embaixo, não a origem.
+    SELECT fixture_id, competition, competition_id, season, kickoff_utc, status_short,
+           home_team_id AS team_id
+    FROM {{ ref('fact_fixtures') }}
+    UNION ALL
+    SELECT fixture_id, competition, competition_id, season, kickoff_utc, status_short,
+           away_team_id
+    FROM {{ ref('fact_fixtures') }}
+),
+
+ancoras AS (
+    SELECT 'A_ticket'             AS variante, l.* FROM lados l
+    WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
+    UNION ALL
+    SELECT 'B_fronteira_por_data', l.* FROM lados l
+    WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
+    UNION ALL
+    SELECT 'C_encerradas_literal', l.* FROM lados l
+    WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short IN ('FT', 'AET', 'PEN')
+    UNION ALL
+    SELECT 'D_como_o_pit_conta',   l.* FROM lados l
+    WHERE {{ taskf_universo_filtro('l.') }} AND l.status_short = 'FT'
+),
+
+pares AS (
+    SELECT
+        a.variante,
+        a.competition,
+        a.fixture_id,
+        a.team_id,
+
+        -- COLUNA 1 DO TICKET — "jogos na própria competição". Sem limite de tempo e sem limite de
+        -- temporada em A/B/C; a temporada só entra na D, que é como o PIT conta.
+        COUNTIF(
+            l.competition_id = a.competition_id
+            AND (a.variante != 'D_como_o_pit_conta' OR l.season = a.season)
+        ) AS propria,
+
+        -- COLUNA 2 DO TICKET — "jogos em tudo, 180 dias". Qualquer competição do time. A
+        -- fronteira dos 180 dias é o que separa A de B; na D não há fronteira de dias, e sim a
+        -- temporada corrente, porque é essa a contagem que a célula `escopo` usa.
+        COUNTIF(
+            CASE a.variante
+                WHEN 'B_fronteira_por_data' THEN
+                    DATE(l.kickoff_utc) > DATE_SUB(DATE(a.kickoff_utc), INTERVAL 180 DAY)
+                WHEN 'D_como_o_pit_conta' THEN
+                    l.season = a.season
+                ELSE
+                    l.kickoff_utc >= TIMESTAMP_SUB(a.kickoff_utc, INTERVAL 180 DAY)
+            END
+        ) AS tudo
+
+    FROM ancoras a
+    LEFT JOIN lados l
+        ON  l.team_id     = a.team_id
+        AND l.kickoff_utc < a.kickoff_utc
+        -- O histórico segue a mesma régua de encerramento da âncora: AET e PEN só contam na C.
+        AND (l.status_short = 'FT'
+             OR (a.variante = 'C_encerradas_literal' AND l.status_short IN ('AET', 'PEN')))
+    GROUP BY 1, 2, 3, 4
+),
+
+-- O GABARITO: os 16 números publicados no ticket, digitados. Ficam aqui, e não na prosa do doc,
+-- para a divergência ser alta — quem rodar a análise vê o delta, não precisa conferir de olho.
+gabarito AS (
+    SELECT * FROM UNNEST([
+        STRUCT('copa_do_brasil'   AS competition, 10.2 AS propria_tkt, 25.5 AS tudo_tkt,
+                                    19 AS p5_propria_tkt, 0 AS p5_tudo_tkt),
+               ('sudamericana',     8.9, 12.5, 27,   0),
+               ('copa_mundo',       2.0,  2.0, 96,  96),
+               ('champions_league', 4.0,  1.0, 69, 100)
+    ])
+),
+
+medido AS (
+    SELECT
+        p.variante,
+        p.competition,
+        COUNT(*)                                            AS pares,
+        COUNT(DISTINCT p.fixture_id)                        AS jogos,
+        ROUND(AVG(p.propria), 1)                            AS propria,
+        ROUND(AVG(p.tudo), 1)                               AS tudo,
+        ROUND(100 * COUNTIF(p.propria < 5) / COUNT(*))      AS p5_propria,
+        ROUND(100 * COUNTIF(p.tudo    < 5) / COUNT(*))      AS p5_tudo,
+        -- As somas brutas saem junto porque são elas que tornam o resíduo legível: um delta de
+        -- 0,1 numa média de 16 pares é UMA partida a mais ou a menos, e a média arredondada não
+        -- deixa isso aparecer.
+        SUM(p.propria)                                      AS soma_propria,
+        SUM(p.tudo)                                         AS soma_tudo
+    FROM pares p
+    GROUP BY 1, 2
+)
+
+SELECT
+    m.variante,
+    m.competition                          AS competicao,
+    m.jogos,
+    m.pares,
+
+    m.propria,      g.propria_tkt,    ROUND(m.propria - g.propria_tkt, 1)  AS d_propria,
+    m.tudo,         g.tudo_tkt,       ROUND(m.tudo    - g.tudo_tkt,    1)  AS d_tudo,
+    m.p5_propria,   g.p5_propria_tkt, m.p5_propria - g.p5_propria_tkt      AS d_p5_propria,
+    m.p5_tudo,      g.p5_tudo_tkt,    m.p5_tudo    - g.p5_tudo_tkt         AS d_p5_tudo,
+
+    m.soma_propria,
+    m.soma_tudo,
+
+    -- Quantas das quatro células da linha bateram. A tolerância é meia casa da última casa
+    -- publicada — não é folga para acomodar divergência, é o que separa igualdade de ruído de
+    -- ponto flutuante depois do ROUND.
+    CAST(ABS(m.propria    - g.propria_tkt)    < 0.05 AS INT64)
+  + CAST(ABS(m.tudo       - g.tudo_tkt)       < 0.05 AS INT64)
+  + CAST(ABS(m.p5_propria - g.p5_propria_tkt) < 0.5  AS INT64)
+  + CAST(ABS(m.p5_tudo    - g.p5_tudo_tkt)    < 0.5  AS INT64) AS celulas_exatas
+
+FROM medido m
+JOIN gabarito g USING (competition)
+ORDER BY m.variante, m.pares DESC

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1147,3 +1147,207 @@ DBT_PROFILES_DIR=.. ../.venv/bin/dbt test --target taskF \
 
 Os quatro `dbt build` fecham **43/43** (`base`, incluindo a Costura A) e **42/42** (as outras
 três), com `ERROR=0` e `SKIP=0` — iguais aos da #54.
+
+---
+
+## Ticket #56 — A reconciliação do diagnóstico de 180 dias
+
+`analyses/taskf_reconciliacao_180d.sql` · execução 2026-08-13 12:45 UTC · commit `de6ae05` ·
+dataset `futebol` (produção)
+
+A tabela de quatro linhas que abre o ticket de origem — a que diz que o time de Copa do Brasil tem
+10,2 jogos na própria competição e 25,5 contando tudo — reproduzida da nossa base. É o que dá ao
+autor motivo para confiar no resto dos números: se os 25,5 não saem, nada do que as células
+mediram depois merece crédito.
+
+Esta é a única seção da [F] que não encosta no dataset de medição. A análise desce até
+`fact_fixtures` e refaz a contagem de partidas anteriores por conta própria — não passa pelo
+`int_futebol_team_form_pit`, nem pela camada de premissas, nem pelo `task01_base()`. Era critério
+de aceite da #56, e o motivo é direto: uma conferência que passasse pela máquina conferida não
+conferiria coisa alguma.
+
+### Veredito
+
+**15 das 16 células da tabela do ticket reproduzem EXATAMENTE**, por uma receita só, nas quatro
+competições. A décima sexta diverge em 0,1 jogo, e a divergência tem nome, sobrenome e horário:
+uma partida que cai **30 minutos** dentro da fronteira dos 180 dias.
+
+O diagnóstico do ticket está certo, e as três leituras que ele tira da tabela se sustentam. Mas a
+tabela tem uma armadilha de construção que o próprio ticket não viu, e ela muda o que a linha da
+Champions significa: **as duas primeiras colunas não têm o mesmo recorte de tempo**.
+
+### A tabela do ticket, reproduzida
+
+Variante `A_ticket`. Cada célula sai como `medido / ticket`.
+
+| competição | jogos-âncora | pares | jogos na própria competição | jogos em tudo, 180 dias | % com < 5 na competição | % com < 5 contando tudo |
+|---|---|---|---|---|---|---|
+| Copa do Brasil | 8 | 16 | **10,2** / 10,2 | **25,6** / 25,5 ⚠️ | **19%** / 19% | **0%** / 0% |
+| Sudamericana | 15 | 30 | **8,9** / 8,9 | **12,5** / 12,5 | **27%** / 27% | **0%** / 0% |
+| Copa do Mundo | 80 | 160 | **2,0** / 2,0 | **2,0** / 2,0 | **96%** / 96% | **96%** / 96% |
+| Champions | 51 | 102 | **4,0** / 4,0 | **1,0** / 1,0 | **69%** / 69% | **100%** / 100% |
+
+### A receita, e o que cada pedaço dela vale
+
+Nenhum dos quatro pedaços é escolha de gosto: trocar qualquer um deles quebra a reprodução, e o
+número que ele passa a dar está medido nas variantes.
+
+- **O recorte de tempo é o universo congelado** (`taskf_universo()`), com o teto no instante de
+  04/08 12:00 UTC. O ticket foi aberto às **22:52 UTC** daquele dia; entre ~02:00 e 16:00 UTC não
+  há jogo nenhum na base, então qualquer instante do vão devolve o mesmo conjunto. É o mesmo
+  argumento de "instante, não dia" que o universo congelado já fazia para os 169 jogos.
+- **As âncoras são só os jogos ENCERRADOS**, `status_short = 'FT'`. Sem isso a Copa do Mundo sai
+  2,1 e 94% em vez de 2,0 e 96% — os 9 jogos de mata-mata decididos na prorrogação ou nos pênaltis
+  entram como âncora e puxam a conta.
+- **A unidade é o par (jogo, time)**, não o time distinto. O cabeçalho do ticket diz "times com <
+  5 jogos", mas um time entra uma vez por jogo que disputa. Por time distinto a Champions vai a
+  74% e a Copa do Mundo a 100%, e só **5 das 16 células** continuam batendo.
+- **As duas colunas usam recortes diferentes** — ver abaixo. É o pedaço que não se adivinha.
+
+⚠️ O recorte é aplicado a `fact_fixtures`, e **não** ao universo de 169 jogos das células. São
+conjuntos diferentes de propósito: as células medem jogo liquidado COM preço nos 5 mercados do
+Motor, e a Champions não tem um único jogo lá dentro (a #51 mediu isso). A tabela do ticket é
+sobre jogos, não sobre apostas — é por isso que a Champions pode ser diagnosticada aqui e não pôde
+ser medida nas células, e é por isso que o `jogos_esperados = 169` não se aplica a nada nesta
+seção. Nas duas copas os conjuntos coincidem (8 e 15 jogos, os mesmos das células); na Copa do
+Mundo são 80 âncoras contra 79 jogos medidos.
+
+### ⚠️ As duas colunas do ticket não têm o mesmo recorte — e a Champions é a prova
+
+"Jogos na própria competição" conta o histórico **inteiro** do time naquela competição, todas as
+temporadas, sem limite de tempo. "Jogos em tudo, 180 dias" conta todas as competições, mas só nos
+180 dias anteriores ao jogo.
+
+Sob um recorte comum, `tudo` ⊇ `própria` e a segunda coluna **nunca** poderia ser menor que a
+primeira. A linha da Champions tem 4,0 e 1,0. Não é erro de medição do autor nem falha de
+reprodução nossa: é a assinatura de dois recortes diferentes na mesma tabela, e a decomposição
+mostra onde a diferença mora. Os 102 pares contam **405** partidas de Champions no total, das
+quais **309 são de 2024 e 2025** — quase todas de fase qualificatória, e todas fora dos 180 dias.
+Dentro dos 180 dias sobram **101** partidas contando todas as competições, e **96 delas são as
+próprias qualificatórias de 2026**: o campeonato nacional daqueles times rende cinco partidas na
+base inteira. O 4,0 é histórico antigo da mesma competição; o 1,0 é o presente em tudo.
+
+Consequência para quem for ler a tabela de novo: **a leitura do ticket sobre a Champions se
+sustenta pelo lado do 1,0**, que é real e é o que interessa ("aqueles times têm 1 jogo na nossa
+base em 180 dias, porque não coletamos o campeonato nacional deles"). O que não se sustenta é a
+comparação dos dois números entre si — "é pior do que a conta por competição sugere" está certo
+pelo motivo errado, e a mesma frase aplicada às outras três linhas induziria a erro.
+
+### A única divergência: uma partida, 30 minutos dentro da fronteira
+
+Copa do Brasil, coluna "em tudo, 180 dias": medimos 25,6 e o ticket publicou 25,5. São 16 pares,
+então a média é uma fração de denominador 16 — e a diferença inteira é **409 partidas contadas
+contra 408**. Uma.
+
+Ela está identificada:
+
+| | |
+|---|---|
+| jogo-âncora | `1546843` — Atlético Paranaense × **Vitória**, Copa do Brasil, 04/08/2026 00:00 UTC |
+| fronteira dos 180 dias | 05/02/2026 **00:00** UTC |
+| partida na fronteira | `1492126` — Palmeiras × **Vitória**, Brasileirão 2026, 05/02/2026 **00:30** UTC |
+
+A partida cai meia hora dentro da fronteira. Contada em instante (`kickoff >= kickoff_âncora - 180
+dias`), ela entra e a média dá 25,6; contada em data (`DATE(kickoff) > DATE(âncora) - 180 dias`),
+ela sai e a média dá exatamente os 25,5 publicados. É a variante `B_fronteira_por_data`, e ela
+fecha **16 de 16**.
+
+⚠️ **A variante B não é a receita, e isto é deliberado.** Escolher a convenção que faz o último
+número bater é calibrar até o resultado sair — o oposto do que o universo congelado fez com o
+teto, onde a robustez veio de o vão de catorze horas devolver o mesmo conjunto. A convenção de
+instante é a que o resto da medição usa; ela fica, com o resíduo explicado. As outras quinze
+células são **insensíveis** à escolha: nenhuma delas se mexe entre A e B.
+
+### As variantes que não reproduzem, e o que cada uma mede
+
+| variante | células exatas | o que ela troca |
+|---|---|---|
+| `A_ticket` | **15 / 16** | a receita |
+| `B_fronteira_por_data` | 16 / 16 | a fronteira dos 180 dias em data, não em instante |
+| `C_encerradas_literal` | 5 / 16 | "partidas encerradas" ao pé da letra: AET e PEN entram |
+| `D_como_o_pit_conta` | 7 / 16 | a contagem que o PIT de produção realmente faz |
+
+### ⚠️ A coluna 1 do ticket é mais generosa que produção — o artefato é maior do que ele mediu
+
+A variante `D` responde uma pergunta que o ticket não faz: o que o Motor **de fato** enxerga.
+Produção escopa por competição **e temporada** (é o join do `int_futebol_team_form_pit`, e é a
+célula `base`), enquanto a coluna 1 do ticket conta todas as temporadas daquela competição.
+
+| competição | coluna 1 do ticket | o que o PIT conta | % < 5 no ticket | % < 5 no PIT |
+|---|---|---|---|---|
+| Copa do Brasil | 10,2 | **2,2** | 19% | **94%** |
+| Sudamericana | 8,9 | **3,5** | 27% | **50%** |
+| Champions | 4,0 | **0,9** | 69% | **100%** |
+| Copa do Mundo | 2,0 | 2,0 | 96% | 96% |
+
+O time de Copa do Brasil não é tratado como um time de 10,2 jogos: é tratado como um time de
+**2,2**. A tese do ticket sai reforçada, não enfraquecida — o vão entre o que o Motor usa (2,2) e
+o que existe (25,6 em 180 dias, 26,4 na temporada corrente contando tudo) é maior do que os
+10,2 → 25,5 da tabela publicada.
+
+A Copa do Mundo é a linha que **não muda em definição nenhuma**: 2,0 nas quatro colunas, 96% em
+todas. Para seleção não existe outra competição para emprestar nem outra temporada para contar. O
+deserto dela não é artefato de escopo, de recorte, de temporada ou de convenção de fronteira — é o
+dado.
+
+### O diagnóstico e as células dizem a mesma coisa
+
+O ticket previu, a partir desta tabela, que juntar o histórico recuperaria Copa do Brasil e
+Sudamericana inteiras. A célula `escopo` mediu exatamente isso na #53: o piso 5 sobe de 69 para 92
+jogos, e os 23 que cruzam são **as 15 partidas de Sudamericana e as 8 de Copa do Brasil** — as
+mesmas 15 e 8 âncoras que aparecem na tabela desta seção. Aqui, a coluna "% com < 5 contando tudo"
+dá **0% nas duas**, e a variante `D` mostra que a contagem que a célula `escopo` usa (todas as
+competições, temporada corrente) também dá 0% nas duas.
+
+A terceira leitura do ticket — "a Copa do Mundo é 47% da amostra de medição" — bate com os 46,7%
+(79 de 169) que a #53 mediu.
+
+### Observação de passagem: 142 partidas encerradas que não entram no histórico de ninguém
+
+A variante `C` foi construída para falsificar a leitura literal de "partidas encerradas", e mediu,
+de passagem, um efeito que não é da [F] mas fica registrado. O `team_log` de todo o pipeline
+filtra `status_short = 'FT'`, e jogo decidido na prorrogação (`AET`) ou nos pênaltis (`PEN`) não é
+`FT`:
+
+| competição | encerradas | fora do histórico (AET+PEN) | % |
+|---|---|---|---|
+| Copa do Brasil | 386 | 55 | **14,2%** |
+| Copa do Mundo | 104 | 9 | 8,7% |
+| Sudamericana | 446 | 30 | 6,7% |
+| Libertadores | 439 | 19 | 4,3% |
+| Champions | 636 | 26 | 4,1% |
+| **base inteira** | **8.094** | **142** | 1,8% |
+
+No agregado é 1,8% e ninguém veria; nas copas de mata-mata é uma partida em sete. Sob a contagem
+`C`, a média da Copa do Brasil na própria competição vai de 10,2 para **11,4**. Não é para mexer
+aqui — a #56 e a #49 proíbem mudar pipeline —, e a decisão de incluir ou não tem lado defensável
+nos dois sentidos (o placar de um jogo decidido nos pênaltis é empate, e é assim que ele entraria
+nas médias de gols). Fica como candidato a ticket próprio.
+
+### Por que esta seção não vira guarda
+
+As outras seções da [F] viraram invariante cobrada (#55). Esta não, e o motivo é o mesmo que
+justifica as outras: guarda que fica vermelha por trabalho alheio deixa de ser sinal.
+
+- A coluna 1 **não tem limite de tempo**. Backfill de temporada antiga — o passo padrão de todo
+  rollout de liga — move o número legitimamente.
+- O conjunto de âncoras é jogo `FT` dentro do corte, e há **4 jogos `PST` do Brasileirão** lá
+  dentro. Remarcação ou resultado ingerido depois muda âncora e histórico ao mesmo tempo.
+
+O gabarito de 16 números mora **dentro da análise**, com coluna de delta e um contador
+`celulas_exatas` por linha. Quem rodar vê a divergência sem conferir de olho, e nada fica vermelho
+em quem não pediu.
+
+### Reprodução
+
+```bash
+cd dbt_futebol
+
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target dev --select taskf_reconciliacao_180d
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_reconciliacao_180d.sql
+```
+
+O target é indiferente: `fact_fixtures` é a mesma tabela de produção em `dev`, `prod` e `taskF`, e
+esta análise não lê nada do dataset de medição. A saída são 16 linhas — quatro variantes × quatro
+competições —, e a soma de `celulas_exatas` na variante `A_ticket` é **15**.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1152,8 +1152,8 @@ três), com `ERROR=0` e `SKIP=0` — iguais aos da #54.
 
 ## Ticket #56 — A reconciliação do diagnóstico de 180 dias
 
-`analyses/taskf_reconciliacao_180d.sql` · execução 2026-08-13 12:45 UTC · commit `de6ae05` ·
-dataset `futebol` (produção)
+`analyses/taskf_reconciliacao_180d.sql` + `analyses/taskf_partida_da_fronteira.sql` · execução
+2026-08-13 13:13 UTC · commit `7651233` · dataset `futebol` (produção)
 
 A tabela de quatro linhas que abre o ticket de origem — a que diz que o time de Copa do Brasil tem
 10,2 jogos na própria competição e 25,5 contando tudo — reproduzida da nossa base. É o que dá ao
@@ -1168,17 +1168,17 @@ conferiria coisa alguma.
 
 ### Veredito
 
-**15 das 16 células da tabela do ticket reproduzem EXATAMENTE**, por uma receita só, nas quatro
-competições. A décima sexta diverge em 0,1 jogo, e a divergência tem nome, sobrenome e horário:
+**15 dos 16 campos da tabela do ticket reproduzem EXATAMENTE**, por uma receita só, nas quatro
+competições. O décimo sexto diverge em 0,1 jogo, e a divergência tem nome, sobrenome e horário:
 uma partida que cai **30 minutos** dentro da fronteira dos 180 dias.
 
 O diagnóstico do ticket está certo, e as três leituras que ele tira da tabela se sustentam. Mas a
 tabela tem uma armadilha de construção que o próprio ticket não viu, e ela muda o que a linha da
-Champions significa: **as duas primeiras colunas não têm o mesmo recorte de tempo**.
+Champions significa: **as duas primeiras colunas não contam o mesmo trecho do passado**.
 
 ### A tabela do ticket, reproduzida
 
-Variante `A_ticket`. Cada célula sai como `medido / ticket`.
+Variante `A_ticket`. Cada campo sai como `medido / ticket`.
 
 | competição | jogos-âncora | pares | jogos na própria competição | jogos em tudo, 180 dias | % com < 5 na competição | % com < 5 contando tudo |
 |---|---|---|---|---|---|---|
@@ -1192,19 +1192,20 @@ Variante `A_ticket`. Cada célula sai como `medido / ticket`.
 Nenhum dos quatro pedaços é escolha de gosto: trocar qualquer um deles quebra a reprodução, e o
 número que ele passa a dar está medido nas variantes.
 
-- **O recorte de tempo é o universo congelado** (`taskf_universo()`), com o teto no instante de
-  04/08 12:00 UTC. O ticket foi aberto às **22:52 UTC** daquele dia; entre ~02:00 e 16:00 UTC não
-  há jogo nenhum na base, então qualquer instante do vão devolve o mesmo conjunto. É o mesmo
-  argumento de "instante, não dia" que o universo congelado já fazia para os 169 jogos.
-- **As âncoras são só os jogos ENCERRADOS**, `status_short = 'FT'`. Sem isso a Copa do Mundo sai
-  2,1 e 94% em vez de 2,0 e 96% — os 9 jogos de mata-mata decididos na prorrogação ou nos pênaltis
-  entram como âncora e puxam a conta.
-- **A unidade é o par (jogo, time)**, não o time distinto. O cabeçalho do ticket diz "times com <
-  5 jogos", mas um time entra uma vez por jogo que disputa. Por time distinto a Champions vai a
-  74% e a Copa do Mundo a 100%, e só **5 das 16 células** continuam batendo.
-- **As duas colunas usam recortes diferentes** — ver abaixo. É o pedaço que não se adivinha.
+- **O corte de tempo das âncoras é o universo congelado** (`taskf_universo()`), com o teto no
+  instante de 04/08 12:00 UTC. O ticket foi aberto às **22:52 UTC** daquele dia; entre ~02:00 e
+  16:00 UTC não há jogo nenhum na base, então qualquer instante do vão devolve o mesmo conjunto.
+  É o mesmo argumento de "instante, não dia" que o universo congelado já fazia para os 169 jogos.
+- **As âncoras são só os jogos ENCERRADOS**, `status_short = 'FT'` (variante `D`). Sem isso a Copa
+  do Mundo sai 2,1 e 94% em vez de 2,0 e 96% — os 9 jogos de mata-mata decididos na prorrogação ou
+  nos pênaltis entram como âncora e puxam a conta.
+- **A unidade é o par (jogo, time)**, não o time distinto (variante `G`). O cabeçalho do ticket
+  diz "times com < 5 jogos", mas um time entra uma vez por jogo que disputa. Por time distinto a
+  Champions vai a 74% e a Copa do Mundo a 100%, e só **5 dos 16 campos** continuam batendo.
+- **As duas colunas contam trechos diferentes do passado** — ver abaixo. É o pedaço que não se
+  adivinha.
 
-⚠️ O recorte é aplicado a `fact_fixtures`, e **não** ao universo de 169 jogos das células. São
+⚠️ O corte é aplicado a `fact_fixtures`, e **não** ao universo de 169 jogos das células. São
 conjuntos diferentes de propósito: as células medem jogo liquidado COM preço nos 5 mercados do
 Motor, e a Champions não tem um único jogo lá dentro (a #51 mediu isso). A tabela do ticket é
 sobre jogos, não sobre apostas — é por isso que a Champions pode ser diagnosticada aqui e não pôde
@@ -1212,7 +1213,7 @@ ser medida nas células, e é por isso que o `jogos_esperados = 169` não se apl
 seção. Nas duas copas os conjuntos coincidem (8 e 15 jogos, os mesmos das células); na Copa do
 Mundo são 80 âncoras contra 79 jogos medidos.
 
-### ⚠️ As duas colunas do ticket não têm o mesmo recorte — e a Champions é a prova
+### ⚠️ As duas colunas do ticket não contam o mesmo passado — e a Champions é a prova
 
 "Jogos na própria competição" conta o histórico **inteiro** do time naquela competição, todas as
 temporadas, sem limite de tempo. "Jogos em tudo, 180 dias" conta todas as competições, mas só nos
@@ -1221,11 +1222,13 @@ temporadas, sem limite de tempo. "Jogos em tudo, 180 dias" conta todas as compet
 Sob um recorte comum, `tudo` ⊇ `própria` e a segunda coluna **nunca** poderia ser menor que a
 primeira. A linha da Champions tem 4,0 e 1,0. Não é erro de medição do autor nem falha de
 reprodução nossa: é a assinatura de dois recortes diferentes na mesma tabela, e a decomposição
-mostra onde a diferença mora. Os 102 pares contam **405** partidas de Champions no total, das
-quais **309 são de 2024 e 2025** — quase todas de fase qualificatória, e todas fora dos 180 dias.
-Dentro dos 180 dias sobram **101** partidas contando todas as competições, e **96 delas são as
-próprias qualificatórias de 2026**: o campeonato nacional daqueles times rende cinco partidas na
-base inteira. O 4,0 é histórico antigo da mesma competição; o 1,0 é o presente em tudo.
+mostra onde a diferença mora. Os 102 pares contam **405** partidas de Champions no total
+(`soma_propria` da `A`), das quais só **96 são da temporada corrente** (`soma_propria` da `F`, que
+escopa por temporada) — as outras 309 são de 2024 e 2025, e nenhuma delas cabe em 180 dias. Dentro
+dos 180 dias sobram **101** partidas contando todas as competições (`soma_tudo` da `A`), e 96
+delas são as mesmas partidas de Champions desta temporada: o campeonato nacional daqueles times
+rende **cinco** partidas na base inteira. O 4,0 é histórico antigo da mesma competição; o 1,0 é o
+presente em tudo.
 
 Consequência para quem for ler a tabela de novo: **a leitura do ticket sobre a Champions se
 sustenta pelo lado do 1,0**, que é real e é o que interessa ("aqueles times têm 1 jogo na nossa
@@ -1247,29 +1250,53 @@ Ela está identificada:
 | fronteira dos 180 dias | 05/02/2026 **00:00** UTC |
 | partida na fronteira | `1492126` — Palmeiras × **Vitória**, Brasileirão 2026, 05/02/2026 **00:30** UTC |
 
-A partida cai meia hora dentro da fronteira. Contada em instante (`kickoff >= kickoff_âncora - 180
-dias`), ela entra e a média dá 25,6; contada em data (`DATE(kickoff) > DATE(âncora) - 180 dias`),
-ela sai e a média dá exatamente os 25,5 publicados. É a variante `B_fronteira_por_data`, e ela
-fecha **16 de 16**.
+A identificação não é dedução: `analyses/taskf_partida_da_fronteira.sql` lista todo par (âncora,
+partida do histórico) em que as duas réguas discordam, sobre as mesmas âncoras da reconciliação.
+A saída tem **uma linha**, e é esta, com `distancia_da_fronteira_min = 30`.
 
-⚠️ **A variante B não é a receita, e isto é deliberado.** Escolher a convenção que faz o último
-número bater é calibrar até o resultado sair — o oposto do que o universo congelado fez com o
-teto, onde a robustez veio de o vão de catorze horas devolver o mesmo conjunto. A convenção de
-instante é a que o resto da medição usa; ela fica, com o resíduo explicado. As outras quinze
-células são **insensíveis** à escolha: nenhuma delas se mexe entre A e B.
+A partida cai meia hora dentro da fronteira — ela é a **marginal** sob qualquer régua de 180 dias,
+e é por isso que uma diferença de régua aparece nela e em mais nada.
 
-### As variantes que não reproduzem, e o que cada uma mede
+| régua da fronteira | conta a partida? | Copa do Brasil "em tudo" | campos exatos |
+|---|---|---|---|
+| `A` — instante, inclusiva (`kickoff >= âncora − 180 dias`) | sim | 25,6 (409) | 15 / 16 |
+| `C` — data, inclusiva (`DATE(l) >= DATE(a) − 180`) | sim | 25,6 (409) | 15 / 16 |
+| `B` — data, **estrita** (`DATE(l) > DATE(a) − 180`) | não | **25,5** (408) | 16 / 16 |
 
-| variante | células exatas | o que ela troca |
+⚠️ **Não é a granularidade, é a estriteza** — e isso está medido, não deduzido. Trocar instante por
+data sem mexer no sinal (`C`) devolve os mesmos números da `A`, campo a campo: a partida das 00:30
+continua dentro. Quem a exclui é o `>` da `B`, que descarta o dia inteiro da fronteira e por isso
+é até 24 horas mais apertada que a régua por instante.
+
+⚠️ **A `B` não é a receita, e isto é deliberado.** Ela não é a convenção alternativa natural — é a
+convenção *mais apertada*, e adotá-la porque o último número bate seria calibrar até o resultado
+sair, o oposto do que o universo congelado fez com o teto (lá a robustez veio de o vão de catorze
+horas devolver o mesmo conjunto). A fronteira inclusiva fica, com o resíduo explicado. Os outros
+quinze campos são **insensíveis** às três réguas: nenhum deles se mexe entre `A`, `B` e `C`.
+
+Não dá para saber, de fora, qual régua o autor usou — e não precisa: a divergência inteira é uma
+partida em 409.
+
+### As sete variantes, e o que cada uma troca
+
+Cada uma mexe em **uma** coisa em relação à `A`, para a diferença ser atribuível. Uma variante que
+mexesse em duas mediria a soma dos dois efeitos e não falsificaria nenhum — é por isso que a
+leitura literal de "partidas encerradas" (AET e PEN dos dois lados) não tem variante própria: ela é
+a composição de `D` com `E`.
+
+| variante | campos exatos | o que ela troca |
 |---|---|---|
 | `A_ticket` | **15 / 16** | a receita |
-| `B_fronteira_por_data` | 16 / 16 | a fronteira dos 180 dias em data, não em instante |
-| `C_encerradas_literal` | 5 / 16 | "partidas encerradas" ao pé da letra: AET e PEN entram |
-| `D_como_o_pit_conta` | 7 / 16 | a contagem que o PIT de produção realmente faz |
+| `B_fronteira_estrita_por_data` | 16 / 16 | a fronteira dos 180 dias em data e estrita (`>`) |
+| `C_fronteira_inclusiva_por_data` | 15 / 16 | a fronteira em data e inclusiva (`>=`) — igual à `A` |
+| `D_ancoras_com_pen_aet` | 7 / 16 | AET e PEN entram como âncora, e só como âncora |
+| `E_historico_com_pen_aet` | 8 / 16 | AET e PEN entram no histórico, e só nele |
+| `F_como_o_pit_conta` | 7 / 16 | a contagem que o PIT de produção realmente faz |
+| `G_por_time_distinto` | 5 / 16 | a unidade: time distinto no lugar do par (jogo, time) |
 
 ### ⚠️ A coluna 1 do ticket é mais generosa que produção — o artefato é maior do que ele mediu
 
-A variante `D` responde uma pergunta que o ticket não faz: o que o Motor **de fato** enxerga.
+A variante `F` responde uma pergunta que o ticket não faz: o que o Motor **de fato** enxerga.
 Produção escopa por competição **e temporada** (é o join do `int_futebol_team_form_pit`, e é a
 célula `base`), enquanto a coluna 1 do ticket conta todas as temporadas daquela competição.
 
@@ -1285,10 +1312,12 @@ O time de Copa do Brasil não é tratado como um time de 10,2 jogos: é tratado 
 o que existe (25,6 em 180 dias, 26,4 na temporada corrente contando tudo) é maior do que os
 10,2 → 25,5 da tabela publicada.
 
-A Copa do Mundo é a linha que **não muda em definição nenhuma**: 2,0 nas quatro colunas, 96% em
-todas. Para seleção não existe outra competição para emprestar nem outra temporada para contar. O
-deserto dela não é artefato de escopo, de recorte, de temporada ou de convenção de fronteira — é o
-dado.
+E a Copa do Mundo tem uma invariante própria, visível nas **sete** variantes: as duas colunas dela
+são sempre **iguais entre si** — 2,0 e 2,0 na `A`, 2,1 e 2,1 na `D`, 1,8 e 1,8 na `G`. Juntar
+competição não acrescenta nada porque não há outra competição, e mudar de temporada não acrescenta
+nada porque não há outra temporada. O deserto dela não é artefato de escopo, de recorte, de
+temporada nem de convenção de fronteira: é o dado. O que move a linha da Copa do Mundo é só quem
+entra na conta (âncora e unidade), e isso move todas as linhas.
 
 ### O diagnóstico e as células dizem a mesma coisa
 
@@ -1296,18 +1325,19 @@ O ticket previu, a partir desta tabela, que juntar o histórico recuperaria Copa
 Sudamericana inteiras. A célula `escopo` mediu exatamente isso na #53: o piso 5 sobe de 69 para 92
 jogos, e os 23 que cruzam são **as 15 partidas de Sudamericana e as 8 de Copa do Brasil** — as
 mesmas 15 e 8 âncoras que aparecem na tabela desta seção. Aqui, a coluna "% com < 5 contando tudo"
-dá **0% nas duas**, e a variante `D` mostra que a contagem que a célula `escopo` usa (todas as
+dá **0% nas duas**, e a variante `F` mostra que a contagem que a célula `escopo` usa (todas as
 competições, temporada corrente) também dá 0% nas duas.
 
 A terceira leitura do ticket — "a Copa do Mundo é 47% da amostra de medição" — bate com os 46,7%
-(79 de 169) que a #53 mediu.
+(79 de 169) que a #51 publicou na composição do universo congelado.
 
 ### Observação de passagem: 142 partidas encerradas que não entram no histórico de ninguém
 
-A variante `C` foi construída para falsificar a leitura literal de "partidas encerradas", e mediu,
-de passagem, um efeito que não é da [F] mas fica registrado. O `team_log` de todo o pipeline
-filtra `status_short = 'FT'`, e jogo decidido na prorrogação (`AET`) ou nos pênaltis (`PEN`) não é
-`FT`:
+A variante `E` foi construída para falsificar o lado do histórico da leitura literal de "partidas
+encerradas", e mediu, de passagem, um efeito que não é da [F] mas fica registrado. O `team_log` de
+todo o pipeline filtra `status_short = 'FT'`, e jogo decidido na prorrogação (`AET`) ou nos
+pênaltis (`PEN`) não é `FT`. Contagem sobre a `fact_fixtures` inteira (a query está na Reprodução),
+com `status_short IN ('FT','AET','PEN')` como denominador:
 
 | competição | encerradas | fora do histórico (AET+PEN) | % |
 |---|---|---|---|
@@ -1318,8 +1348,12 @@ filtra `status_short = 'FT'`, e jogo decidido na prorrogação (`AET`) ou nos p�
 | Champions | 636 | 26 | 4,1% |
 | **base inteira** | **8.094** | **142** | 1,8% |
 
+As três que faltam para 142 são de Ligue 1 (2) e Bundesliga (1), e as três são jogo de
+acesso/rebaixamento — `Relegation Round`, `Semi-finals` e `Final` no campo `round`. Liga de pontos
+corridos não produz prorrogação; as copas produzem.
+
 No agregado é 1,8% e ninguém veria; nas copas de mata-mata é uma partida em sete. Sob a contagem
-`C`, a média da Copa do Brasil na própria competição vai de 10,2 para **11,4**. Não é para mexer
+`E`, a média da Copa do Brasil na própria competição vai de 10,2 para **11,4**. Não é para mexer
 aqui — a #56 e a #49 proíbem mudar pipeline —, e a decisão de incluir ou não tem lado defensável
 nos dois sentidos (o placar de um jogo decidido nos pênaltis é empate, e é assim que ele entraria
 nas médias de gols). Fica como candidato a ticket próprio.
@@ -1335,7 +1369,7 @@ justifica as outras: guarda que fica vermelha por trabalho alheio deixa de ser s
   dentro. Remarcação ou resultado ingerido depois muda âncora e histórico ao mesmo tempo.
 
 O gabarito de 16 números mora **dentro da análise**, com coluna de delta e um contador
-`celulas_exatas` por linha. Quem rodar vê a divergência sem conferir de olho, e nada fica vermelho
+`campos_exatos` por linha. Quem rodar vê a divergência sem conferir de olho, e nada fica vermelho
 em quem não pediu.
 
 ### Reprodução
@@ -1343,11 +1377,33 @@ em quem não pediu.
 ```bash
 cd dbt_futebol
 
-DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target dev --select taskf_reconciliacao_180d
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target dev \
+  --select taskf_reconciliacao_180d taskf_partida_da_fronteira
+
 bq query --use_legacy_sql=false --project_id=smartbetting-dados \
   < target/compiled/dbt_futebol/analyses/taskf_reconciliacao_180d.sql
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_partida_da_fronteira.sql
+
+# as duas contagens de passagem desta seção: o rodapé de AET/PEN e os PST dentro do corte
+bq query --use_legacy_sql=false --project_id=smartbetting-dados <<'SQL'
+SELECT COALESCE(competition, 'TOTAL') AS competicao,
+       COUNTIF(status_short IN ('FT','AET','PEN'))                     AS encerradas,
+       COUNTIF(status_short IN ('AET','PEN'))                          AS fora_do_historico,
+       COUNTIF(status_short = 'PST'
+               AND kickoff_utc >= TIMESTAMP('2026-06-16')
+               AND kickoff_utc <  TIMESTAMP('2026-08-04 12:00:00'))    AS pst_no_corte
+FROM `smartbetting-dados.futebol.fact_fixtures`
+GROUP BY ROLLUP(competition)
+HAVING fora_do_historico > 0 OR pst_no_corte > 0
+ORDER BY fora_do_historico DESC
+SQL
 ```
 
 O target é indiferente: `fact_fixtures` é a mesma tabela de produção em `dev`, `prod` e `taskF`, e
-esta análise não lê nada do dataset de medição. A saída são 16 linhas — quatro variantes × quatro
-competições —, e a soma de `celulas_exatas` na variante `A_ticket` é **15**.
+nenhuma das duas análises lê o dataset de medição. A reconciliação sai com **28 linhas** — sete
+variantes × quatro competições —, e a soma de `campos_exatos` na variante `A_ticket` é **15**. A
+análise da fronteira sai com **uma** linha.
+
+⚠️ `bq query` com o SQL como argumento trava nesta máquina; por redirecionamento ou heredoc,
+funciona.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1153,7 +1153,7 @@ três), com `ERROR=0` e `SKIP=0` — iguais aos da #54.
 ## Ticket #56 — A reconciliação do diagnóstico de 180 dias
 
 `analyses/taskf_reconciliacao_180d.sql` + `analyses/taskf_partida_da_fronteira.sql` · execução
-2026-08-13 13:13 UTC · commit `7651233` · dataset `futebol` (produção)
+2026-08-13 13:13–13:14 UTC · commit `f27f79b` · dataset `futebol` (produção)
 
 A tabela de quatro linhas que abre o ticket de origem — a que diz que o time de Copa do Brasil tem
 10,2 jogos na própria competição e 25,5 contando tudo — reproduzida da nossa base. É o que dá ao
@@ -1189,8 +1189,9 @@ Variante `A_ticket`. Cada campo sai como `medido / ticket`.
 
 ### A receita, e o que cada pedaço dela vale
 
-Nenhum dos quatro pedaços é escolha de gosto: trocar qualquer um deles quebra a reprodução, e o
-número que ele passa a dar está medido nas variantes.
+Nenhum dos quatro pedaços é escolha de gosto: trocar qualquer um deles quebra a reprodução. Três
+deles têm o número da troca medido nas variantes; o quarto — o corte das âncoras — não ganhou
+variante própria porque herda o argumento já publicado do universo congelado.
 
 - **O corte de tempo das âncoras é o universo congelado** (`taskf_universo()`), com o teto no
   instante de 04/08 12:00 UTC. O ticket foi aberto às **22:52 UTC** daquele dia; entre ~02:00 e


### PR DESCRIPTION
Closes #56

A tabela de quatro linhas que abre o ticket de origem da [F] reproduzida da nossa base, sem passar
por célula nenhuma: a análise desce até `fact_fixtures` e reconstrói a contagem de partidas
anteriores por conta própria (critério de aceite — conferência que passasse pela máquina conferida
não conferiria nada).

## Veredito

**15 dos 16 campos reproduzem exatamente**, por uma receita só, nas quatro competições.

| competição | própria competição | em tudo, 180 dias | % < 5 própria | % < 5 tudo |
|---|---|---|---|---|
| Copa do Brasil | 10,2 / 10,2 | 25,6 / 25,5 ⚠️ | 19% / 19% | 0% / 0% |
| Sudamericana | 8,9 / 8,9 | 12,5 / 12,5 | 27% / 27% | 0% / 0% |
| Copa do Mundo | 2,0 / 2,0 | 2,0 / 2,0 | 96% / 96% | 96% / 96% |
| Champions | 4,0 / 4,0 | 1,0 / 1,0 | 69% / 69% | 100% / 100% |

## Os três achados

1. **As duas primeiras colunas do ticket não contam o mesmo passado.** A coluna 1 é o histórico
   inteiro do time naquela competição, todas as temporadas, sem limite; a coluna 2 é tudo, mas só
   180 dias. É por isso que a Champions aparece com 4,0 e 1,0 — sob um recorte comum isso seria
   impossível. A leitura do ticket se sustenta pelo lado do 1,0; comparar os dois números entre si
   não se sustenta.

2. **A única divergência é uma partida.** 409 contadas contra 408, em 16 pares: Palmeiras × Vitória,
   05/02/2026 00:30 UTC, exatamente **30 minutos** dentro da fronteira dos 180 dias do jogo-âncora.
   `taskf_partida_da_fronteira.sql` a nomeia. A régua mais apertada que a exclui existe como
   variante e fecha 16/16 — mas **não** vira a receita: adotá-la porque o último número bate seria
   calibrar até o resultado sair.

3. **A coluna 1 do ticket é mais generosa que produção.** O PIT escopa também por temporada: o time
   de Copa do Brasil é tratado como time de **2,2** jogos, não de 10,2, e 94% deles ficam abaixo de
   5, não 19%. A tese do ticket sai reforçada — o vão é maior do que a tabela publicada mostrou.

## Como está construído

Sete variantes, cada uma mexendo em **uma** coisa em relação à receita, para a diferença ser
atribuível: as três réguas de fronteira, AET/PEN como âncora, AET/PEN no histórico, a contagem do
PIT e a unidade por time distinto. Os 16 números do ticket entram como gabarito digitado dentro da
análise, com coluna de delta e um contador `campos_exatos` por linha.

De passagem, um efeito registrado para virar ticket próprio: `status_short = 'FT'` deixa **142
partidas encerradas** fora do histórico de todo o pipeline — 14,2% da Copa do Brasil.

## Verificação

- `dbt parse` limpo; `dbt test --select tag:guarda` → **PASS=16 ERROR=0**
- Execução 2026-08-13 13:13–13:14 UTC, commit `f27f79b`, dataset `futebol` (produção, leitura só)
- Nenhum modelo tocado — a mudança é duas análises, a seção do doc e uma entrada de glossário

🤖 Generated with [Claude Code](https://claude.com/claude-code)
