### PR TITLE
[F-8] Confundidores: força do adversário pequena, rodízio de 1,46 titular

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -348,3 +348,29 @@ Sudamericana, Copa do Mundo and Champions. Reproduced from `fact_fixtures` in
 whole history in that competition, every season, unbounded; column 2 is every competition but only
 180 days back. That is why the Champions row reads 4,0 against 1,0, which no common window could
 produce — and why the two columns must never be compared to each other.
+
+**Adversário fora da base**:
+An opponent no collected points-corridos league reaches, so nothing in our data says how good it
+is. It is a **category, never an imputation** — no competition average, no percentile stands in
+for the missing `ppg`. Two distinct populations fall in it: the Série C/D club a Copa do Brasil
+early round throws up, and the South American club of the Libertadores and the Sudamericana whose
+national league we do not collect. The second is the larger of the two. A **seleção** is counted
+apart: it has no league to collect, which is the shape of international football and not a limit
+of ours.
+_Avoid_: adversário desconhecido (suggests a gap to fill; the absence is the finding)
+
+**Rodízio de elenco (medido)**:
+How much of a team's starting eleven carries over between two consecutive fixtures — distinct from
+the `sem_rodizio` premissa, which reads the standings and never looks at a lineup. It only means
+something against its control: 8,34 of 11 repeat between two league fixtures, and 6,88 between a
+league and a cup fixture, so the cup costs 1,46 starters *beyond* ordinary week-to-week churn. Read
+without the control, the 6,88 alone says nothing.
+
+**ppg de liga**:
+An opponent's points per game restricted to points-corridos fixtures, computed point-in-time. It
+exists because the PIT `ppg` is not comparable across competitions: in a knockout cup the losers
+stop playing, so the survivors' average climbs — 2,609 in the Copa do Brasil against 1,364 in the
+Brasileirão. The ppg de liga removes that survivorship, but it still measures position **within**
+the opponent's own league and so never measures level between leagues. Level is only observable as
+the league the opponent belongs to.
+_Avoid_: força do adversário as if it were one number (no single number in this base carries it)

--- a/dbt_futebol/analyses/taskf_forca_do_adversario.sql
+++ b/dbt_futebol/analyses/taskf_forca_do_adversario.sql
@@ -376,7 +376,7 @@ conferencia AS (
         COUNTIF(categoria_adversario = 'selecao')                            AS adv_selecao,
         COUNTIF(adv_ppg_liga IS NOT NULL)                                    AS adv_com_ppg_liga,
         ROUND(AVG(adv_ppg), 3)                                               AS ppg_medio,
-        ROUND(APPROX_QUANTILES(adv_ppg, 2)[OFFSET(1)], 3)                    AS ppg_mediana,
+        {{ taskf_mediana('adv_ppg') }}                                       AS ppg_mediana,
         ROUND(AVG(adv_ppg_liga), 3)                                          AS ppg_liga_medio,
         ROUND(AVG(gf), 3)                                                    AS gols_pro_medio,
         ROUND(AVG(ga), 3)                                                    AS gols_contra_medio

--- a/dbt_futebol/analyses/taskf_forca_do_adversario.sql
+++ b/dbt_futebol/analyses/taskf_forca_do_adversario.sql
@@ -468,7 +468,15 @@ empilhado AS (
         CAST(NULL AS FLOAT64) AS gols_contra_medio,
         pares_batem_base,
         pares_batem_escopo,
-        IF(pares = pares_batem_base AND pares = pares_batem_escopo,
+        {#- A COBERTURA ENTRA NO VEREDITO, e não só a concordância. `pares` vem de um INNER JOIN
+            contra o carimbo: par que o carimbo não tem é descartado ANTES de ser contado, e
+            portanto nunca discorda. Sem a igualdade contra 2 x jogos_no_universo, um carimbo
+            incompleto — uma célula re-rodada sozinha, um resultado que entrou depois — sairia
+            `EXATA` tendo conferido um subconjunto. É a guarda em que toda a seção se apoia; ela
+            não pode ser verdadeira por omissão. -#}
+        IF(pares = pares_batem_base
+             AND pares = pares_batem_escopo
+             AND pares = 2 * jogos_no_universo,
            'EXATA',
            'DIVERGENTE — nada abaixo desta linha significa o que diz') AS veredito
     FROM conferencia

--- a/dbt_futebol/analyses/taskf_forca_do_adversario.sql
+++ b/dbt_futebol/analyses/taskf_forca_do_adversario.sql
@@ -381,8 +381,12 @@ conferencia AS (
         ROUND(AVG(adv_ppg), 3)                                               AS ppg_medio,
         {{ taskf_mediana('adv_ppg') }}                                       AS ppg_mediana,
         ROUND(AVG(adv_ppg_liga), 3)                                          AS ppg_liga_medio,
-        ROUND(AVG(gf), 3)                                                    AS gols_pro_medio,
-        ROUND(AVG(ga), 3)                                                    AS gols_contra_medio
+        {#- SUM/COUNT, e não AVG, pelo mesmo motivo do analyses/taskf_rodizio_de_elenco.sql: gols
+            são INT64, a soma é exata e a média fica determinística. Os dois `ppg_*` acima seguem
+            em AVG porque o somando já é FLOAT64 e não há soma exata a recuperar — nas três
+            execuções desta análise eles não se mexeram, mas a garantia ali é mais fraca. -#}
+        ROUND(SAFE_DIVIDE(SUM(gf), COUNT(*)), 3)                             AS gols_pro_medio,
+        ROUND(SAFE_DIVIDE(SUM(ga), COUNT(*)), 3)                             AS gols_contra_medio
 {%- endset %}
 
 por_total AS (

--- a/dbt_futebol/analyses/taskf_forca_do_adversario.sql
+++ b/dbt_futebol/analyses/taskf_forca_do_adversario.sql
@@ -125,10 +125,13 @@
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
         --select taskf_forca_do_adversario
-      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+      bq query --use_legacy_sql=false --max_rows=100000 --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_forca_do_adversario.sql
 
-    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+    ⚠️ DUAS ARMADILHAS DO `bq query`, as duas silenciosas. O SQL como ARGUMENTO trava nesta
+    máquina (sempre por redirecionamento). E o `--max_rows` PRECISA estar lá: o default é 100
+    linhas e ele TRUNCA sem avisar — a saída sai com cara de completa, e a linha que falta é
+    exatamente a do fim da ordenação. Custou uma contagem errada de times durante a própria #57.
 
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */

--- a/dbt_futebol/analyses/taskf_forca_do_adversario.sql
+++ b/dbt_futebol/analyses/taskf_forca_do_adversario.sql
@@ -1,0 +1,552 @@
+/*
+    [F-8] FORÇA DO ADVERSÁRIO — o primeiro dos dois confundidores do merge, medido em vez de
+    registrado.
+
+    O QUE ELE AMEAÇA. A célula `escopo` aumenta a amostra emprestando ao histórico de um time as
+    partidas que ele jogou em OUTRA competição da mesma temporada. Se essas partidas emprestadas
+    forem contra adversários de nível diferente, o ganho de amostra vem junto com um viés de
+    nível: a média que decide se a aposta é boa passa a misturar jogo de Brasileirão com jogo de
+    fase inicial de Copa do Brasil, e a premissa acende por um passado que descreve outro
+    campeonato. É o confundidor que o ticket de origem não menciona e que a spec #49 acrescentou
+    (user stories 21 e 22).
+
+    O QUE ESTA ANÁLISE MEDE, e onde:
+
+      (a) de ONDE vem cada partida emprestada — a competição de origem, por competição-âncora;
+      (b) QUEM era o adversário naquela partida, em quatro categorias EXCLUDENTES e sem imputação:
+          `na_base_com_ppg`, `na_base_sem_ppg`, `fora_da_base` e `selecao`;
+      (c) o `ppg` PIT do adversário quando ele existe, nativo contra emprestado, e ao lado dele o
+          `ppg` de LIGA do mesmo adversário — o mesmo número na mesma unidade, seja qual for a
+          competição da partida;
+      (d) a LIGA a que o adversário pertence, que é a única medida de nível que a base permite;
+      (e) os gols pró/contra do próprio time nas duas origens — o canal por onde o viés chega às
+          médias que as premissas leem.
+
+    ⚠️ O QUE `ppg` ALCANÇA, E O QUE NÃO — E O `ppg_referencia` EXISTE PARA ISSO SER CONFERIDO, NÃO
+    ACREDITADO. `ppg` é pontos por jogo DENTRO da competição. Numa competição de PONTOS CORRIDOS a
+    média dele é quase constante por construção (o campeonato distribui 3 pontos por jogo decidido
+    e 2 por empate), e medido é isso mesmo: 1,364 no Brasileirão e 1,333 na Série B. Ali `ppg` mede
+    posição RELATIVA — se o adversário é de cima ou de baixo da tabela DELE — e é cego a diferença
+    de NÍVEL entre competições.
+
+    Em competição de MATA-MATA ele não mede nem isso. Quem perde é eliminado e para de jogar, então
+    a população que chega à rodada seguinte é a dos que venceram: a média de `ppg` da Copa do Brasil
+    é **2,609**, contra 1,438 da Libertadores (que tem fase de grupos e por isso volta a se
+    comportar como liga). `ppg` alto numa copa de mata-mata é sobrevivência, não força. Comparar
+    `ppg` de copa com `ppg` de liga como se fossem a mesma régua é o erro que esta análise existe
+    para não cometer — o nível sai da COMPOSIÇÃO (de qual competição a partida veio, `nivel =
+    'fonte'`) e do tamanho das categorias sem número, nunca do `ppg_medio` sozinho.
+
+    ⚠️ `fora_da_base` NÃO É IMPUTADO. Um time está na base quando alguma competição de PONTOS
+    CORRIDOS da coleta o alcança (`dim_leagues.league_type = 'League'`, derivado do dado e não de
+    uma lista digitada). Não coletamos Série C nem D, então o adversário das fases iniciais da
+    Copa do Brasil é invisível — e a medição mostrou que o buraco é maior do que a spec supôs: o
+    clube sul-americano de Libertadores e de Sudamericana também está fora, porque não coletamos as
+    ligas nacionais dele. Não há `ppg` de nenhum dos dois em lugar nenhum, e inventar um — média da
+    competição, percentil, o que for — trocaria o achado por um número. A categoria fica explícita
+    e o tamanho dela é o resultado.
+
+    As outras duas categorias sem `ppg` são OUTRAS COISAS, e por isso não se juntam à primeira:
+
+      `na_base_sem_ppg`  o adversário existe na base, mas naquele instante ainda não tinha partida
+                         anterior na competição daquele jogo (rodada 1), então o PIT dele é NULL
+                         por degradação graciosa. É ausência de passado, não ausência de coleta.
+      `selecao`          adversário de Copa do Mundo. Seleção não tem liga a coletar — a ausência
+                         é o formato do futebol de seleções, não um limite nosso.
+
+    ⚠️ E É POR ISSO QUE EXISTE O NÍVEL `liga_do_adversario`, QUE É ONDE A RESPOSTA MORA. Nenhum
+    `ppg` enxerga NÍVEL: o do PIT é relativo à competição da partida, e o `ppg_liga_medio` é
+    relativo à liga do adversário — um time de Série B com 1,40 não vale o mesmo que um de Série A
+    com 1,40. O que é observável sem inventar rating é a LIGA a que o adversário pertence, e é
+    exatamente a variável do medo da spec ("emprestar jogos de uma competição mais forte para
+    outra mais fraca"). Esse nível conta quantas partidas de cada origem foram contra time de cada
+    liga, e o `gols_pro_medio`/`gols_contra_medio` ao lado mostra o que aquilo faz com a média que
+    as premissas leem.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    SEIS NÍVEIS NA MESMA SAÍDA, com a coluna `nivel` separando os grãos. Somar linhas de níveis
+    diferentes conta a mesma partida mais de uma vez — filtre `nivel` sempre.
+
+      conferencia         1 linha. A reconstrução aqui bate com o que o MODELO gravou?
+      total               por `origem`, o universo inteiro.
+      competicao          por (competição-âncora, `origem`).
+      fonte               por (competição-âncora, competição da partida emprestada). Só emprestadas.
+      liga_do_adversario  por (competição-âncora, liga do adversário, `origem`).
+      ppg_referencia      por competição: a média de `ppg` de todo o PIT dela. É a régua de leitura
+                          dos `ppg_medio` acima, não uma medição do universo.
+
+    As colunas não querem dizer a mesma coisa nos seis níveis, e a legenda é esta:
+
+      nível               chave / chave2                  partidas          adv_com_ppg
+      ──────────────────  ──────────────────────────────  ────────────────  ──────────────────
+      conferencia         —                               —                 —
+      total               'TODAS'                         partidas do hist. adversários com ppg
+      competicao          competição-âncora               idem              idem
+      fonte               âncora / competição de origem   idem              idem
+      liga_do_adversario  âncora / liga do adversário     idem              idem
+      ppg_referencia      competição                      linhas do PIT     linhas do PIT com ppg
+
+    `pares_batem_base`, `pares_batem_escopo` e `veredito` só existem no nível `conferencia`;
+    `ppg_min`/`ppg_max` só no `ppg_referencia`. `jogos_no_universo` é o universo congelado inteiro
+    na `conferencia` (o gabarito) e, nos demais níveis, as âncoras que têm pelo menos uma partida
+    naquele estrato — os dois números diferem, e é assim que se enxerga quanto do universo o
+    estrato alcança.
+
+    ⚠️ O RÓTULO `fora_da_base` DO NÍVEL `liga_do_adversario` NÃO É A MESMA CONTAGEM DA COLUNA
+    `adv_fora_da_base`, e a diferença é informação. A coluna é por BASE INTEIRA (o time tem liga
+    em alguma temporada?); o rótulo é por TEMPORADA (o time tem liga NAQUELA temporada?). Medido:
+    583 partidas com o rótulo contra 573 na coluna — 10 em 4.021, e são adversários que têm liga
+    na base mas não em 2026. São 40 times nessa situação, quase todos rebaixados ou promovidos
+    entre o backfill de 24/25 e agora (Amazonas, Brusque, Ferroviária, Burnley, Empoli...).
+
+    ⚠️ POR QUE HÁ UMA CONFERÊNCIA, E POR QUE ELA É A PRIMEIRA LINHA. Esta análise RECONSTRÓI o
+    join de histórico do int_futebol_team_form_pit em vez de ler um agregado pronto — precisa da
+    partida individual, e o carimbo guarda só a contagem. Reconstrução é cópia, e cópia deriva do
+    original em silêncio: bastaria esquecer o `l.season = a.season` para o número sair maior e com
+    cara de certo. Então a reconstrução é cobrada contra o carimbo das células (`base` e `escopo`,
+    #53), par a par: as partidas `nativa` têm de ser exatamente o `played_total` da `base`, e o
+    total (nativa + emprestada) exatamente o da `escopo`. Se a linha `conferencia` não sair
+    `EXATA`, nada abaixo dela significa o que diz.
+
+    ⚠️ ESTA ANÁLISE NÃO DEPENDE DA CÉLULA MATERIALIZADA, e isso é escolha, não sorte. Ela lê três
+    coisas do dataset: o UNIVERSO (invariante entre células — é a primeira invariante da Costura
+    B, #55), o `ppg` do PIT (invariante por construção — a tabela do campeonato é sempre
+    competição+temporada, ADR 0008; medido: 1.916 de 1.916 pares idênticos entre a produção e a
+    célula `ambos`) e o CARIMBO, que tem as quatro células gravadas lado a lado. O `jogos_no_universo`
+    sai na saída para ser conferido contra os {{ taskf_universo().jogos_esperados }} do gabarito.
+
+    COMO RODAR (do dbt_futebol/), com o carimbo das células `base` e `escopo` já gravado:
+
+      # dim_leagues e dim_teams não estavam no dataset de medição — a ancestria das células não
+      # passa por elas. Uma vez só, e sem risco de tocar célula: nenhum dos seis nós de premissas
+      # as referencia.
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt run --target taskF \
+        --select dim_leagues stg_futebol_leagues dim_teams stg_futebol_teams
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+        --select taskf_forca_do_adversario
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_forca_do_adversario.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{#- O carimbo é lido por `source()`, como todo o resto do dataset de medição. Só a ESCRITA dele
+    (analyses/taskf_pit_por_celula.sql) é literal, e por um motivo específico da ADR 0007 — o
+    destino não pode seguir o `--target`. -#}
+{%- set carimbos = source('futebol_taskF', 'taskf_pit_por_celula') -%}
+
+WITH {{ task01_base() }},
+
+apostas_congeladas AS (
+    SELECT * FROM apostas
+    WHERE {{ taskf_universo_filtro() }}
+),
+
+universo AS (
+    SELECT DISTINCT fixture_id FROM apostas_congeladas
+),
+
+fixtures AS (
+    SELECT
+        fixture_id, competition, competition_id, season, kickoff_utc,
+        status_short, home_team_id, away_team_id, goals_home, goals_away
+    FROM {{ ref('fact_fixtures') }}
+),
+
+{#- Tipo da competição, DERIVADO do catálogo e não de uma lista de slugs digitada: a Onda 2
+    acrescentou cinco ligas em três semanas, e uma lista digitada envelheceria calada — a liga
+    nova cairia no lado errado da fronteira liga/copa e o número sairia com cara de certo. Grão
+    (league_id): `dim_leagues` tem uma linha por (league_id, season_year) e o tipo não muda entre
+    temporadas. -#}
+tipo_competicao AS (
+    SELECT DISTINCT league_id AS competition_id, league_type
+    FROM {{ ref('dim_leagues') }}
+),
+
+{#- NA BASE = alcançado por alguma competição de pontos corridos da coleta. É a definição de
+    "temos como saber quanto esse time vale": um time de Série C aparece na nossa base APENAS
+    pelos jogos de Copa do Brasil dele, e ali o passado que existe é o da própria copa. -#}
+times_na_base AS (
+    SELECT DISTINCT lados.team_id
+    FROM (
+        SELECT home_team_id AS team_id, competition_id FROM fixtures
+        UNION ALL
+        SELECT away_team_id,            competition_id FROM fixtures
+    ) AS lados
+    JOIN tipo_competicao AS t
+      ON  t.competition_id = lados.competition_id
+     AND  t.league_type    = 'League'
+),
+
+{#- Mesmo `team_log` do int_futebol_team_form_pit — 1 linha por (time, jogo encerrado), agora com
+    o adversário ao lado. O filtro é o do modelo, `status_short = 'FT'`: jogo decidido na
+    prorrogação ou nos pênaltis não entra no histórico de ninguém hoje (issue #71), e reproduzir
+    o modelo é o ponto. -#}
+team_log AS (
+    SELECT competition_id, competition, season, kickoff_utc, fixture_id,
+           home_team_id AS team_id, away_team_id AS oponente_id,
+           goals_home   AS gf,      goals_away   AS ga
+    FROM fixtures
+    WHERE status_short = 'FT' AND goals_home IS NOT NULL AND goals_away IS NOT NULL
+    UNION ALL
+    SELECT competition_id, competition, season, kickoff_utc, fixture_id,
+           away_team_id,            home_team_id,
+           goals_away,              goals_home
+    FROM fixtures
+    WHERE status_short = 'FT' AND goals_home IS NOT NULL AND goals_away IS NOT NULL
+),
+
+{#- As âncoras: os dois lados de cada jogo do universo congelado. É o mesmo grão (jogo, time) do
+    carimbo, e é nele que a conferência casa. -#}
+ancoras AS (
+    SELECT
+        f.fixture_id, f.competition, f.competition_id, f.season, f.kickoff_utc,
+        lado AS team_id
+    FROM fixtures AS f
+    JOIN universo USING (fixture_id)
+    CROSS JOIN UNNEST([f.home_team_id, f.away_team_id]) AS lado
+),
+
+{#- O histórico que a célula `escopo` enxerga: partidas anteriores do time na MESMA temporada, em
+    QUALQUER competição. `origem` separa o que a `base` já contava do que o merge acrescenta. -#}
+historico AS (
+    SELECT
+        a.fixture_id     AS ancora_fixture_id,
+        a.competition    AS ancora_competition,
+        a.team_id,
+        l.fixture_id     AS hist_fixture_id,
+        l.competition    AS hist_competition,
+        l.kickoff_utc    AS hist_kickoff_utc,
+        l.season         AS hist_season,
+        l.oponente_id,
+        l.gf,
+        l.ga,
+        IF(l.competition_id = a.competition_id, 'nativa', 'emprestada') AS origem
+    FROM ancoras AS a
+    JOIN team_log AS l
+      ON  l.team_id     = a.team_id
+      AND l.season      = a.season
+      AND l.kickoff_utc < a.kickoff_utc
+),
+
+{# A LIGA a que o adversário pertence naquela temporada — a única medida de NÍVEL que esta base
+   permite sem inventar um rating. Nem o `ppg` do PIT nem o `ppg` de liga enxergam nível: os dois
+   são relativos ao campeonato em que foram calculados, e um time de Série B com 1,40 não vale o
+   mesmo que um de Série A com 1,40. Já a liga do adversário é observável e é exatamente o que a
+   spec teme ("emprestar jogos de uma competição mais forte para outra mais fraca"). Quando o
+   adversário não tem liga nenhuma na coleta, o rótulo é a própria ausência. -#}
+liga_do_adversario AS (
+    SELECT team_id, season, liga
+    FROM (
+        SELECT
+            lado          AS team_id,
+            f.season,
+            f.competition AS liga,
+            COUNT(*)      AS n_jogos
+        FROM fixtures AS f
+        CROSS JOIN UNNEST([f.home_team_id, f.away_team_id]) AS lado
+        JOIN tipo_competicao AS tc
+          ON  tc.competition_id = f.competition_id
+         AND  tc.league_type    = 'League'
+        GROUP BY lado, f.season, f.competition
+    )
+    {#- Um clube joga uma liga nacional por temporada; o desempate por contagem existe só para o
+        caso de a base passar a ter duas (uma liga regional, um playoff cadastrado à parte) e não
+        escolher em silêncio. -#}
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY team_id, season ORDER BY n_jogos DESC, liga
+    ) = 1
+),
+
+{# O `ppg` DE LIGA do adversário: pontos por jogo dele em competição de PONTOS CORRIDOS, contando
+   só o que já tinha acontecido quando aquela partida foi jogada.
+
+   Existe porque o `ppg` do PIT não é comparável entre competições — numa copa de mata-mata ele é
+   sobrevivência (2,609 na Copa do Brasil contra 1,364 no Brasileirão). Este aqui está sempre na
+   mesma unidade, seja qual for a competição da partida, e é ele que responde de fato "o
+   adversário era forte?". Ele é NULL exatamente para quem está `fora_da_base` ou é `selecao` —
+   não por acaso: é a mesma ausência, agora em forma de número que falta. -#}
+adv_ppg_de_liga AS (
+    SELECT
+        h.ancora_fixture_id,
+        h.team_id,
+        h.hist_fixture_id,
+        SAFE_DIVIDE(
+            SUM(CASE WHEN l.gf > l.ga THEN 3 WHEN l.gf = l.ga THEN 1 ELSE 0 END),
+            COUNT(*)
+        ) AS ppg_liga
+    FROM historico AS h
+    JOIN team_log AS l
+      ON  l.team_id     = h.oponente_id
+      AND l.season      = h.hist_season
+      AND l.kickoff_utc < h.hist_kickoff_utc
+    JOIN tipo_competicao AS tc
+      ON  tc.competition_id = l.competition_id
+     AND  tc.league_type    = 'League'
+    GROUP BY h.ancora_fixture_id, h.team_id, h.hist_fixture_id
+),
+
+{#- O adversário daquela partida, classificado. O `ppg` sai do PIT do próprio jogo histórico —
+    ponto no tempo de verdade, e não a tabela de hoje: é o que o adversário valia quando a
+    partida foi jogada.
+
+    A ORDEM DO `CASE` É A CLASSIFICAÇÃO. `selecao` vem primeiro porque seleção não é clube sem
+    liga: ela não tem liga a coletar. Jogar as duas ausências na mesma categoria daria a impressão
+    de que a Copa do Mundo tem o mesmo buraco da Copa do Brasil, e são coisas diferentes — uma é
+    limite da coleta, a outra é o formato do futebol de seleções. Medido: `national = TRUE` em
+    `dim_teams` é exatamente o conjunto dos 48 times que só aparecem em `copa_mundo`. -#}
+historico_classificado AS (
+    SELECT
+        h.*,
+        p.ppg      AS adv_ppg,
+        pl.ppg_liga AS adv_ppg_liga,
+        COALESCE(la.liga, IF(dt.national, 'selecao', 'fora_da_base')) AS adv_liga,
+        CASE
+            WHEN dt.national       THEN 'selecao'
+            WHEN b.team_id IS NULL THEN 'fora_da_base'
+            WHEN p.ppg     IS NULL THEN 'na_base_sem_ppg'
+            ELSE                        'na_base_com_ppg'
+        END AS categoria_adversario
+    FROM historico AS h
+    LEFT JOIN times_na_base AS b
+           ON b.team_id = h.oponente_id
+    LEFT JOIN {{ ref('dim_teams') }} AS dt
+           ON dt.team_id = h.oponente_id
+    LEFT JOIN {{ ref('int_futebol_team_form_pit') }} AS p
+           ON  p.fixture_id = h.hist_fixture_id
+          AND  p.team_id    = h.oponente_id
+    LEFT JOIN adv_ppg_de_liga AS pl
+           ON  pl.ancora_fixture_id = h.ancora_fixture_id
+          AND  pl.team_id           = h.team_id
+          AND  pl.hist_fixture_id   = h.hist_fixture_id
+    LEFT JOIN liga_do_adversario AS la
+           ON  la.team_id = h.oponente_id
+          AND  la.season  = h.hist_season
+),
+
+-- ─────────────────────────── conferência contra o carimbo ───────────────────────────
+
+{# LEFT JOIN de propósito: par sem NENHUMA partida anterior não aparece em `historico`, e no
+    carimbo ele existe com played_total = 0. Cortá-lo aqui tiraria da conferência exatamente os
+    pares que a degradação graciosa produz. -#}
+contagem_reconstruida AS (
+    SELECT
+        a.fixture_id,
+        a.team_id,
+        COUNTIF(h.origem = 'nativa') AS n_nativa,
+        COUNT(h.origem)              AS n_total
+    FROM ancoras AS a
+    LEFT JOIN historico AS h
+           ON  h.ancora_fixture_id = a.fixture_id
+          AND  h.team_id           = a.team_id
+    GROUP BY a.fixture_id, a.team_id
+),
+
+conferencia AS (
+    SELECT
+        {#- O gabarito do universo congelado sai daqui, e não das linhas de histórico: um jogo
+            cujos DOIS lados estreiam na temporada não tem partida anterior nenhuma e some dos
+            níveis abaixo. Conferir 169 contra a contagem de histórico daria falso alarme. -#}
+        (SELECT COUNT(DISTINCT fixture_id) FROM ancoras) AS jogos_no_universo,
+        COUNT(*)                                  AS pares,
+        COUNTIF(c.n_nativa = b.played_total)      AS pares_batem_base,
+        COUNTIF(c.n_total  = e.played_total)      AS pares_batem_escopo
+    FROM contagem_reconstruida AS c
+    JOIN (SELECT fixture_id, team_id, played_total FROM {{ carimbos }} WHERE celula = 'base')   AS b
+      USING (fixture_id, team_id)
+    JOIN (SELECT fixture_id, team_id, played_total FROM {{ carimbos }} WHERE celula = 'escopo') AS e
+      USING (fixture_id, team_id)
+),
+
+-- ─────────────────────────── os agregados ───────────────────────────
+
+{# A lista de métricas existe UMA vez e é renderizada nos três níveis que compartilham o grão de
+    partida. Escrita três vezes, ela derivaria — e a divergência entre um rollup e o detalhe dele
+    não dá erro, dá número errado. -#}
+{%- set metricas_de_partida %}
+        COUNT(*)                                                             AS partidas,
+        COUNT(DISTINCT FORMAT('%d-%d', ancora_fixture_id, team_id))          AS pares,
+        COUNT(DISTINCT ancora_fixture_id)                                    AS jogos_no_universo,
+        COUNTIF(categoria_adversario = 'na_base_com_ppg')                    AS adv_com_ppg,
+        COUNTIF(categoria_adversario = 'na_base_sem_ppg')                    AS adv_sem_ppg,
+        COUNTIF(categoria_adversario = 'fora_da_base')                       AS adv_fora_da_base,
+        COUNTIF(categoria_adversario = 'selecao')                            AS adv_selecao,
+        COUNTIF(adv_ppg_liga IS NOT NULL)                                    AS adv_com_ppg_liga,
+        ROUND(AVG(adv_ppg), 3)                                               AS ppg_medio,
+        ROUND(APPROX_QUANTILES(adv_ppg, 2)[OFFSET(1)], 3)                    AS ppg_mediana,
+        ROUND(AVG(adv_ppg_liga), 3)                                          AS ppg_liga_medio,
+        ROUND(AVG(gf), 3)                                                    AS gols_pro_medio,
+        ROUND(AVG(ga), 3)                                                    AS gols_contra_medio
+{%- endset %}
+
+por_total AS (
+    SELECT origem, {{ metricas_de_partida }}
+    FROM historico_classificado
+    GROUP BY ROLLUP(origem)
+),
+
+{# O `HAVING` descarta o total geral do ROLLUP — `por_total` já o emite, e o BigQuery não aceita
+    ROLLUP ao lado de outro elemento de agrupamento, então a subtotal por competição tem de vir
+    do ROLLUP das duas colunas. -#}
+por_competicao AS (
+    SELECT ancora_competition, origem, {{ metricas_de_partida }}
+    FROM historico_classificado
+    GROUP BY ROLLUP(ancora_competition, origem)
+    HAVING ancora_competition IS NOT NULL
+),
+
+por_fonte AS (
+    SELECT ancora_competition, hist_competition, {{ metricas_de_partida }}
+    FROM historico_classificado
+    WHERE origem = 'emprestada'
+    GROUP BY ancora_competition, hist_competition
+),
+
+por_liga_do_adversario AS (
+    SELECT ancora_competition, origem, adv_liga, {{ metricas_de_partida }}
+    FROM historico_classificado
+    GROUP BY ancora_competition, origem, adv_liga
+),
+
+{#- A RÉGUA DE LEITURA do `ppg`, e não uma medição do universo: a média de `ppg` de cada
+    competição sobre TODAS as linhas do PIT dela em que a tabela já existe. É o número que mostra
+    que `ppg` é normalizado dentro da competição — se ele der ~1,4 em toda parte, comparar `ppg`
+    entre competições não mede nível, mede posição relativa. -#}
+ppg_referencia AS (
+    SELECT
+        p.competition,
+        COUNT(*)                        AS linhas_do_pit,
+        COUNTIF(p.ppg IS NOT NULL)      AS linhas_com_ppg,
+        ROUND(AVG(p.ppg), 3)            AS ppg_medio,
+        ROUND(MIN(p.ppg), 3)            AS ppg_min,
+        ROUND(MAX(p.ppg), 3)            AS ppg_max
+    FROM {{ ref('int_futebol_team_form_pit') }} AS p
+    {# A temporada sai das próprias âncoras, e não de um literal: o universo congelado é de uma
+        temporada só hoje, mas quem estender a janela não deveria ter de lembrar de um segundo
+        lugar para trocar o ano. O teto é o mesmo do universo — a régua tem de ser lida sobre o
+        mesmo passado que o resto da análise mede. -#}
+    WHERE p.season IN (SELECT DISTINCT season FROM ancoras)
+      AND p.kickoff_utc < TIMESTAMP('{{ taskf_universo().teto_utc }}')
+    GROUP BY p.competition
+),
+
+-- ─────────────────────────── empilhamento ───────────────────────────
+
+{# Os NULL são CASTADOS: sem o cast o literal entra como INT64 e a união com uma coluna STRING
+    falha por falta de supertipo comum. -#}
+empilhado AS (
+    SELECT
+        'conferencia'         AS nivel,
+        0                     AS nivel_ord,
+        CAST(NULL AS STRING)  AS chave,
+        CAST(NULL AS STRING)  AS chave2,
+        CAST(NULL AS STRING)  AS origem,
+        CAST(NULL AS INT64)   AS partidas,
+        pares,
+        jogos_no_universo,
+        CAST(NULL AS INT64)   AS adv_com_ppg,
+        CAST(NULL AS INT64)   AS adv_sem_ppg,
+        CAST(NULL AS INT64)   AS adv_fora_da_base,
+        CAST(NULL AS INT64)   AS adv_selecao,
+        CAST(NULL AS INT64)   AS adv_com_ppg_liga,
+        CAST(NULL AS FLOAT64) AS ppg_medio,
+        CAST(NULL AS FLOAT64) AS ppg_mediana,
+        CAST(NULL AS FLOAT64) AS ppg_liga_medio,
+        CAST(NULL AS FLOAT64) AS ppg_min,
+        CAST(NULL AS FLOAT64) AS ppg_max,
+        CAST(NULL AS FLOAT64) AS gols_pro_medio,
+        CAST(NULL AS FLOAT64) AS gols_contra_medio,
+        pares_batem_base,
+        pares_batem_escopo,
+        IF(pares = pares_batem_base AND pares = pares_batem_escopo,
+           'EXATA',
+           'DIVERGENTE — nada abaixo desta linha significa o que diz') AS veredito
+    FROM conferencia
+
+    UNION ALL
+
+    SELECT
+        'total', 1, 'TODAS', CAST(NULL AS STRING), COALESCE(origem, 'TODAS'),
+        partidas, pares, jogos_no_universo,
+        adv_com_ppg, adv_sem_ppg, adv_fora_da_base, adv_selecao, adv_com_ppg_liga,
+        ppg_medio, ppg_mediana, ppg_liga_medio, CAST(NULL AS FLOAT64), CAST(NULL AS FLOAT64),
+        gols_pro_medio, gols_contra_medio,
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS STRING)
+    FROM por_total
+
+    UNION ALL
+
+    SELECT
+        'competicao', 2, ancora_competition, CAST(NULL AS STRING), COALESCE(origem, 'TODAS'),
+        partidas, pares, jogos_no_universo,
+        adv_com_ppg, adv_sem_ppg, adv_fora_da_base, adv_selecao, adv_com_ppg_liga,
+        ppg_medio, ppg_mediana, ppg_liga_medio, CAST(NULL AS FLOAT64), CAST(NULL AS FLOAT64),
+        gols_pro_medio, gols_contra_medio,
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS STRING)
+    FROM por_competicao
+
+    UNION ALL
+
+    SELECT
+        'fonte', 3, ancora_competition, hist_competition, 'emprestada',
+        partidas, pares, jogos_no_universo,
+        adv_com_ppg, adv_sem_ppg, adv_fora_da_base, adv_selecao, adv_com_ppg_liga,
+        ppg_medio, ppg_mediana, ppg_liga_medio, CAST(NULL AS FLOAT64), CAST(NULL AS FLOAT64),
+        gols_pro_medio, gols_contra_medio,
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS STRING)
+    FROM por_fonte
+
+    UNION ALL
+
+    SELECT
+        'liga_do_adversario', 4, ancora_competition, adv_liga, origem,
+        partidas, pares, jogos_no_universo,
+        adv_com_ppg, adv_sem_ppg, adv_fora_da_base, adv_selecao, adv_com_ppg_liga,
+        ppg_medio, ppg_mediana, ppg_liga_medio, CAST(NULL AS FLOAT64), CAST(NULL AS FLOAT64),
+        gols_pro_medio, gols_contra_medio,
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS STRING)
+    FROM por_liga_do_adversario
+
+    UNION ALL
+
+    SELECT
+        'ppg_referencia', 5, competition, CAST(NULL AS STRING), CAST(NULL AS STRING),
+        linhas_do_pit, CAST(NULL AS INT64), CAST(NULL AS INT64),
+        linhas_com_ppg, CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS INT64),
+        ppg_medio, CAST(NULL AS FLOAT64), CAST(NULL AS FLOAT64), ppg_min, ppg_max,
+        CAST(NULL AS FLOAT64), CAST(NULL AS FLOAT64),
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS STRING)
+    FROM ppg_referencia
+)
+
+SELECT
+    nivel,
+    chave,
+    chave2,
+    origem,
+    partidas,
+    pares,
+    jogos_no_universo,
+    adv_com_ppg,
+    adv_sem_ppg,
+    adv_fora_da_base,
+    adv_selecao,
+    adv_com_ppg_liga,
+    ROUND(SAFE_DIVIDE(adv_fora_da_base, partidas) * 100, 1) AS pct_fora_da_base,
+    ROUND(SAFE_DIVIDE(adv_selecao,      partidas) * 100, 1) AS pct_selecao,
+    ppg_medio,
+    ppg_mediana,
+    ppg_liga_medio,
+    ppg_min,
+    ppg_max,
+    gols_pro_medio,
+    gols_contra_medio,
+    pares_batem_base,
+    pares_batem_escopo,
+    veredito
+FROM empilhado
+ORDER BY nivel_ord, chave, chave2, origem

--- a/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+++ b/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
@@ -280,7 +280,14 @@ pares AS (
             ELSE                                                             'liga_copa'
         END                                                       AS estrato,
         TIMESTAMP_DIFF(s.kickoff_utc, s.kickoff_anterior, DAY)    AS dias_entre,
-        xa.n_titulares = 11 AND xb.n_titulares = 11               AS utilizavel,
+        {#- COALESCE, e não a comparação nua: lado SEM escalação nenhuma sai do LEFT JOIN com
+            `n_titulares` NULL, e `NULL AND TRUE` é NULL — não FALSE. O `COUNTIF(NOT utilizavel)`
+            que conta os descartes pula NULL, então esses pares somem das DUAS colunas e a
+            invariante `pares_no_estrato = pares + pares_descartados` quebra calada. E quebra
+            exatamente onde a cobertura é pior, que é a única coisa que `pares_descartados` existe
+            para mostrar. -#}
+        COALESCE(xa.n_titulares, 0) = 11
+            AND COALESCE(xb.n_titulares, 0) = 11                  AS utilizavel,
         (SELECT COUNT(*) FROM UNNEST(xa.jogadores) AS j
           WHERE j IN UNNEST(xb.jogadores))                        AS sobreposicao
     FROM sequencia AS s

--- a/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+++ b/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
@@ -38,9 +38,10 @@
     ⚠️ POR QUE A FASE `real`, E NÃO A ESCALAÇÃO INTEIRA. O `fact_fixture_lineups_players` dedupa
     por (fixture_id, player_id) com latest-wins, e não por (fixture_id, team_id, fase). Quando a
     escalação `confirmed` (~T-30min) e a `real` (pós-jogo) discordam sobre um jogador, as duas
-    sobrevivem — uma por jogador — e o time aparece com 12 ou 13 "titulares". Medido sobre 2026:
-    92 lados fora de 11 sem o filtro, contra 34 com ele. Os 34 que sobram são falha de coleta, não
-    artefato de dedup, e caem no `cobertura`.
+    sobrevivem — uma por jogador — e o time aparece com 12 ou 13 "titulares". O custo do filtro
+    não é afirmação de cabeçalho: o escopo `temporada_sem_filtro_de_fase` do nível `cobertura`
+    repete a mesma contagem sem ele, e a diferença entre os dois escopos é o tamanho do artefato.
+    O que sobra depois do filtro é falha de coleta, não dedup.
 
     ────────────────────────────────────────────────────────────────────────────────
     O UNIVERSO. Os times são os do universo congelado da [F] (a mesma macro do resto da task), e
@@ -50,9 +51,11 @@
 
     QUATRO NÍVEIS NA MESMA SAÍDA, com a coluna `nivel` separando os grãos:
 
-      cobertura       por (competição, escopo). `escopo = pool` são os lados que esta medição usa;
-                      `escopo = temporada` são TODOS os lados encerrados da temporada dentro do
-                      teto, e é ali que a afirmação de cobertura do ticket é conferida.
+      cobertura       por (competição, escopo). `pool` são os lados que esta medição usa;
+                      `temporada` são TODOS os lados encerrados da temporada dentro do teto, e é
+                      ali que a afirmação de cobertura do ticket é conferida;
+                      `temporada_sem_filtro_de_fase` é o mesmo sem o filtro `real`, e a diferença
+                      para o anterior é o tamanho do artefato de dedup.
       total           por estrato, todos os times juntos. É a linha do veredito.
       estrato_x_dias  por (estrato, faixa de dias entre os dois jogos). O controle do calendário.
       time            por (time, estrato), só para os times que TÊM par liga↔copa — são os times
@@ -63,16 +66,21 @@
 
     COMO RODAR (do dbt_futebol/):
 
-      # uma vez, se dim_leagues/dim_teams ainda não estiverem no dataset de medição
+      # uma vez, se os nós abaixo ainda não estiverem no dataset de medição — a ancestria das
+      # células não passa por eles, e nenhum dos seis nós de premissas os referencia
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt run --target taskF \
-        --select dim_leagues stg_futebol_leagues dim_teams stg_futebol_teams
+        --select dim_leagues stg_futebol_leagues dim_teams stg_futebol_teams \
+                 fact_fixture_lineups_players stg_futebol_fixture_lineups_players
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
         --select taskf_rodizio_de_elenco
-      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+      bq query --use_legacy_sql=false --max_rows=100000 --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
 
-    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+    ⚠️ DUAS ARMADILHAS DO `bq query`, as duas silenciosas. O SQL como ARGUMENTO trava nesta
+    máquina (sempre por redirecionamento). E o `--max_rows` PRECISA estar lá: o default é 100
+    linhas e ele TRUNCA sem avisar — a saída sai com cara de completa, e a linha que falta é
+    exatamente a do fim da ordenação. Custou uma contagem errada de times durante a própria #57.
 
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */
@@ -153,6 +161,21 @@ xi AS (
     GROUP BY fixture_id, team_id
 ),
 
+{# O MESMO XI SEM O FILTRO DE FASE, que só existe para o custo do filtro ser um número emitido e
+   não uma afirmação do cabeçalho. Ele alimenta o escopo `temporada_sem_filtro_de_fase` do nível
+   `cobertura`, e a diferença entre os dois escopos é exatamente quantos lados a discordância
+   entre a escalação `confirmed` e a `real` inflaria. -#}
+xi_sem_filtro AS (
+    SELECT
+        fixture_id,
+        team_id,
+        CAST(NULL AS ARRAY<INT64>) AS jogadores,
+        COUNT(*)                   AS n_titulares
+    FROM {{ ref('fact_fixture_lineups_players') }}
+    WHERE is_starter
+    GROUP BY fixture_id, team_id
+),
+
 {# Todos os lados encerrados da temporada dentro do teto, INCLUSIVE os de times que não estão no
    universo — é o escopo em que a afirmação do ticket ("cobertura de 100% em todas as
    competições") pode ser conferida. O pool sozinho não a falsificaria: ele só tem os times do
@@ -195,6 +218,18 @@ cobertura AS (
         {{ metricas_de_cobertura }}
     FROM lados_da_temporada AS p
     LEFT JOIN xi AS x
+           ON  x.fixture_id = p.fixture_id
+          AND  x.team_id    = p.team_id
+    GROUP BY p.competition
+
+    UNION ALL
+
+    SELECT
+        p.competition,
+        'temporada_sem_filtro_de_fase',
+        {{ metricas_de_cobertura }}
+    FROM lados_da_temporada AS p
+    LEFT JOIN xi_sem_filtro AS x
            ON  x.fixture_id = p.fixture_id
           AND  x.team_id    = p.team_id
     GROUP BY p.competition

--- a/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+++ b/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
@@ -247,7 +247,7 @@ pares AS (
         COUNT(DISTINCT IF(utilizavel, team_id, NULL))                   AS times,
         ROUND(AVG(IF(utilizavel, sobreposicao, NULL)), 2)               AS sobreposicao_media,
         ROUND(AVG(IF(utilizavel, sobreposicao, NULL)) / 11 * 100, 1)    AS pct_sobreposicao,
-        APPROX_QUANTILES(IF(utilizavel, sobreposicao, NULL), 2)[OFFSET(1)] AS sobreposicao_mediana,
+        {{ taskf_mediana('IF(utilizavel, sobreposicao, NULL)', casas=0) }} AS sobreposicao_mediana,
         MIN(IF(utilizavel, sobreposicao, NULL))                         AS sobreposicao_min,
         ROUND(AVG(IF(utilizavel, dias_entre, NULL)), 1)                 AS dias_entre_medio
 {%- endset %}

--- a/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+++ b/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
@@ -49,7 +49,7 @@
     kickoff antes do teto congelado, encerrados em `FT` — o mesmo filtro do
     `int_futebol_team_form_pit`, para o elenco medido ser o dos jogos que de fato entram na média.
 
-    QUATRO NÍVEIS NA MESMA SAÍDA, com a coluna `nivel` separando os grãos:
+    CINCO NÍVEIS NA MESMA SAÍDA, com a coluna `nivel` separando os grãos:
 
       cobertura       por (competição, escopo). `pool` são os lados que esta medição usa;
                       `temporada` são TODOS os lados encerrados da temporada dentro do teto, e é
@@ -61,6 +61,12 @@
       time            por (time, estrato), só para os times que TÊM par liga↔copa — são os times
                       sobre os quais a pergunta do ticket existe. Quantos ficaram de fora por não
                       ter nenhum sai na linha `total`, em `times_sem_par_liga_copa`.
+      times_do_universo  por categoria de time: quem é cada um dos que ficaram de fora. Existe
+                      porque o `times_sem_par_liga_copa` sozinho convida à leitura "não jogam as
+                      duas coisas", que é verdade para a maioria e falsa para uma parte — há
+                      clube de liga que simplesmente não teve jogo de copa dentro do teto, e há
+                      quem jogue os dois sem que dois deles caiam consecutivos. `lados` aqui é
+                      jogo no pool (não lado), e `times_sem_par_nenhum` conta quem tem um jogo só.
 
     Somar linhas de níveis diferentes conta o mesmo par mais de uma vez — filtre `nivel` sempre.
 
@@ -113,6 +119,21 @@ fixtures AS (
 tipo_competicao AS (
     SELECT DISTINCT league_id AS competition_id, league_type
     FROM {{ ref('dim_leagues') }}
+),
+
+{# NA BASE = alcançado por alguma competição de pontos corridos da coleta. Mesma definição da
+   analyses/taskf_forca_do_adversario.sql, e pelo mesmo motivo: é ela que separa o clube cuja liga
+   não coletamos do clube que simplesmente não jogou copa nesta janela. -#}
+times_na_base AS (
+    SELECT DISTINCT lados.team_id
+    FROM (
+        SELECT home_team_id AS team_id, competition_id FROM fixtures
+        UNION ALL
+        SELECT away_team_id,            competition_id FROM fixtures
+    ) AS lados
+    JOIN tipo_competicao AS t
+      ON  t.competition_id = lados.competition_id
+     AND  t.league_type    = 'League'
 ),
 
 {# Os times do universo congelado, e a temporada deles — as duas coisas que amarram esta medição
@@ -331,6 +352,49 @@ por_time AS (
     GROUP BY p.team_id, p.estrato
 ),
 
+{# QUEM É QUEM NO UNIVERSO. O nível `total` diz quantos times ficaram sem par liga↔copa, e
+   sozinho esse número convida à leitura errada — "não jogam as duas coisas" —, que é verdade para
+   a maioria e falsa para uma parte. Aqui a composição sai medida: seleção não tem liga a jogar;
+   clube sul-americano de Libertadores e Sudamericana tem, mas não a coletamos; e existe ainda o
+   clube de liga que simplesmente não teve jogo de copa dentro do teto congelado, que é outro caso
+   e não pertence a nenhum dos dois. -#}
+perfil_do_time AS (
+    SELECT
+        team_id,
+        COUNT(*)                          AS jogos_no_pool,
+        COUNTIF(league_type = 'League')    AS jogos_de_liga,
+        COUNTIF(league_type = 'Cup')       AS jogos_de_copa
+    FROM pool
+    GROUP BY team_id
+),
+
+categoria_do_time AS (
+    SELECT
+        t.team_id,
+        t.jogos_no_pool,
+        CASE
+            WHEN dt.national          THEN 'selecao'
+            WHEN b.team_id IS NULL    THEN 'clube_sem_liga_na_coleta'
+            WHEN t.jogos_de_copa = 0  THEN 'clube_de_liga_sem_copa_no_pool'
+            WHEN t.jogos_de_liga = 0  THEN 'clube_so_de_copa_no_pool'
+            ELSE                           'joga_os_dois'
+        END AS categoria
+    FROM perfil_do_time AS t
+    LEFT JOIN {{ ref('dim_teams') }} AS dt USING (team_id)
+    LEFT JOIN times_na_base          AS b  USING (team_id)
+),
+
+por_categoria AS (
+    SELECT
+        categoria,
+        COUNT(*)                                                          AS times,
+        SUM(jogos_no_pool)                                                AS jogos_no_pool,
+        COUNTIF(team_id IN (SELECT team_id FROM times_com_par_misto))     AS times_com_par_liga_copa,
+        COUNTIF(jogos_no_pool = 1)                                        AS times_sem_par_nenhum
+    FROM categoria_do_time
+    GROUP BY categoria
+),
+
 empilhado AS (
     SELECT
         'cobertura'           AS nivel,
@@ -351,7 +415,9 @@ empilhado AS (
         CAST(NULL AS INT64)   AS sobreposicao_mediana,
         CAST(NULL AS INT64)   AS sobreposicao_min,
         CAST(NULL AS FLOAT64) AS dias_entre_medio,
-        CAST(NULL AS INT64)   AS times_sem_par_liga_copa
+        CAST(NULL AS INT64)   AS times_sem_par_liga_copa,
+        CAST(NULL AS INT64)   AS times_com_par_liga_copa,
+        CAST(NULL AS INT64)   AS times_sem_par_nenhum
     FROM cobertura
 
     UNION ALL
@@ -364,7 +430,8 @@ empilhado AS (
         sobreposicao_media, pct_sobreposicao, sobreposicao_mediana, sobreposicao_min,
         dias_entre_medio,
         (SELECT COUNT(DISTINCT team_id) FROM pares
-          WHERE team_id NOT IN (SELECT team_id FROM times_com_par_misto))
+          WHERE team_id NOT IN (SELECT team_id FROM times_com_par_misto)),
+        CAST(NULL AS INT64), CAST(NULL AS INT64)
     FROM por_estrato
 
     UNION ALL
@@ -376,7 +443,7 @@ empilhado AS (
         pares_no_estrato, pares, pares_descartados, times,
         sobreposicao_media, pct_sobreposicao, sobreposicao_mediana, sobreposicao_min,
         dias_entre_medio,
-        CAST(NULL AS INT64)
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64)
     FROM por_estrato_dias
 
     UNION ALL
@@ -388,9 +455,21 @@ empilhado AS (
         p.pares_no_estrato, p.pares, p.pares_descartados, p.times,
         p.sobreposicao_media, p.pct_sobreposicao, p.sobreposicao_mediana, p.sobreposicao_min,
         p.dias_entre_medio,
-        CAST(NULL AS INT64)
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64)
     FROM por_time AS p
     LEFT JOIN {{ ref('dim_teams') }} AS t USING (team_id)
+
+    UNION ALL
+
+    SELECT
+        'times_do_universo', 4, categoria, CAST(NULL AS STRING),
+        jogos_no_pool, CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS FLOAT64),
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64), times,
+        CAST(NULL AS FLOAT64), CAST(NULL AS FLOAT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS FLOAT64),
+        CAST(NULL AS INT64), times_com_par_liga_copa, times_sem_par_nenhum
+    FROM por_categoria
 )
 
 SELECT *

--- a/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+++ b/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
@@ -280,11 +280,20 @@ pares AS (
         COUNTIF(utilizavel)                                             AS pares,
         COUNTIF(NOT utilizavel)                                         AS pares_descartados,
         COUNT(DISTINCT IF(utilizavel, team_id, NULL))                   AS times,
-        ROUND(AVG(IF(utilizavel, sobreposicao, NULL)), 2)               AS sobreposicao_media,
-        ROUND(AVG(IF(utilizavel, sobreposicao, NULL)) / 11 * 100, 1)    AS pct_sobreposicao,
+        {#- SUM/COUNT, e não AVG: `sobreposicao` é INT64, a soma dele é exata e a divisão fica
+            determinística. O AVG do BigQuery combina médias parciais em ponto flutuante e o
+            resultado depende de como a execução foi paralelizada — medido na #57, o estrato
+            `copa_copa` na faixa de 4 a 5 dias saiu 8,43 numa execução e 8,42 na seguinte, sobre
+            dado idêntico: a média verdadeira é 8,425 e cai bem em cima do desempate do ROUND.
+            Mesmo argumento do macros/taskf_mediana.sql. -#}
+        ROUND(SAFE_DIVIDE(SUM(IF(utilizavel, sobreposicao, 0)),
+                          COUNTIF(utilizavel)), 2)                      AS sobreposicao_media,
+        ROUND(SAFE_DIVIDE(SUM(IF(utilizavel, sobreposicao, 0)),
+                          COUNTIF(utilizavel)) / 11 * 100, 1)           AS pct_sobreposicao,
         {{ taskf_mediana('IF(utilizavel, sobreposicao, NULL)', casas=0) }} AS sobreposicao_mediana,
         MIN(IF(utilizavel, sobreposicao, NULL))                         AS sobreposicao_min,
-        ROUND(AVG(IF(utilizavel, dias_entre, NULL)), 1)                 AS dias_entre_medio
+        ROUND(SAFE_DIVIDE(SUM(IF(utilizavel, dias_entre, 0)),
+                          COUNTIF(utilizavel)), 1)                      AS dias_entre_medio
 {%- endset %}
 
 por_estrato AS (

--- a/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+++ b/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
@@ -1,0 +1,354 @@
+/*
+    [F-8] RODÍZIO DE ELENCO — o segundo confundidor do merge, com número em vez de opinião.
+
+    O QUE ELE AMEAÇA. A célula `escopo` empresta ao histórico de um time as partidas que ele jogou
+    em outra competição. Se o time entra em campo na copa com OUTRO elenco — poupando titulares
+    para o campeonato —, essas partidas emprestadas descrevem um time que não vai jogar o jogo
+    sobre o qual a premissa decide. O ganho de amostra seria real e a informação, não. O ticket de
+    origem registrou a ressalva sem número; a spec #49 (user story 23) pediu o número.
+
+    A MEDIDA. Para cada time, os jogos dele são postos em ordem de kickoff e cada par de jogos
+    CONSECUTIVOS vira uma observação: quantos dos 11 titulares se repetiram. O par é classificado
+    pelo tipo das duas competições (`dim_leagues.league_type`, derivado do catálogo):
+
+      liga_liga   os dois jogos são de pontos corridos           → é o CONTROLE
+      liga_copa   um de cada — é a pergunta do ticket            → é o TRATAMENTO
+      copa_copa   os dois de copa
+
+    ⚠️ SEM O CONTROLE, O NÚMERO DO TRATAMENTO NÃO QUER DIZER NADA. "7 dos 11 titulares se
+    repetiram entre a liga e a copa" só é rodízio se entre dois jogos DE LIGA se repetirem 11 — e
+    não se repetem: lesão, suspensão e desgaste mexem no XI o tempo todo. O que responde à
+    pergunta do ticket é a DIFERENÇA entre os dois estratos, e é por isso que o controle é medido
+    aqui dentro e não citado de memória.
+
+    ⚠️ E O CONTROLE TEM UM CONFUNDIDOR PRÓPRIO: CALENDÁRIO. Par liga↔copa costuma ser jogo de
+    meio de semana seguido de jogo de fim de semana, e par liga↔liga costuma ter uma semana
+    inteira no meio. Rodízio por congestionamento e rodízio por prioridade de competição são
+    coisas diferentes, e a segunda é a do ticket. Por isso a saída tem o nível
+    `estrato_x_dias`, que corta os dois estratos pela distância entre os jogos: se a diferença
+    entre `liga_copa` e `liga_liga` sobreviver DENTRO da mesma faixa de dias, ela não é
+    calendário.
+
+    ⚠️ A PREMISSA DO CRITÉRIO DE ACEITE É FALSA, E ISSO É RESULTADO. O ticket afirma que "a
+    cobertura de lineups é de 100% em todas as competições". Não é — e falha exatamente onde o
+    próprio ticket manda olhar, as fases iniciais da Copa do Brasil. O nível `cobertura` mede isso
+    por competição, e nenhum lado sem XI utilizável entra num par: ele é contado e descartado, não
+    completado. XI utilizável = exatamente 11 titulares na fase `real`.
+
+    ⚠️ POR QUE A FASE `real`, E NÃO A ESCALAÇÃO INTEIRA. O `fact_fixture_lineups_players` dedupa
+    por (fixture_id, player_id) com latest-wins, e não por (fixture_id, team_id, fase). Quando a
+    escalação `confirmed` (~T-30min) e a `real` (pós-jogo) discordam sobre um jogador, as duas
+    sobrevivem — uma por jogador — e o time aparece com 12 ou 13 "titulares". Medido sobre 2026:
+    92 lados fora de 11 sem o filtro, contra 34 com ele. Os 34 que sobram são falha de coleta, não
+    artefato de dedup, e caem no `cobertura`.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O UNIVERSO. Os times são os do universo congelado da [F] (a mesma macro do resto da task), e
+    os jogos são os que a célula `escopo` teria para emprestar: mesma temporada das âncoras,
+    kickoff antes do teto congelado, encerrados em `FT` — o mesmo filtro do
+    `int_futebol_team_form_pit`, para o elenco medido ser o dos jogos que de fato entram na média.
+
+    QUATRO NÍVEIS NA MESMA SAÍDA, com a coluna `nivel` separando os grãos:
+
+      cobertura       por (competição, escopo). `escopo = pool` são os lados que esta medição usa;
+                      `escopo = temporada` são TODOS os lados encerrados da temporada dentro do
+                      teto, e é ali que a afirmação de cobertura do ticket é conferida.
+      total           por estrato, todos os times juntos. É a linha do veredito.
+      estrato_x_dias  por (estrato, faixa de dias entre os dois jogos). O controle do calendário.
+      time            por (time, estrato), só para os times que TÊM par liga↔copa — são os times
+                      sobre os quais a pergunta do ticket existe. Quantos ficaram de fora por não
+                      ter nenhum sai na linha `total`, em `times_sem_par_liga_copa`.
+
+    Somar linhas de níveis diferentes conta o mesmo par mais de uma vez — filtre `nivel` sempre.
+
+    COMO RODAR (do dbt_futebol/):
+
+      # uma vez, se dim_leagues/dim_teams ainda não estiverem no dataset de medição
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt run --target taskF \
+        --select dim_leagues stg_futebol_leagues dim_teams stg_futebol_teams
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+        --select taskf_rodizio_de_elenco
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set faixas_de_dias = [
+    ('ate_3',     'dias_entre <= 3'),
+    ('4_a_5',     'dias_entre BETWEEN 4 AND 5'),
+    ('6_a_7',     'dias_entre BETWEEN 6 AND 7'),
+    ('8_ou_mais', 'dias_entre >= 8')
+] -%}
+
+WITH {{ task01_base() }},
+
+apostas_congeladas AS (
+    SELECT * FROM apostas
+    WHERE {{ taskf_universo_filtro() }}
+),
+
+universo AS (
+    SELECT DISTINCT fixture_id FROM apostas_congeladas
+),
+
+fixtures AS (
+    SELECT
+        fixture_id, competition, competition_id, season, kickoff_utc,
+        status_short, home_team_id, away_team_id, goals_home, goals_away
+    FROM {{ ref('fact_fixtures') }}
+),
+
+tipo_competicao AS (
+    SELECT DISTINCT league_id AS competition_id, league_type
+    FROM {{ ref('dim_leagues') }}
+),
+
+{# Os times do universo congelado, e a temporada deles — as duas coisas que amarram esta medição
+   ao mesmo recorte do resto da [F]. -#}
+times_do_universo AS (
+    SELECT DISTINCT lado AS team_id, f.season
+    FROM fixtures AS f
+    JOIN universo USING (fixture_id)
+    CROSS JOIN UNNEST([f.home_team_id, f.away_team_id]) AS lado
+),
+
+{# O pool: os jogos que a célula `escopo` teria para emprestar. Mesmo filtro de encerramento do
+   int_futebol_team_form_pit (`FT`), porque o elenco que interessa é o dos jogos que entram na
+   média — jogo decidido na prorrogação ou nos pênaltis não entra em histórico nenhum hoje
+   (issue #71) e por isso também não entra aqui. -#}
+pool AS (
+    SELECT
+        t.team_id,
+        f.fixture_id,
+        f.competition,
+        f.kickoff_utc,
+        tc.league_type
+    FROM times_do_universo AS t
+    JOIN fixtures AS f
+      ON  f.season = t.season
+      AND t.team_id IN (f.home_team_id, f.away_team_id)
+    JOIN tipo_competicao AS tc
+      ON tc.competition_id = f.competition_id
+    WHERE f.status_short = 'FT'
+      AND f.goals_home IS NOT NULL
+      AND f.goals_away IS NOT NULL
+      AND f.kickoff_utc < TIMESTAMP('{{ taskf_universo().teto_utc }}')
+),
+
+{# O XI titular. Ver o cabeçalho para a fase `real`: sem ela o dedup por jogador deixa passar
+   time com 12 e 13 titulares. -#}
+xi AS (
+    SELECT
+        fixture_id,
+        team_id,
+        ARRAY_AGG(player_id) AS jogadores,
+        COUNT(*)             AS n_titulares
+    FROM {{ ref('fact_fixture_lineups_players') }}
+    WHERE is_starter
+      AND lineup_phase = 'real'
+    GROUP BY fixture_id, team_id
+),
+
+{# Todos os lados encerrados da temporada dentro do teto, INCLUSIVE os de times que não estão no
+   universo — é o escopo em que a afirmação do ticket ("cobertura de 100% em todas as
+   competições") pode ser conferida. O pool sozinho não a falsificaria: ele só tem os times do
+   universo, e o adversário de Série C das fases iniciais da Copa do Brasil, que é justamente
+   quem não tem escalação coletada, não está lá. -#}
+lados_da_temporada AS (
+    SELECT f.fixture_id, f.competition, lado AS team_id
+    FROM fixtures AS f
+    CROSS JOIN UNNEST([f.home_team_id, f.away_team_id]) AS lado
+    WHERE f.status_short = 'FT'
+      AND f.goals_home IS NOT NULL
+      AND f.goals_away IS NOT NULL
+      AND f.kickoff_utc < TIMESTAMP('{{ taskf_universo().teto_utc }}')
+      AND f.season IN (SELECT DISTINCT season FROM times_do_universo)
+),
+
+{%- set metricas_de_cobertura %}
+        COUNT(*)                                                  AS lados,
+        COUNTIF(x.n_titulares = 11)                               AS lados_com_xi,
+        COUNTIF(x.fixture_id IS NULL)                             AS lados_sem_lineup,
+        COUNTIF(x.fixture_id IS NOT NULL AND x.n_titulares != 11) AS lados_xi_incompleto
+{%- endset %}
+
+cobertura AS (
+    SELECT
+        p.competition,
+        'pool' AS escopo,
+        {{ metricas_de_cobertura }}
+    FROM pool AS p
+    LEFT JOIN xi AS x
+           ON  x.fixture_id = p.fixture_id
+          AND  x.team_id    = p.team_id
+    GROUP BY p.competition
+
+    UNION ALL
+
+    SELECT
+        p.competition,
+        'temporada',
+        {{ metricas_de_cobertura }}
+    FROM lados_da_temporada AS p
+    LEFT JOIN xi AS x
+           ON  x.fixture_id = p.fixture_id
+          AND  x.team_id    = p.team_id
+    GROUP BY p.competition
+),
+
+{# Cada jogo olha para o ANTERIOR do mesmo time. O par se forma sobre o pool INTEIRO, e não só
+   sobre os jogos com XI utilizável: parear pulando o jogo sem escalação criaria par entre jogos
+   distantes com cara de consecutivos. O par sem XI dos dois lados é contado e descartado. -#}
+sequencia AS (
+    SELECT
+        team_id,
+        fixture_id,
+        kickoff_utc,
+        league_type,
+        LAG(fixture_id)  OVER (PARTITION BY team_id ORDER BY kickoff_utc) AS fixture_anterior,
+        LAG(kickoff_utc) OVER (PARTITION BY team_id ORDER BY kickoff_utc) AS kickoff_anterior,
+        LAG(league_type) OVER (PARTITION BY team_id ORDER BY kickoff_utc) AS tipo_anterior
+    FROM pool
+),
+
+pares AS (
+    SELECT
+        s.team_id,
+        CASE
+            WHEN s.league_type = 'League' AND s.tipo_anterior = 'League' THEN 'liga_liga'
+            WHEN s.league_type = 'Cup'    AND s.tipo_anterior = 'Cup'    THEN 'copa_copa'
+            ELSE                                                             'liga_copa'
+        END                                                       AS estrato,
+        TIMESTAMP_DIFF(s.kickoff_utc, s.kickoff_anterior, DAY)    AS dias_entre,
+        xa.n_titulares = 11 AND xb.n_titulares = 11               AS utilizavel,
+        (SELECT COUNT(*) FROM UNNEST(xa.jogadores) AS j
+          WHERE j IN UNNEST(xb.jogadores))                        AS sobreposicao
+    FROM sequencia AS s
+    LEFT JOIN xi AS xa
+           ON  xa.fixture_id = s.fixture_id
+          AND  xa.team_id    = s.team_id
+    LEFT JOIN xi AS xb
+           ON  xb.fixture_id = s.fixture_anterior
+          AND  xb.team_id    = s.team_id
+    WHERE s.fixture_anterior IS NOT NULL
+),
+
+{# A lista de métricas existe UMA vez e é renderizada nos três níveis que compartilham o grão de
+   par. `pares_descartados` fica ao lado de `pares` de propósito: um estrato cuja cobertura de
+   escalação é ruim tem de mostrar isso na mesma linha em que mostra a média. -#}
+{%- set metricas_de_par %}
+        COUNT(*)                                                        AS pares_no_estrato,
+        COUNTIF(utilizavel)                                             AS pares,
+        COUNTIF(NOT utilizavel)                                         AS pares_descartados,
+        COUNT(DISTINCT IF(utilizavel, team_id, NULL))                   AS times,
+        ROUND(AVG(IF(utilizavel, sobreposicao, NULL)), 2)               AS sobreposicao_media,
+        ROUND(AVG(IF(utilizavel, sobreposicao, NULL)) / 11 * 100, 1)    AS pct_sobreposicao,
+        APPROX_QUANTILES(IF(utilizavel, sobreposicao, NULL), 2)[OFFSET(1)] AS sobreposicao_mediana,
+        MIN(IF(utilizavel, sobreposicao, NULL))                         AS sobreposicao_min,
+        ROUND(AVG(IF(utilizavel, dias_entre, NULL)), 1)                 AS dias_entre_medio
+{%- endset %}
+
+por_estrato AS (
+    SELECT estrato, {{ metricas_de_par }}
+    FROM pares
+    GROUP BY estrato
+),
+
+por_estrato_dias AS (
+    SELECT
+        estrato,
+        CASE
+        {%- for nome, predicado in faixas_de_dias %}
+            WHEN {{ predicado }} THEN '{{ nome }}'
+        {%- endfor %}
+        END AS faixa_de_dias,
+        {{ metricas_de_par }}
+    FROM pares
+    GROUP BY estrato, faixa_de_dias
+),
+
+{# Só os times que TÊM par liga↔copa: são aqueles sobre os quais a pergunta do ticket existe.
+   Quem não tem nenhum não é um time sem rodízio, é um time que não joga as duas coisas — e
+   misturar os dois casos numa média por time responderia outra pergunta. -#}
+times_com_par_misto AS (
+    SELECT DISTINCT team_id
+    FROM pares
+    WHERE estrato = 'liga_copa' AND utilizavel
+),
+
+por_time AS (
+    SELECT p.team_id, p.estrato, {{ metricas_de_par }}
+    FROM pares AS p
+    JOIN times_com_par_misto USING (team_id)
+    GROUP BY p.team_id, p.estrato
+),
+
+empilhado AS (
+    SELECT
+        'cobertura'           AS nivel,
+        0                     AS nivel_ord,
+        competition           AS chave,
+        escopo                AS chave2,
+        lados,
+        lados_com_xi,
+        lados_sem_lineup,
+        lados_xi_incompleto,
+        ROUND(SAFE_DIVIDE(lados_com_xi, lados) * 100, 1) AS pct_com_xi,
+        CAST(NULL AS INT64)   AS pares_no_estrato,
+        CAST(NULL AS INT64)   AS pares,
+        CAST(NULL AS INT64)   AS pares_descartados,
+        CAST(NULL AS INT64)   AS times,
+        CAST(NULL AS FLOAT64) AS sobreposicao_media,
+        CAST(NULL AS FLOAT64) AS pct_sobreposicao,
+        CAST(NULL AS INT64)   AS sobreposicao_mediana,
+        CAST(NULL AS INT64)   AS sobreposicao_min,
+        CAST(NULL AS FLOAT64) AS dias_entre_medio,
+        CAST(NULL AS INT64)   AS times_sem_par_liga_copa
+    FROM cobertura
+
+    UNION ALL
+
+    SELECT
+        'total', 1, estrato, CAST(NULL AS STRING),
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS FLOAT64),
+        pares_no_estrato, pares, pares_descartados, times,
+        sobreposicao_media, pct_sobreposicao, sobreposicao_mediana, sobreposicao_min,
+        dias_entre_medio,
+        (SELECT COUNT(DISTINCT team_id) FROM pares
+          WHERE team_id NOT IN (SELECT team_id FROM times_com_par_misto))
+    FROM por_estrato
+
+    UNION ALL
+
+    SELECT
+        'estrato_x_dias', 2, estrato, faixa_de_dias,
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS FLOAT64),
+        pares_no_estrato, pares, pares_descartados, times,
+        sobreposicao_media, pct_sobreposicao, sobreposicao_mediana, sobreposicao_min,
+        dias_entre_medio,
+        CAST(NULL AS INT64)
+    FROM por_estrato_dias
+
+    UNION ALL
+
+    SELECT
+        'time', 3, COALESCE(t.team_name, FORMAT('team_id=%d', p.team_id)), p.estrato,
+        CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64), CAST(NULL AS INT64),
+        CAST(NULL AS FLOAT64),
+        p.pares_no_estrato, p.pares, p.pares_descartados, p.times,
+        p.sobreposicao_media, p.pct_sobreposicao, p.sobreposicao_mediana, p.sobreposicao_min,
+        p.dias_entre_medio,
+        CAST(NULL AS INT64)
+    FROM por_time AS p
+    LEFT JOIN {{ ref('dim_teams') }} AS t USING (team_id)
+)
+
+SELECT *
+FROM empilhado
+ORDER BY nivel_ord, chave, chave2

--- a/dbt_futebol/macros/taskf_mediana.sql
+++ b/dbt_futebol/macros/taskf_mediana.sql
@@ -1,0 +1,43 @@
+{#
+    MEDIANA EXATA E REPRODUTÍVEL, para agregado com GROUP BY.
+
+    Por que existe. O caminho óbvio em BigQuery é `APPROX_QUANTILES(x, 2)[OFFSET(1)]`, e ele **não
+    é reproduzível**: é um sketch, e o resultado depende de como a execução foi paralelizada.
+    Medido durante a #57, sobre dado idêntico e query idêntica, em duas execuções seguidas: a
+    mediana de `ppg` do histórico nativo do Brasileirão saiu 1,313 e depois 1,294, e a da Copa do
+    Mundo saiu 1,333 e depois 1,0. `PERCENTILE_CONT` resolveria, mas é função analítica — não
+    entra num SELECT com GROUP BY sem uma segunda passada.
+
+    Isso importa mais aqui do que importaria em outro lugar: os números destas análises são
+    PUBLICADOS em `docs/TASKF_RESULTADOS.md` e a task inteira se apoia em comparar execuções.
+    Este repositório já gastou tempo caçando bug inexistente atrás de número que se mexia sozinho
+    (a instabilidade do mercado de Gols, em `docs/TASK01_RESULTADOS.md`); uma segunda fonte de
+    ruído, essa evitável, não vale a economia de uma linha.
+
+    A forma abaixo ordena o grupo inteiro e indexa — exata por construção, determinística, e o
+    custo é irrelevante nas dezenas de milhares de linhas que estas análises agregam. Para
+    contagem par devolve o menor dos dois centrais (mediana inferior), o que é declarado e não
+    descoberto. Grupo em que TODOS os valores são NULL devolve NULL: o array sai vazio, `DIV(-1,
+    2)` dá 0 e o `SAFE_OFFSET` de um array vazio é NULL — a mesma degradação graciosa do resto do
+    projeto, e está coberto pelo caso `c` do teste de mesa abaixo.
+
+    ⚠️ O índice é calculado com `COUNTIF(... IS NOT NULL)`, e não com `ARRAY_LENGTH` do próprio
+    agregado: o BigQuery recusa `ARRAY_AGG` dentro de `UNNEST` ("Aggregate function ARRAY_AGG not
+    allowed in UNNEST"), que é a forma óbvia de dar nome ao array para medi-lo. As duas expressões
+    são agregados do mesmo GROUP BY e contam o mesmo conjunto, porque as duas ignoram NULL.
+
+    Teste de mesa (rodado): três grupos — 'a' com [1,2,3,NULL] devolve 2,0; 'b' com [10,20]
+    devolve 10,0 (mediana inferior); 'c' com [NULL] devolve NULL.
+
+    Uso (dentro de um SELECT com GROUP BY):
+
+        SELECT competicao, {{ taskf_mediana('adv_ppg') }} AS ppg_mediana
+        FROM ... GROUP BY competicao
+#}
+
+{% macro taskf_mediana(coluna, casas=3) %}
+    ROUND(
+        ARRAY_AGG({{ coluna }} IGNORE NULLS ORDER BY {{ coluna }})
+            [SAFE_OFFSET(DIV(COUNTIF(({{ coluna }}) IS NOT NULL) - 1, 2))],
+        {{ casas }})
+{%- endmacro %}

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1414,3 +1414,362 @@ análise da fronteira sai com **uma** linha.
 
 ⚠️ `bq query` com o SQL como argumento trava nesta máquina; por redirecionamento ou heredoc,
 funciona.
+
+---
+
+## Ticket #57 — Os dois confundidores, medidos
+
+`analyses/taskf_forca_do_adversario.sql` + `analyses/taskf_rodizio_de_elenco.sql` · execução
+2026-08-13 14:37–14:38 UTC · commit `7fdf1b3` · dataset `futebol_taskF`
+
+Os dois confundidores que podem inverter a recomendação da task: se o ganho de amostra do merge
+vier com viés de nível, ou descrever um elenco que não entra em campo, juntar deixa de ser
+gratuito. O ticket de origem registrou o segundo como ressalva sem número e não mencionou o
+primeiro; a spec #49 pediu os dois com número.
+
+### Veredito
+
+**Força do adversário — efeito PEQUENO no que dá para medir, e o achado é o que não dá.** Na
+única régua comparável entre competições — o `ppg` de liga do adversário — a partida emprestada
+vale **1,387** contra **1,341** da nativa: 0,046 de diferença, nada. A mistura de nível que a
+spec teme existe e é fina: 27 das 1.364 partidas do histórico fundido de um time de Brasileirão
+são contra Série B (2,0%), e 40 das 1.542 de um time de Série B são contra Série A (2,6%). O que é
+grande é o buraco: **40,7% das partidas emprestadas são contra adversário que a coleta não
+alcança**, contra 3,5% das nativas — e é justamente nelas que o perfil de gols é outro.
+
+**Rodízio de elenco — efeito REAL e MODERADO, 1,46 titular de 11.** Entre dois jogos consecutivos
+de liga o mesmo time repete **8,34** dos 11 titulares; entre um jogo de liga e um de copa, apenas
+**6,88**. A diferença sobrevive ao controle de calendário, então não é congestionamento. Mas não é
+elenco reserva: entre dois jogos de liga o XI já troca 2,66 titulares sozinho, e a copa acrescenta
+1,46 a isso — uma troca e meia a mais, não outro time.
+
+Nenhum dos dois inverte a recomendação. Os dois entram na [B] como ressalva com tamanho: o merge
+não é gratuito, mas o que ele cobra é 1,5 titular de elenco e uma fração de 2% a 3% de histórico
+de nível diferente — e não o viés estrutural que o desenho temia.
+
+### A conferência vem antes de tudo
+
+A análise de força **reconstrói** o join de histórico do `int_futebol_team_form_pit`, porque
+precisa da partida individual e o carimbo guarda só a contagem. Reconstrução é cópia, e cópia
+deriva do original em silêncio — bastaria esquecer o `l.season = a.season` para o número sair
+maior e com cara de certo.
+
+Por isso a primeira linha da saída não é resultado, é conferência, par a par contra o carimbo das
+células (#53):
+
+| pares | batem a `base` | batem o `escopo` | veredito |
+|---|---|---|---|
+| 338 | **338** | **338** | `EXATA` |
+
+As partidas classificadas como `nativa` são exatamente o `played_total` que a célula `base`
+gravou, e o total (nativa + emprestada) exatamente o da `escopo`. O universo sai com **169** jogos,
+o gabarito da macro. Sem essa linha verde, nada abaixo dela significa o que diz.
+
+### O histórico, e de onde vem a parte emprestada
+
+4.021 partidas alimentam as 338 âncoras do universo congelado. O merge acrescenta 1.159 delas
+(28,8%) — e a composição não é a mesma nas duas metades:
+
+| origem | partidas | adversário com `ppg` | fora da base | seleção |
+|---|---|---|---|---|
+| nativa | 2.862 | 2.306 | 101 (**3,5%**) | 313 (10,9%) |
+| emprestada | 1.159 | 598 | 472 (**40,7%**) | 0 |
+
+Por competição-âncora, só a parte emprestada:
+
+| âncora | partidas emprestadas | fora da base | de onde vêm |
+|---|---|---|---|
+| brasileirao | 322 | **71,7%** | libertadores 121, copa_do_brasil 107, sudamericana 94 |
+| serie_b | 174 | 54,6% | copa_do_brasil 174 |
+| sudamericana | 275 | 31,3% | brasileirao 156, libertadores 103, copa_do_brasil 16 |
+| copa_do_brasil | 388 | 15,5% | brasileirao 288, serie_b 40, libertadores 30, sudamericana 30 |
+| copa_mundo | **0** | — | — |
+
+⚠️ **O merge corta nos dois sentidos, e isso ninguém tinha escrito.** Para âncora de LIGA ele
+piora a visibilidade do adversário: o histórico nativo de um time de Brasileirão é 100% contra
+adversário que enxergamos, e o emprestado é 71,7% contra adversário que não. Para âncora de COPA
+ele **melhora**: o histórico nativo da Copa do Brasil tem 31,4% de adversário fora da base e o
+emprestado tem 15,5%, porque o que ele empresta é jogo de campeonato nacional. Para a Copa do
+Mundo não há o que emprestar — zero partidas, o que reproduz por outro caminho o que a #53 já
+sabia.
+
+E o peso importa: para âncora de copa o histórico emprestado é a MAIOR PARTE do fundido — 388 de
+423 na Copa do Brasil (91,7%) e 275 de 379 na Sudamericana (72,6%). O merge não complementa o
+passado dessas âncoras, ele praticamente o constitui.
+
+⚠️ **A spec supôs que o buraco era Série C e D. É maior.** O adversário invisível de um time de
+Brasileirão não vem da Copa do Brasil (só 16 das 235 partidas dele contra time fora da base): vem
+da **Libertadores e da Sudamericana**, 121 e 94 partidas, 100% contra clube sul-americano cuja
+liga nacional não coletamos. A Série C e D existem e são o caso da Série B (95 partidas), mas no
+agregado o continente pesa mais que a divisão de acesso.
+
+### ⚠️ `ppg` de copa de mata-mata é sobrevivência, não força
+
+A leitura ingênua do `ppg` PIT diz que a partida emprestada foi contra adversário **mais forte**:
+1,622 contra 1,366 da nativa. É artefato, e a régua que o denuncia está na própria saída
+(`nivel = 'ppg_referencia'` — a média de `ppg` sobre todas as linhas do PIT de cada competição):
+
+| competição | média de `ppg` |
+|---|---|
+| Copa do Brasil | **2,609** |
+| Champions (qualifs) | 1,750 |
+| Copa do Mundo | 1,661 |
+| Sudamericana | 1,565 |
+| Libertadores | 1,438 |
+| Brasileirão | 1,364 |
+| Série B | 1,333 |
+
+Numa liga de pontos corridos a média é quase constante por construção, e medido é isso: 1,364 e
+1,333. Numa copa de mata-mata quem perde é eliminado e para de jogar, então quem chega à rodada
+seguinte é quem venceu — e a média sobe para 2,609. A Libertadores, que tem fase de grupos, volta
+para 1,438 e confirma o mecanismo.
+
+Consequência prática: **o `ppg` que o modelo calcula não serve para comparar adversários entre
+competições.** O `ppg_liga_medio` corrige a sobrevivência — é sempre calculado sobre jogos de
+pontos corridos — e é ele que dá o 1,387 contra 1,341 do veredito. Mas nem ele mede NÍVEL: continua
+relativo à liga do adversário, e um time de Série B com 1,40 não vale o mesmo que um de Série A
+com 1,40. Nível só sai da liga a que o adversário pertence, que é o nível `liga_do_adversario`.
+
+⚠️ E a régua corrigida **cobre pouco justamente onde importa**: só 632 das 1.159 partidas
+emprestadas (54,5%) têm `ppg` de liga, contra 2.312 das 2.862 nativas (80,8%). O 1,387 descreve a
+metade visível da amostra emprestada e é silencioso sobre a outra.
+
+### O canal por onde o viés chega: os gols
+
+As premissas leem médias de gols, não `ppg`. É ali que o efeito aparece:
+
+| âncora | origem | gols pró | gols contra |
+|---|---|---|---|
+| brasileirao | nativa | 1,333 | 1,321 |
+| | emprestada | 1,457 | 0,826 |
+| | **fundida** | **1,362** | **1,205** |
+| serie_b | nativa | 1,149 | 1,139 |
+| | emprestada | 1,649 | 0,615 |
+| | **fundida** | **1,206** | **1,080** |
+
+O merge move a média de gols sofridos em **−0,116** no Brasileirão (−8,8%) e **−0,059** na Série B
+(−5,2%), e a de gols marcados em +0,029 e +0,057. É pouco em valor absoluto, e é sempre no mesmo
+sentido: o time fundido parece marcar um pouco mais e sofrer bem menos.
+
+O extremo mostra por quê. As 95 partidas em que um time de Série B enfrentou adversário fora da
+base — Copa do Brasil, fases iniciais — têm **2,221 gols pró e 0,168 contra**. Nenhum jogo de
+campeonato se parece com isso. São 6,2% do histórico fundido da Série B, e é essa fração que puxa.
+As premissas que leem defesa (`defesa_forte`, `clean_sheets_altos`, `defesas_firmes`) são as
+expostas.
+
+### Rodízio: é o controle que dá sentido ao número
+
+"6,88 dos 11 titulares se repetem entre a liga e a copa" não quer dizer nada sozinho — lesão,
+suspensão e desgaste mexem no XI o tempo todo. O que responde é a comparação com o par liga↔liga
+dos mesmos times, medida na mesma execução:
+
+| estrato | pares | sobreposição média | % dos 11 | mediana | dias entre |
+|---|---|---|---|---|---|
+| liga ↔ liga (**controle**) | 635 | **8,34** | 75,8% | 9 | 7,7 |
+| liga ↔ copa (**tratamento**) | 300 | **6,88** | 62,5% | 7 | 3,2 |
+| copa ↔ copa | 243 | 8,32 | 75,6% | 9 | 9,1 |
+
+Duas leituras. A primeira: o rodízio é da TRANSIÇÃO entre competições, não da copa — dois jogos de
+copa seguidos repetem tanto quanto dois de liga (8,32 contra 8,34). A segunda: a diferença é
+**−1,46 titular**, ou 13,3 pp.
+
+### O rodízio não é calendário — e isso foi medido, não suposto
+
+Par liga↔copa tem 3,2 dias no meio e par liga↔liga tem 7,7. Rodízio por congestionamento e rodízio
+por prioridade de competição são coisas diferentes, e só a segunda é a pergunta do ticket.
+Cortando os dois estratos pela mesma distância entre jogos:
+
+| dias entre os jogos | liga ↔ liga | liga ↔ copa | diferença |
+|---|---|---|---|
+| até 3 | 8,17 (n=127) | 6,81 (n=215) | **−1,36** |
+| 4 a 5 | 8,58 (n=119) | 6,96 (n=77) | **−1,62** |
+| 6 a 7 | 8,61 (n=211) | 8,00 (n=3) | −0,61 |
+| 8 ou mais | 7,98 (n=178) | 7,80 (n=5) | −0,18 |
+
+Nas duas faixas com amostra dos dois lados a diferença sobrevive inteira. As duas de baixo têm 3 e
+5 pares no tratamento e não sustentam leitura — ficam na tabela porque escondê-las faria o corte
+parecer mais limpo do que é.
+
+### Por time: 24 dos 33 caem, e o topo é quem joga continental
+
+| time | liga ↔ copa | liga ↔ liga | delta |
+|---|---|---|---|
+| Vasco da Gama | 4,58 (n=19) | 9,20 (n=10) | **−4,62** |
+| São Bernardo | 6,00 (n=1) | 8,89 (n=19) | −2,89 |
+| Mirassol | 5,59 (n=17) | 8,09 (n=11) | −2,50 |
+| Flamengo | 5,21 (n=14) | 7,67 (n=12) | −2,46 |
+| Athletic Club | 6,80 (n=5) | 8,71 (n=17) | −1,91 |
+| Atletico-MG | 6,60 (n=15) | 8,50 (n=12) | −1,90 |
+| … 18 times entre −1,68 e −0,01 … | | | |
+| Santos | 7,68 (n=19) | 7,00 (n=10) | +0,68 |
+| Vitoria | 9,20 (n=5) | 8,17 (n=18) | +1,03 |
+| Londrina | 10,00 (n=1) | 8,84 (n=19) | +1,16 |
+| Corinthians | 7,00 (n=17) | 5,83 (n=12) | **+1,17** |
+
+Os 33 times com par liga↔copa têm todos os dois estratos: **24 caem e 9 sobem**. O rodízio não é
+regra de campeonato, é escolha de clube — e os que mais poupam são os que disputam Libertadores e
+Sudamericana. Os outros 67 times do universo não têm nenhum par liga↔copa, porque não jogam as
+duas coisas: as 48 seleções da Copa do Mundo e os clubes sul-americanos cuja liga não coletamos.
+
+### ⚠️ A cobertura de lineups NÃO é de 100% em todas as competições
+
+O critério de aceite do ticket parte dessa afirmação. Ela é falsa, e falha exatamente onde o
+próprio ticket manda olhar:
+
+| competição | lados encerrados na temporada | com XI utilizável | % |
+|---|---|---|---|
+| Copa do Brasil | 202 | 141 | **69,8%** |
+| Libertadores | 236 | 231 | 97,9% |
+| Sudamericana | 242 | 240 | 99,2% |
+| Brasileirão | 410 | 410 | 100,0% |
+| Série B | 400 | 400 | 100,0% |
+| Copa do Mundo | 190 | 190 | 100,0% |
+| Champions | 102 | 102 | 100,0% |
+
+Os 61 lados de Copa do Brasil sem XI utilizável — 46 sem escalação nenhuma e 15 com escalação
+incompleta — estão nas fases iniciais, as mesmas em que o adversário está fora da base. **Os dois
+confundidores têm o mesmo ponto cego**, e ele é estrutural: nas primeiras rodadas o adversário é
+de Série C ou D, e a API não traz nem a classificação dele nem a escalação do jogo.
+
+Dentro do pool que esta medição usa o estrago é menor — 94,8% a 100% —, porque o pool só tem times
+do universo e o time de Série C não está lá. Nenhum lado sem XI utilizável entrou num par: foram
+contados e descartados (7 pares no `copa_copa`, 0 nos outros dois), nunca completados.
+
+### O que a fase `real` da escalação evitou
+
+`fact_fixture_lineups_players` dedupa por (fixture_id, player_id) com latest-wins, e não por
+(fixture_id, team_id, fase). Quando a escalação `confirmed` (~T-30min) e a `real` (pós-jogo)
+discordam sobre um jogador, as duas sobrevivem — uma por jogador — e o time aparece com 12 ou 13
+"titulares". O escopo `temporada_sem_filtro_de_fase` do nível `cobertura` repete a contagem sem o
+filtro, e a diferença é o tamanho do artefato:
+
+| competição | sem filtro de fase | com filtro `real` | lados que o artefato criaria |
+|---|---|---|---|
+| Série B | 383 de 400 | 400 de 400 | 17 |
+| Copa do Mundo | 178 de 190 | 190 de 190 | 12 |
+| Sudamericana | 238 de 242 | 240 de 242 | 2 |
+| Brasileirão | 409 de 410 | 410 de 410 | 1 |
+| Copa do Brasil | 140 de 202 | 141 de 202 | 1 |
+
+Sem o filtro, 33 lados entrariam na medição com XI de tamanho errado — e "sobreposição de 11"
+estaria comparando conjuntos de tamanhos diferentes, inflando o número sem ninguém ver. O que
+sobra depois do filtro é falha de coleta, não dedup, e é o que a tabela anterior mostra.
+
+### ⚠️ Dois números publicados não eram reproduzíveis, e um terceiro estava truncado
+
+Achados de percurso, os três corrigidos antes de qualquer número desta seção ser escrito. Ficam
+registrados porque nenhum deles é específico da #57 — os três voltam a morder na próxima análise
+que alguém escrever neste repositório.
+
+1. **`APPROX_QUANTILES` é um sketch.** Duas execuções seguidas, dado idêntico e query idêntica,
+   devolveram **1,313 e depois 1,294** para a mediana de `ppg` do histórico nativo do Brasileirão,
+   e **1,333 e depois 1,0** para a da Copa do Mundo. `macros/taskf_mediana.sql` ordena o grupo e
+   indexa — exata e determinística.
+
+2. **`AVG` sobre inteiro empata no arredondamento.** O estrato `copa_copa` na faixa de 4 a 5 dias
+   saiu **8,43 e depois 8,42**: a média verdadeira é 8,425, cai em cima do desempate do `ROUND`, e
+   o `AVG` do BigQuery combina médias parciais em ponto flutuante. Onde o somando é INT64
+   (sobreposição, dias entre jogos, gols) a média passou a sair de `SUM/COUNT`. Os dois `ppg_*`
+   seguem em `AVG`, porque o somando já é FLOAT64 e não há soma exata a recuperar — está declarado
+   no comentário da análise, não escondido.
+
+3. **`bq query` trunca em 100 linhas por padrão, calado.** A análise de rodízio tem 117 linhas: o
+   nível `time` perdia os últimos times em ordem alfabética, e a contagem saiu **29 times quando
+   são 33** — com Vasco da Gama, que é o maior efeito de rodízio da tabela, entre os cortados. A
+   saída sai com cara de completa. `--max_rows` está agora nos dois cabeçalhos, ao lado da
+   armadilha que já se conhecia (SQL como argumento trava a máquina).
+
+### O que ficou de fora, e por quê
+
+- **O rótulo `fora_da_base` do nível `liga_do_adversario` não bate exatamente com a coluna
+  `adv_fora_da_base`**: 583 partidas contra 573, 10 em 4.021. A coluna é por base inteira (o time
+  tem liga em ALGUMA temporada?) e o rótulo é por temporada (tem liga NAQUELA?). São 40 times nessa
+  situação, quase todos rebaixados ou promovidos entre o backfill de 24/25 e agora — Amazonas,
+  Brusque, Ferroviária, Burnley, Empoli. Fica declarado em vez de reconciliado: as duas perguntas
+  são legítimas e a diferença entre elas é informação.
+- **Nenhuma medida ABSOLUTA de nível foi construída.** Um rating cross-liga responderia "Série B
+  vale quanto de Série A?", não existe na base e não cabe numa task de medição. O que existe é a
+  liga a que o adversário pertence, que é observável, e é com ela que o veredito é dado.
+- **`dim_leagues`, `dim_teams` e `fact_fixture_lineups_players` entraram no dataset de medição.** A
+  ancestria das quatro células não passava por eles. Nenhum dos seis nós de premissas os
+  referencia, então materializá-los no `futebol_taskF` não toca célula nenhuma — mas quem
+  reproduzir precisa rodá-los antes, e o comando está na Reprodução.
+
+### Por que esta seção não vira guarda
+
+Mesmo argumento da #56: guarda que fica vermelha por trabalho alheio deixa de ser sinal.
+
+- A cobertura de escalação **melhora sozinha** quando a API preenche um jogo antigo, e piora quando
+  uma liga nova entra sem lineups. Nos dois casos o vermelho não seria da [F].
+- O conjunto de partidas do histórico **não tem limite inferior de tempo dentro da temporada**, e
+  backfill de temporada corrente move as contagens legitimamente.
+- A conferência que de fato precisa ser cobrada — reconstrução contra carimbo — **já está dentro da
+  análise**, como primeira linha e com veredito próprio. Quem rodar vê `EXATA` ou vê o número
+  divergente, sem conferir de olho e sem deixar nada vermelho para quem não pediu.
+
+### Reprodução
+
+```bash
+cd dbt_futebol
+
+# uma vez: os três nós que faltavam no dataset de medição (não tocam célula nenhuma)
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt run --target taskF \
+  --select dim_leagues stg_futebol_leagues dim_teams stg_futebol_teams \
+           fact_fixture_lineups_players stg_futebol_fixture_lineups_players
+
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+  --select taskf_forca_do_adversario taskf_rodizio_de_elenco
+
+bq query --use_legacy_sql=false --max_rows=100000 --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_forca_do_adversario.sql
+bq query --use_legacy_sql=false --max_rows=100000 --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_rodizio_de_elenco.sql
+
+# os dois números de passagem desta seção que não saem das análises
+bq query --use_legacy_sql=false --project_id=smartbetting-dados <<'SQL'
+-- (a) o `ppg` é invariante de célula? (ADR 0008) — a produção contra a última célula
+--     materializada no dataset de medição, que é a `ambos`
+WITH p AS (
+  SELECT fixture_id, team_id, ppg FROM `smartbetting-dados.futebol.int_futebol_team_form_pit`
+  WHERE season = 2026 AND kickoff_utc < TIMESTAMP('2026-08-04 12:00:00')
+),
+t AS (
+  SELECT fixture_id, team_id, ppg FROM `smartbetting-dados.futebol_taskF.int_futebol_team_form_pit`
+  WHERE season = 2026 AND kickoff_utc < TIMESTAMP('2026-08-04 12:00:00')
+)
+SELECT COUNT(*) AS pares, COUNTIF(COALESCE(p.ppg,-1) = COALESCE(t.ppg,-1)) AS ppg_igual
+FROM p JOIN t USING (fixture_id, team_id)
+SQL
+
+bq query --use_legacy_sql=false --project_id=smartbetting-dados <<'SQL'
+-- (b) quem tem liga na base mas NÃO em 2026 — explica o descasamento de 583 contra 573
+WITH tipos AS (
+  SELECT DISTINCT league_id AS competition_id, league_type
+  FROM `smartbetting-dados.futebol_taskF.dim_leagues`
+),
+lados AS (
+  SELECT home_team_id AS team_id, competition_id, season FROM `smartbetting-dados.futebol.fact_fixtures`
+  UNION ALL
+  SELECT away_team_id, competition_id, season FROM `smartbetting-dados.futebol.fact_fixtures`
+),
+liga_por_time_season AS (
+  SELECT DISTINCT l.team_id, l.season
+  FROM lados l JOIN tipos t USING (competition_id)
+  WHERE t.league_type = 'League'
+)
+SELECT
+  COUNT(DISTINCT team_id) AS times_na_base,
+  COUNT(DISTINCT IF(team_id NOT IN (SELECT team_id FROM liga_por_time_season WHERE season = 2026),
+                    team_id, NULL)) AS na_base_mas_sem_liga_em_2026
+FROM liga_por_time_season
+SQL
+```
+
+A análise de força sai com **55 linhas** (1 de conferência, 3 de total, 14 de competição, 11 de
+fonte, 19 de liga do adversário e 7 de referência de `ppg`) e a de rodízio com **117** (20 de
+cobertura, 3 de total, 12 de estrato × dias e 82 de time). As duas leem o carimbo das células
+`base` e `escopo`, que precisa estar gravado — já estava, da #53. A consulta (a) devolve **1.916 de
+1.916** e a (b), **40 de 194**.
+
+⚠️ `bq query` com o SQL como argumento trava nesta máquina; por redirecionamento ou heredoc,
+funciona. E sem `--max_rows` ele corta em 100 linhas sem avisar.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1420,7 +1420,7 @@ funciona.
 ## Ticket #57 — Os dois confundidores, medidos
 
 `analyses/taskf_forca_do_adversario.sql` + `analyses/taskf_rodizio_de_elenco.sql` · execução
-2026-08-13 14:37–14:38 UTC · commit `7fdf1b3` · dataset `futebol_taskF`
+2026-08-13 14:55–14:57 UTC · commit `d6ad236` · dataset `futebol_taskF`
 
 Os dois confundidores que podem inverter a recomendação da task: se o ganho de amostra do merge
 vier com viés de nível, ou descrever um elenco que não entra em campo, juntar deixa de ser
@@ -1608,8 +1608,28 @@ parecer mais limpo do que é.
 
 Os 33 times com par liga↔copa têm todos os dois estratos: **24 caem e 9 sobem**. O rodízio não é
 regra de campeonato, é escolha de clube — e os que mais poupam são os que disputam Libertadores e
-Sudamericana. Os outros 67 times do universo não têm nenhum par liga↔copa, porque não jogam as
-duas coisas: as 48 seleções da Copa do Mundo e os clubes sul-americanos cuja liga não coletamos.
+Sudamericana.
+
+Os outros **67** não têm nenhum par liga↔copa, e "não jogam as duas coisas" só explica a maioria
+deles. O nível `times_do_universo` mede quem são, porque a leitura preguiçosa dessa linha é
+exatamente o tipo de coisa que a [B] herdaria como verdade:
+
+| categoria | times | jogos no pool | com par liga↔copa |
+|---|---|---|---|
+| seleção (Copa do Mundo) | 48 | 190 | 0 |
+| clube cuja liga nacional não coletamos | 12 | 102 | 0 |
+| clube de liga sem jogo de copa dentro do teto | 6 | 120 | 0 |
+| joga os dois | 34 | 878 | **33** |
+
+São **100 times no universo**, e 100 − 33 = 67 fecha. Os 6 da terceira linha não são time que não
+joga copa: são time de liga que, dentro do teto congelado, não teve jogo de copa — outro caso, e
+não pertence a nenhum dos dois primeiros. E um dos 34 que jogam os dois nunca teve dois jogos
+consecutivos de tipos diferentes, então não produziu par.
+
+⚠️ O `times_sem_par_liga_copa` é contado sobre quem tem PELO MENOS UM par de qualquer tipo, então
+time com um único jogo no pool escaparia dele. Hoje não escapa ninguém — `times_sem_par_nenhum` é
+**0** nas quatro categorias —, e é por isso que a conta fecha em 100. A coluna existe para que o
+dia em que deixar de fechar seja visível em vez de calado.
 
 ### ⚠️ A cobertura de lineups NÃO é de 100% em todas as competições
 
@@ -1633,7 +1653,9 @@ de Série C ou D, e a API não traz nem a classificação dele nem a escalação
 
 Dentro do pool que esta medição usa o estrago é menor — 94,8% a 100% —, porque o pool só tem times
 do universo e o time de Série C não está lá. Nenhum lado sem XI utilizável entrou num par: foram
-contados e descartados (7 pares no `copa_copa`, 0 nos outros dois), nunca completados.
+contados e descartados — **11 pares no `copa_copa`, 1 no `liga_copa`, 0 no `liga_liga`** —, nunca
+completados. A conta fecha nos três estratos (254 = 243 + 11, 301 = 300 + 1, 635 = 635 + 0), e o
+fechamento não é decorativo: ver o quarto achado de percurso.
 
 ### O que a fase `real` da escalação evitou
 
@@ -1655,11 +1677,11 @@ Sem o filtro, 33 lados entrariam na medição com XI de tamanho errado — e "so
 estaria comparando conjuntos de tamanhos diferentes, inflando o número sem ninguém ver. O que
 sobra depois do filtro é falha de coleta, não dedup, e é o que a tabela anterior mostra.
 
-### ⚠️ Dois números publicados não eram reproduzíveis, e um terceiro estava truncado
+### ⚠️ Quatro achados de percurso, os quatro sobre a própria maquinaria
 
-Achados de percurso, os três corrigidos antes de qualquer número desta seção ser escrito. Ficam
-registrados porque nenhum deles é específico da #57 — os três voltam a morder na próxima análise
-que alguém escrever neste repositório.
+Corrigidos antes de qualquer número desta seção ser publicado. Ficam registrados porque nenhum
+deles é específico da #57 — os quatro voltam a morder na próxima análise que alguém escrever neste
+repositório.
 
 1. **`APPROX_QUANTILES` é um sketch.** Duas execuções seguidas, dado idêntico e query idêntica,
    devolveram **1,313 e depois 1,294** para a mediana de `ppg` do histórico nativo do Brasileirão,
@@ -1673,11 +1695,21 @@ que alguém escrever neste repositório.
    seguem em `AVG`, porque o somando já é FLOAT64 e não há soma exata a recuperar — está declarado
    no comentário da análise, não escondido.
 
-3. **`bq query` trunca em 100 linhas por padrão, calado.** A análise de rodízio tem 117 linhas: o
+3. **`bq query` trunca em 100 linhas por padrão, calado.** A análise de rodízio tem 121 linhas: o
    nível `time` perdia os últimos times em ordem alfabética, e a contagem saiu **29 times quando
    são 33** — com Vasco da Gama, que é o maior efeito de rodízio da tabela, entre os cortados. A
    saída sai com cara de completa. `--max_rows` está agora nos dois cabeçalhos, ao lado da
    armadilha que já se conhecia (SQL como argumento trava a máquina).
+
+4. **`NULL AND TRUE` é NULL, e o contador de descarte pulava esses pares.** O critério de par
+   utilizável era `xa.n_titulares = 11 AND xb.n_titulares = 11`, e lado SEM escalação nenhuma sai
+   do LEFT JOIN com `n_titulares` NULL — logo o critério dava NULL, não FALSE, e o
+   `COUNTIF(NOT utilizavel)` o pulava. Esses pares ficavam em `pares_no_estrato` e em NENHUMA das
+   duas colunas, quebrando `pares_no_estrato = pares + pares_descartados` em silêncio e
+   **exatamente onde a cobertura é pior** — que é a única coisa que `pares_descartados` existe para
+   mostrar. Os descartes iam de 7 para os 12 reais. As médias não se mexeram (o `IF(NULL, x, 0)` já
+   dava 0 e o `COUNTIF` já não contava), mas a frase "foram contados e descartados" estava errada
+   sobre 5 pares antes desta correção.
 
 ### O que ficou de fora, e por quê
 
@@ -1766,10 +1798,14 @@ SQL
 ```
 
 A análise de força sai com **55 linhas** (1 de conferência, 3 de total, 14 de competição, 11 de
-fonte, 19 de liga do adversário e 7 de referência de `ppg`) e a de rodízio com **117** (20 de
-cobertura, 3 de total, 12 de estrato × dias e 82 de time). As duas leem o carimbo das células
-`base` e `escopo`, que precisa estar gravado — já estava, da #53. A consulta (a) devolve **1.916 de
-1.916** e a (b), **40 de 194**.
+fonte, 19 de liga do adversário e 7 de referência de `ppg`) e a de rodízio com **121** (20 de
+cobertura, 3 de total, 12 de estrato × dias, 82 de time e 4 de times do universo). As duas leem o
+carimbo das células `base` e `escopo`, que precisa estar gravado — já estava, da #53. A consulta
+(a) devolve **1.916 de 1.916** e a (b), **40 de 194**.
+
+Rodadas duas vezes seguidas no commit carimbado, as duas devolvem CSV **idêntico linha a linha** —
+é assim que o segundo e o terceiro achados de percurso ficam fechados por medição e não por
+argumento.
 
 ⚠️ `bq query` com o SQL como argumento trava nesta máquina; por redirecionamento ou heredoc,
 funciona. E sem `--max_rows` ele corta em 100 linhas sem avisar.


### PR DESCRIPTION
Closes #57

Os dois confundidores do merge de histórico, medidos em vez de registrados. O ticket de origem
trouxe o rodízio como ressalva sem número e não mencionou a força do adversário; a spec #49 pediu
os dois com número.

## Veredito

**Força do adversário — efeito PEQUENO no que dá para medir, e o achado é o que não dá.**

| origem | partidas | ppg de liga do adversário | fora da base |
|---|---|---|---|
| nativa | 2.862 | 1,341 | 101 (**3,5%**) |
| emprestada | 1.159 | 1,387 | 472 (**40,7%**) |

Na única régua comparável entre competições a diferença é 0,046 — nada. A mistura de nível existe
e é fina: 27 das 1.364 partidas do histórico fundido de um time de Brasileirão são contra Série B
(2,0%), e 40 das 1.542 de um time de Série B são contra Série A (2,6%).

**Rodízio de elenco — efeito REAL e MODERADO, 1,46 titular de 11.**

| estrato | pares | sobreposição | % dos 11 | dias entre |
|---|---|---|---|---|
| liga ↔ liga (**controle**) | 635 | **8,34** | 75,8% | 7,7 |
| liga ↔ copa (**tratamento**) | 300 | **6,88** | 62,5% | 3,2 |
| copa ↔ copa | 243 | 8,32 | 75,6% | 9,1 |

A diferença sobrevive ao controle de calendário (−1,36 dentro de até 3 dias, −1,62 de 4 a 5), então
não é congestionamento. Mas entre dois jogos de liga o XI já troca 2,66 titulares sozinho: a copa
acrescenta uma troca e meia, não outro elenco. 24 dos 33 times caem; 9 sobem.

**Nenhum dos dois inverte a recomendação da task.** Os dois entram na [B] como ressalva com
tamanho.

## Os três achados de resultado

1. **O merge corta nos dois sentidos, e isso ninguém tinha escrito.** Para âncora de LIGA ele piora
   a visibilidade do adversário — o histórico nativo de um time de Brasileirão é 100% contra
   adversário que enxergamos e o emprestado é 71,7% contra adversário que não. Para âncora de COPA
   ele **melhora**: a Copa do Brasil tem 31,4% de adversário fora da base no histórico nativo e
   15,5% no emprestado, porque o que ele empresta é jogo de campeonato nacional. E o peso importa —
   para âncora de copa o emprestado é 91,7% do histórico fundido.

2. **`ppg` de copa de mata-mata é sobrevivência, não força.** A leitura ingênua diz que a partida
   emprestada foi contra adversário mais forte (1,622 contra 1,366). É artefato: quem perde é
   eliminado e para de jogar, então a média de `ppg` da Copa do Brasil é **2,609** contra 1,364 do
   Brasileirão e 1,438 da Libertadores (que tem fase de grupos e volta a se comportar como liga). A
   régua que denuncia isso está na própria saída, no nível `ppg_referencia`.

3. **⚠️ A premissa do critério de aceite é falsa.** A cobertura de lineups **não** é de 100% em
   todas as competições: a Copa do Brasil tem **69,8%** (141 de 202 lados), e o buraco está nas
   mesmas fases iniciais em que o adversário está fora da base. **Os dois confundidores têm o mesmo
   ponto cego**, e ele é estrutural — nas primeiras rodadas o adversário é de Série C ou D, e a API
   não traz nem a classificação dele nem a escalação do jogo.

De quebra, a spec supôs que o buraco era Série C e D. É maior: o adversário invisível de um time de
Brasileirão vem principalmente da **Libertadores e da Sudamericana** (121 e 94 partidas, 100% fora
da base), porque não coletamos as ligas nacionais sul-americanas.

## Como está construído

Cada análise carrega a própria falsificação.

A de força **reconstrói** o join de histórico do `int_futebol_team_form_pit` — precisa da partida
individual, e o carimbo guarda só a contagem. Reconstrução é cópia, e cópia deriva em silêncio,
então a primeira linha da saída não é resultado, é conferência par a par contra o carimbo das
células (#53): **338 de 338** batem a `base` e o `escopo`, e desde a revisão o veredito cobra também
`pares = 2 × jogos_no_universo`, para carimbo incompleto não sair `EXATA` tendo conferido um
subconjunto.

A de rodízio mede o par **liga↔liga do mesmo time** como controle. Sem ele, "6,88 dos 11 se
repetem" não quer dizer nada — lesão e desgaste mexem no XI o tempo todo. E o controle tem
confundidor próprio (calendário), então o nível `estrato_x_dias` corta os dois estratos pela mesma
distância entre jogos.

Quatro categorias de adversário, excludentes e **sem imputação**: `na_base_com_ppg`,
`na_base_sem_ppg`, `fora_da_base` e `selecao` — seleção separada porque não ter liga é o formato do
futebol de seleções, não um limite da coleta.

## Quatro achados de percurso, sobre a própria maquinaria

Nenhum é específico da #57, e os quatro voltam a morder na próxima análise deste repositório:

- **`APPROX_QUANTILES` é sketch e não reproduz** — 1,313 e depois 1,294 sobre dado idêntico. Virou
  `macros/taskf_mediana.sql`, exata e determinística.
- **`AVG` sobre inteiro empata no arredondamento** — 8,43 e depois 8,42 quando a média é 8,425.
  Onde o somando é INT64, `SUM/COUNT`.
- **`bq query` trunca em 100 linhas por padrão, calado** — custou uma contagem de 29 times quando
  são 33, com o maior efeito de rodízio da tabela entre os cortados.
- **`NULL AND TRUE` é NULL, não FALSE** — o `COUNTIF(NOT utilizavel)` pulava esses pares, e eles
  sumiam das duas colunas de contagem exatamente onde a cobertura é pior.

## Verificação

- `dbt parse` limpo; `dbt test --target dev --select tag:guarda` → **PASS=16 ERROR=0**;
  `dbt test --target taskF --select tag:costura_b` → **PASS=4 ERROR=0**
- Execução 2026-08-13 14:55–14:57 UTC, commit `d6ad236`, dataset `futebol_taskF`
- Duas execuções seguidas de cada análise devolvem CSV **idêntico linha a linha**
- `/code-review high`: um achado médio e três baixos, os quatro corrigidos e re-medidos, com o
  carimbo do doc reapontado para o sha que produziu a saída atual
- Nenhum modelo de produção tocado. A mudança é duas análises, um macro, a seção do doc e três
  entradas de glossário; `dim_leagues`, `dim_teams` e `fact_fixture_lineups_players` foram
  materializados no `futebol_taskF` (nenhum dos seis nós de premissas os referencia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
