### PR TITLE
[F-9] As três respostas: nenhuma das duas exclusões se sustenta — o piso já faz o trabalho

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -302,9 +302,20 @@ cell stamps the one it read in `odds_loaded_at`) or if any of the four is missin
 `base`, `escopo`, `recorte` and `ambos`, named for the axis each releases.
 _Avoid_: C1–C4 (C1, C2 and C3 already name subtasks of the [C] Coleta task)
 
+**Universo de medição**:
+Which fixtures enter the count. Since #58 it is a **third axis**, orthogonal to the célula: the
+célula decides what history each fixture carries, the universo decides which fixtures are
+measured at all. Four of them, defined once in `taskf_universos()`: `completo` (the frozen 169),
+`sem_copa_mundo`, `estendido` (no ceiling — it reaches whatever the facts construction contains)
+and `estendido_sem_champions_classif`. All four of a célula are emitted by the **same INSERT**, so
+the difference between two of them cannot carry a rebuild of the models inside it. Every consumer
+of `taskf_teste2` must filter one; without the filter each premissa appears four times.
+_Avoid_: treating a universo as a fifth célula — they answer different questions, and only cells
+within the same universo are comparable as a 2×2.
+
 **Universo congelado**:
-The fixed set of fixtures every célula is measured over — the [0.1]'s published window, 169
-fixtures. Its ceiling is an **instant**, not a date: the [0.1] ran mid-day with no frozen cutoff,
+The `completo` universo, and the primary one: the fixed set of fixtures every célula is measured
+over — the [0.1]'s published window, 169 fixtures. Its ceiling is an **instant**, not a date: the [0.1] ran mid-day with no frozen cutoff,
 so `DATE(kickoff) <= '2026-08-04'` returns 178 and only `kickoff < 04/08 12:00 UTC` returns the
 published 169. Written once in `taskf_universo()`; see `docs/TASKF_RESULTADOS.md`.
 _Avoid_: janela in prose — that word already names the odds collection window and its two

--- a/dbt_futebol/analyses/taskf_delta_celulas.sql
+++ b/dbt_futebol/analyses/taskf_delta_celulas.sql
@@ -67,6 +67,14 @@
     errado devolveria zero linha ou uma coluna inteira de `SEM_CONTRAPARTE`, e as duas coisas se
     parecem demais com um resultado.
 
+    ⚠️ O UNIVERSO TAMBÉM É VAR, e o default é o primário (`completo`). Desde a #58 a tabela tem
+    quatro universos dentro dela; sem o recorte, esta análise juntaria a linha `completo` da célula
+    A com as quatro da célula B e devolveria quatro linhas por premissa — cada uma parecendo um
+    delta. O recorte é aplicado nos DOIS lados com o MESMO valor de propósito: comparar célula A no
+    universo X com célula B no universo Y misturaria os dois eixos numa diferença só, que é
+    exatamente o erro que o 2×2 desta task existe para não cometer. Quem quer o efeito de EXCLUIR
+    jogos — o mesmo par de células, dois universos — usa analyses/taskf_exclusao.sql.
+
     COMO RODAR (do dbt_futebol/), depois de as duas células terem sido medidas pelo taskf_teste2:
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_delta_celulas
@@ -76,6 +84,9 @@
       # outro par de células:
       ... --select taskf_delta_celulas --vars '{taskf_celula_a: base, taskf_celula_b: ambos}'
 
+      # o mesmo par noutro universo:
+      ... --vars '{taskf_celula_a: base, taskf_celula_b: ambos, taskf_universo: estendido}'
+
     (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
 
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
@@ -83,6 +94,17 @@
 
 {%- set cel_a = var('taskf_celula_a', 'base') -%}
 {%- set cel_b = var('taskf_celula_b', 'escopo') -%}
+{#- O universo é validado pelo mesmo caminho das células — taskf_universo_predicado() levanta erro
+    de compilação em nome desconhecido —, mas aqui o valor é usado como FILTRO da tabela já medida,
+    e não como predicado sobre apostas. A validação vem da lista da macro, não de uma segunda
+    cópia digitada. -#}
+{%- set universo = var('taskf_universo', 'completo') -%}
+{%- set universos_validos = [] -%}
+{%- for u in taskf_universos() -%}{%- set _ = universos_validos.append(u.nome) -%}{%- endfor -%}
+{%- if universo not in universos_validos -%}
+    {{ exceptions.raise_compiler_error(
+        "universo inválido: '" ~ universo ~ "'. Valores aceitos: " ~ universos_validos | join(' | ')) }}
+{%- endif -%}
 {#- Os quatro nomes vêm da macro que os define, nunca de uma segunda lista digitada aqui: uma
     cópia que precisa ficar igual para sempre não fica, e a divergência seria muda. -#}
 {%- set celulas_validas = taskf_nomes_de_celula().values() | list -%}
@@ -106,10 +128,12 @@
 {%- set campos_piso0 = ['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'dif_p0'] -%}
 
 WITH a AS (
-    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }} WHERE celula = '{{ cel_a }}'
+    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    WHERE celula = '{{ cel_a }}' AND universo = '{{ universo }}'
 ),
 b AS (
-    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }} WHERE celula = '{{ cel_b }}'
+    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    WHERE celula = '{{ cel_b }}' AND universo = '{{ universo }}'
 ),
 
 juntado AS (

--- a/dbt_futebol/analyses/taskf_delta_celulas.sql
+++ b/dbt_futebol/analyses/taskf_delta_celulas.sql
@@ -94,17 +94,10 @@
 
 {%- set cel_a = var('taskf_celula_a', 'base') -%}
 {%- set cel_b = var('taskf_celula_b', 'escopo') -%}
-{#- O universo é validado pelo mesmo caminho das células — taskf_universo_predicado() levanta erro
-    de compilação em nome desconhecido —, mas aqui o valor é usado como FILTRO da tabela já medida,
-    e não como predicado sobre apostas. A validação vem da lista da macro, não de uma segunda
-    cópia digitada. -#}
-{%- set universo = var('taskf_universo', 'completo') -%}
-{%- set universos_validos = [] -%}
-{%- for u in taskf_universos() -%}{%- set _ = universos_validos.append(u.nome) -%}{%- endfor -%}
-{%- if universo not in universos_validos -%}
-    {{ exceptions.raise_compiler_error(
-        "universo inválido: '" ~ universo ~ "'. Valores aceitos: " ~ universos_validos | join(' | ')) }}
-{%- endif -%}
+{#- O universo é validado pela mesma macro que o predicado usa (taskf_universo_valido), embora
+    aqui o valor vire FILTRO da tabela já medida e não predicado sobre apostas. Um nome digitado
+    errado devolveria zero linha, que se parece demais com "as duas células são idênticas". -#}
+{%- set universo = taskf_universo_valido(var('taskf_universo', 'completo')) -%}
 {#- Os quatro nomes vêm da macro que os define, nunca de uma segunda lista digitada aqui: uma
     cópia que precisa ficar igual para sempre não fica, e a divergência seria muda. -#}
 {%- set celulas_validas = taskf_nomes_de_celula().values() | list -%}

--- a/dbt_futebol/analyses/taskf_exclusao.sql
+++ b/dbt_futebol/analyses/taskf_exclusao.sql
@@ -54,7 +54,7 @@
     `excluido` abaixo): no piso 5 quase todos os jogos que ela remove JÁ estavam fora.
 
     ────────────────────────────────────────────────────────────────────────────────
-    OS CINCO BLOCOS
+    OS SETE BLOCOS
 
       universo    quantos jogos e linhas cada universo tem, por célula, e quantos a exclusão
                   remove. É a conferência de que o par pedido é encaixado (SEM ⊂ COM) e não-vazio
@@ -68,8 +68,30 @@
       fases       os jogos removidos por (competição, fase), contra o total daquela competição no
                   universo COM. É o que transforma "excluir a fase classificatória ≡ excluir a
                   Champions **nesta janela**" de afirmação em número.
+      fora_do_universo  as partidas ENCERRADAS das competições que a exclusão toca e que mesmo
+                  assim não entram no universo, por fase e por status. É o que separa "não
+                  medimos" de "não aconteceu" — e responde de uma vez as duas perguntas que
+                  costumam vir depois de uma contagem baixa: a partida sem preço coletado e a que
+                  terminou fora do tempo normal (`status_short <> 'FT'`, o filtro do
+                  task01_base(); ver a issue #71).
       ordenacao   as três métricas e o veredito, por (contraste, piso) — as quatro células mais o
                   contraste de referência.
+      topo        as premissas que ENTRARAM ou SAÍRAM do top {{ n_topo }}, com posição e peso dos
+                  dois lados. Sem ele, `trocas_no_topo = 2` é um número sem conteúdo: não dá para
+                  saber se foi uma permuta adjacente na fronteira ou duas premissas atravessando a
+                  tabela inteira, e as duas coisas pedem leituras opostas.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    AS COLUNAS `a`, `b`, `c` MUDAM DE SENTIDO POR BLOCO — é o preço de sete blocos num UNION, e a
+    legenda é esta (o `detalhe` traz o resto sempre):
+
+      universo          a = jogos no COM      b = jogos no SEM     c = jogos removidos
+      excluido          a = jogos excluídos   b = min_jogos médio  c = excluídos acima do piso 5
+      composicao        a = jogos             b = % do universo    c = jogos removidos
+      fases             a = jogos na fase     b = jogos removidos  c = —
+      fora_do_universo  a = partidas de fora  b = com preço        c = —
+      ordenacao         a = rho               b = trocas no topo   c = trocas de sinal
+      topo              a = posição no COM    b = posição no SEM   c = peso no COM
 
     ────────────────────────────────────────────────────────────────────────────────
     COMO RODAR (do dbt_futebol/), depois das quatro células medidas:
@@ -92,16 +114,8 @@
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */
 
-{%- set u_com = var('taskf_universo_com', 'completo') -%}
-{%- set u_sem = var('taskf_universo_sem', 'sem_copa_mundo') -%}
-{%- set universos_validos = [] -%}
-{%- for u in taskf_universos() -%}{%- set _ = universos_validos.append(u.nome) -%}{%- endfor -%}
-{%- for u in [u_com, u_sem] -%}
-    {%- if u not in universos_validos -%}
-        {{ exceptions.raise_compiler_error(
-            "universo inválido: '" ~ u ~ "'. Valores aceitos: " ~ universos_validos | join(' | ')) }}
-    {%- endif -%}
-{%- endfor -%}
+{%- set u_com = taskf_universo_valido(var('taskf_universo_com', 'completo')) -%}
+{%- set u_sem = taskf_universo_valido(var('taskf_universo_sem', 'sem_copa_mundo')) -%}
 {%- if u_com == u_sem -%}
     {{ exceptions.raise_compiler_error(
         "taskf_universo_com e taskf_universo_sem são o mesmo universo ('" ~ u_com ~ "') — nada a excluir.") }}
@@ -278,6 +292,34 @@ bloco_fases AS (
     GROUP BY c.competition, c.round
 ),
 
+-- ── bloco `fora_do_universo` ────────────────────────────────────────────────────────────────
+{# As encerradas que o universo NÃO alcança, nas competições que a exclusão toca. Duas causas
+   possíveis e as duas importam: a partida não teve preço coletado (a coleta é forward-only e
+   entra no ar quando a liga é lançada) ou ela terminou fora do tempo normal — o
+   `jogos_encerrados` do task01_base() filtra `status_short = 'FT'`, então AET e PEN ficam de fora
+   (achado da #56, issue #71).
+
+   `com_preco` distingue as duas sem precisar de terceira consulta: partida encerrada, com preço
+   coletado e ainda assim fora do universo só pode ter saído pelo status. #}
+fora_do_universo AS (
+    SELECT
+        f.competition,
+        f.round,
+        f.status_short,
+        COUNT(*) AS partidas,
+        COUNTIF(o.fixture_id IS NOT NULL) AS com_preco,
+        MIN(DATE(f.kickoff_utc)) AS primeiro,
+        MAX(DATE(f.kickoff_utc)) AS ultimo
+    FROM {{ ref('fact_fixtures') }} AS f
+    LEFT JOIN (SELECT DISTINCT fixture_id FROM {{ ref('fact_odds_snapshot') }}) AS o
+           ON o.fixture_id = f.fixture_id
+    WHERE f.kickoff_utc >= TIMESTAMP('{{ taskf_universo().ini }}')
+      AND f.status_short IN ('FT', 'AET', 'PEN')
+      AND f.competition IN (SELECT DISTINCT competition FROM excluidos)
+      AND f.fixture_id NOT IN (SELECT fixture_id FROM jogos_marcados)
+    GROUP BY f.competition, f.round, f.status_short
+),
+
 -- ── bloco `ordenacao` ───────────────────────────────────────────────────────────────────────
 {# Os lados de cada contraste. Quatro contrastes de EXCLUSÃO (a mesma célula, dois universos) e
     um de EIXO (o mesmo universo, duas células) — construídos pela mesma máquina de propósito: as
@@ -433,6 +475,26 @@ bloco_ordenacao AS (
     FROM metricas AS m
     JOIN trocas_topo AS t USING (contraste, piso)
     JOIN descartes   AS d USING (contraste, piso)
+),
+
+{# QUEM entrou e quem saiu do topo, com posição e peso dos dois lados. Só os que se mexeram: o
+   topo inteiro de cada (contraste, piso) seriam centenas de linhas, e o que a leitura precisa é
+   do movimento. Sem este bloco, a caracterização de uma troca vira consulta ad-hoc — e número de
+   documento que não sai de query commitada é número que ninguém confere depois. #}
+bloco_topo AS (
+    SELECT
+        t.contraste,
+        t.piso,
+        t.premissa,
+        t.mercado,
+        t.pos_a,
+        t.pos_b,
+        p.peso_a,
+        p.peso_b,
+        IF(t.pos_a <= {{ n_topo }}, 'saiu', 'entrou') AS direcao
+    FROM topo AS t
+    JOIN pareado AS p USING (contraste, piso, mercado, premissa, benchmark)
+    WHERE (t.pos_a <= {{ n_topo }}) != (t.pos_b <= {{ n_topo }})
 )
 
 -- ── saída ───────────────────────────────────────────────────────────────────────────────────
@@ -493,7 +555,19 @@ SELECT 4, 'fases',
 FROM bloco_fases
 
 UNION ALL
-SELECT 5, 'ordenacao',
+SELECT 5, 'fora_do_universo',
+    FORMAT('%s · %s · %s', competition, round, status_short),
+    IF(com_preco = partidas, 'SO_O_STATUS',
+       IF(com_preco = 0, 'SEM_PRECO_COLETADO', 'MISTO')),
+    CAST(partidas AS FLOAT64),
+    CAST(com_preco AS FLOAT64),
+    NULL,
+    TO_JSON_STRING(STRUCT(competition, round, status_short, partidas, com_preco,
+                          primeiro, ultimo))
+FROM fora_do_universo
+
+UNION ALL
+SELECT 6, 'ordenacao',
     FORMAT('%s · piso %d', contraste, piso),
     veredito,
     rho,
@@ -506,5 +580,16 @@ SELECT 5, 'ordenacao',
         {{ trocas_sinal_material }} AS regua_sinal
     ))
 FROM bloco_ordenacao
+
+UNION ALL
+SELECT 7, 'topo',
+    FORMAT('%s · piso %d · %s', contraste, piso, premissa),
+    direcao,
+    CAST(pos_a AS FLOAT64),
+    CAST(pos_b AS FLOAT64),
+    peso_a,
+    TO_JSON_STRING(STRUCT(contraste, piso, premissa, mercado, direcao,
+                          pos_a, pos_b, peso_a, peso_b))
+FROM bloco_topo
 
 ORDER BY ordem, chave

--- a/dbt_futebol/analyses/taskf_exclusao.sql
+++ b/dbt_futebol/analyses/taskf_exclusao.sql
@@ -54,7 +54,7 @@
     `excluido` abaixo): no piso 5 quase todos os jogos que ela remove JÁ estavam fora.
 
     ────────────────────────────────────────────────────────────────────────────────
-    OS QUATRO BLOCOS
+    OS CINCO BLOCOS
 
       universo    quantos jogos e linhas cada universo tem, por célula, e quantos a exclusão
                   remove. É a conferência de que o par pedido é encaixado (SEM ⊂ COM) e não-vazio
@@ -62,6 +62,9 @@
       excluido    QUEM são os jogos removidos: quanto histórico eles têm e quantos deles já
                   estavam abaixo do piso de amostra. É aqui que se vê a sobreposição entre excluir
                   e usar piso — e ela é o mecanismo por trás do veredito, não um detalhe.
+      composicao  o universo COM por competição. No par da Copa do Mundo ele reproduz a
+                  composição dos 169 que a #51 publicou; no par da Champions ele é a composição do
+                  universo ESTENDIDO, que é o que a user story 5 da #58 pede reportado à parte.
       fases       os jogos removidos por (competição, fase), contra o total daquela competição no
                   universo COM. É o que transforma "excluir a fase classificatória ≡ excluir a
                   Champions **nesta janela**" de afirmação em número.
@@ -237,6 +240,22 @@ bloco_denominador AS (
     JOIN pit_por_jogo AS p USING (fixture_id)
     WHERE c.no_com
     GROUP BY p.celula
+),
+
+-- ── bloco `composicao` ──────────────────────────────────────────────────────────────────────
+{# O universo COM inteiro, competição a competição. Sai daqui e não de uma contagem à parte porque
+   é do MESMO `classificado` que os outros blocos leem — duas contagens do mesmo universo em
+   lugares diferentes divergem uma hora, e a divergência seria muda. #}
+bloco_composicao AS (
+    SELECT
+        c.competition,
+        COUNT(*)                 AS jogos,
+        COUNTIF(NOT c.no_sem)    AS jogos_removidos,
+        MIN(DATE(c.kickoff_utc)) AS primeiro,
+        MAX(DATE(c.kickoff_utc)) AS ultimo
+    FROM classificado AS c
+    WHERE c.no_com
+    GROUP BY c.competition
 ),
 
 -- ── bloco `fases` ───────────────────────────────────────────────────────────────────────────
@@ -451,7 +470,19 @@ FROM bloco_excluido AS e
 JOIN bloco_denominador AS d USING (celula)
 
 UNION ALL
-SELECT 3, 'fases',
+SELECT 3, 'composicao',
+    competition,
+    IF(jogos_removidos = 0, 'INTACTA',
+       IF(jogos_removidos = jogos, 'REMOVIDA_INTEIRA', 'PARCIAL')),
+    CAST(jogos AS FLOAT64),
+    ROUND(100 * jogos / SUM(jogos) OVER (), 1),
+    CAST(jogos_removidos AS FLOAT64),
+    TO_JSON_STRING(STRUCT(competition, jogos, jogos_removidos, primeiro, ultimo,
+                          SUM(jogos) OVER () AS jogos_no_universo))
+FROM bloco_composicao
+
+UNION ALL
+SELECT 4, 'fases',
     FORMAT('%s · %s', competition, round),
     IF(jogos_removidos = jogos_no_com, 'FASE_INTEIRA',
        IF(jogos_removidos = 0, 'INTACTA', 'PARCIAL')),
@@ -462,7 +493,7 @@ SELECT 3, 'fases',
 FROM bloco_fases
 
 UNION ALL
-SELECT 4, 'ordenacao',
+SELECT 5, 'ordenacao',
     FORMAT('%s · piso %d', contraste, piso),
     veredito,
     rho,

--- a/dbt_futebol/analyses/taskf_exclusao.sql
+++ b/dbt_futebol/analyses/taskf_exclusao.sql
@@ -1,0 +1,479 @@
+/*
+    [F-9] EXCLUIR UM CONJUNTO DE JOGOS DA BASE DE MEDIÇÃO MUDA A ORDENAÇÃO DAS PREMISSAS? —
+    medido COM e SEM, sobre a mesma materialização das quatro células.
+
+    A spec #49 pede duas recomendações do mesmo tipo (user stories 7 e 24): a Copa do Mundo deve
+    sair da base de medição, já que ali o deserto de histórico é real e ela pesa 47% da amostra? E
+    a mesma pergunta para a fase classificatória da Champions. O critério de aceite da #58 é
+    explícito sobre COMO responder: "a recomendação sai do efeito na ordenação das premissas, não
+    do bom senso — o argumento de princípio fica declarado como reserva".
+
+    Esta análise é esse efeito. Ela não decide nada sozinha: emite as três métricas declaradas
+    abaixo, o veredito mecânico delas, e o contraste de referência que dá escala ao veredito.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A RÉGUA, DECLARADA ANTES DE MEDIR
+
+    Mesmo padrão da tolerância de 0,5 pp da #51: o número existe antes do resultado, para não ser
+    escolhido depois de ver qual lado ele favorece.
+
+    O que é ORDENAR. As 39 premissas do benchmark preferido (`usado_para_peso`), ordenadas por
+    `diferenca_p<piso>` — o sinal medido, decrescente. É a ordenação que a [B] leria para decidir
+    em quem mexer.
+
+    TRÊS MÉTRICAS, por (célula, piso):
+
+      rho             correlação de Spearman entre as duas ordenações (Pearson sobre os postos).
+                      1,0 = a exclusão não mexeu em nada; 0 = a ordenação virou outra.
+      trocas_no_topo  quantas premissas entram ou saem do TOP 5 por `peso_p<piso>`. O peso é o que
+                      a [B] usaria como peso, e o topo é onde uma decisão de fato acontece.
+      trocas_de_sinal quantas das 39 trocam o SINAL da diferença. Trocar de sinal é mudar a
+                      resposta ("essa premissa tem ganho" ↔ "não tem"), não a posição.
+
+    VEREDITO. A exclusão é MATERIAL naquele (célula, piso) quando QUALQUER uma valer:
+
+        rho < 0,90     OU     trocas_no_topo >= 2     OU     trocas_de_sinal >= 4
+
+    Fora disso, IMATERIAL. Os três cortes são grosseiros de propósito: eles separam "a ordenação
+    é outra" de "a ordenação é a mesma com ruído", e não pretendem medir significância.
+
+    ⚠️ E POR ISSO O CONTRASTE DE REFERÊNCIA VEM JUNTO. Um `rho` de 0,93 não diz nada sozinho —
+    0,93 é muito ou pouco? A referência responde: as MESMAS três métricas para o par de células
+    `base` → `escopo` DENTRO do universo COM. Esse é o efeito que a [F] existe para medir e que a
+    #53 chamou de grande (30,6% dos pares ganham histórico, o piso 5 vai de 69 para 92 jogos). Se
+    a exclusão mexer na ordenação MENOS do que o eixo que a task mede, ela é ruído perto do que se
+    está medindo; se mexer mais, a base de medição está sendo decidida por ela.
+
+    ⚠️ O QUE FAZER SE O VEREDITO SAIR AMBÍGUO — declarado agora, para não ser escolhido depois. Se
+    as métricas caírem perto dos cortes (rho entre 0,88 e 0,92, ou trocas_no_topo = 1 com
+    trocas_de_sinal = 3), a resposta NÃO é arredondar para o lado conveniente: é acrescentar um
+    universo de placebo — remover N jogos sorteados por hash, do mesmo tamanho do conjunto
+    excluído — e comparar a exclusão real contra a distribuição do placebo. Isso é uma medição a
+    mais (um universo novo em macros/taskf_universos.sql e a re-medição das quatro células), e não
+    foi feita de partida porque a exclusão da Copa do Mundo se sobrepõe ao piso de amostra (bloco
+    `excluido` abaixo): no piso 5 quase todos os jogos que ela remove JÁ estavam fora.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    OS QUATRO BLOCOS
+
+      universo    quantos jogos e linhas cada universo tem, por célula, e quantos a exclusão
+                  remove. É a conferência de que o par pedido é encaixado (SEM ⊂ COM) e não-vazio
+                  — duas coisas que, se falharem, fazem o resto da saída parecer resultado.
+      excluido    QUEM são os jogos removidos: quanto histórico eles têm e quantos deles já
+                  estavam abaixo do piso de amostra. É aqui que se vê a sobreposição entre excluir
+                  e usar piso — e ela é o mecanismo por trás do veredito, não um detalhe.
+      fases       os jogos removidos por (competição, fase), contra o total daquela competição no
+                  universo COM. É o que transforma "excluir a fase classificatória ≡ excluir a
+                  Champions **nesta janela**" de afirmação em número.
+      ordenacao   as três métricas e o veredito, por (contraste, piso) — as quatro células mais o
+                  contraste de referência.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    COMO RODAR (do dbt_futebol/), depois das quatro células medidas:
+
+      # Copa do Mundo (default)
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_exclusao
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=500 \
+        < target/compiled/dbt_futebol/analyses/taskf_exclusao.sql
+
+      # Champions, fase classificatória
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_exclusao \
+        --vars '{taskf_universo_com: estendido,
+                 taskf_universo_sem: estendido_sem_champions_classif}'
+
+    ⚠️ `--max_rows` não é enfeite: o `bq query` trunca a saída em 100 linhas SEM AVISAR, e esta
+    análise emite mais do que isso. Foi assim que a #57 quase publicou uma conta pela metade.
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set u_com = var('taskf_universo_com', 'completo') -%}
+{%- set u_sem = var('taskf_universo_sem', 'sem_copa_mundo') -%}
+{%- set universos_validos = [] -%}
+{%- for u in taskf_universos() -%}{%- set _ = universos_validos.append(u.nome) -%}{%- endfor -%}
+{%- for u in [u_com, u_sem] -%}
+    {%- if u not in universos_validos -%}
+        {{ exceptions.raise_compiler_error(
+            "universo inválido: '" ~ u ~ "'. Valores aceitos: " ~ universos_validos | join(' | ')) }}
+    {%- endif -%}
+{%- endfor -%}
+{%- if u_com == u_sem -%}
+    {{ exceptions.raise_compiler_error(
+        "taskf_universo_com e taskf_universo_sem são o mesmo universo ('" ~ u_com ~ "') — nada a excluir.") }}
+{%- endif -%}
+
+{%- set celulas = taskf_nomes_de_celula().values() | list -%}
+{%- set pisos   = taskf_pisos() -%}
+{%- set carimbos = source('futebol_taskF', 'taskf_pit_por_celula') -%}
+{%- set teste2   = source('futebol_taskF', 'taskf_teste2') -%}
+
+{# A régua, num lugar só: os três cortes do veredito e o tamanho do topo. Estão aqui e não
+    embutidos no SELECT porque são a régua declarada no cabeçalho, e uma régua que mora em três
+    linhas de SQL diferentes deixa de ser uma régua. #}
+{%- set n_topo               = 5    -%}
+{%- set rho_minimo           = 0.90 -%}
+{%- set trocas_topo_material = 2    -%}
+{%- set trocas_sinal_material = 4   -%}
+
+{# O contraste de referência: o par de células que dá escala ao veredito. `base` → `escopo` é o
+    eixo de escopo isolado, o que a spec #49 chama de "juntar os campeonatos". #}
+{%- set ref_a = 'base' -%}
+{%- set ref_b = 'escopo' -%}
+
+
+WITH {{ task01_base() }},
+
+{# OS JOGOS, com o `round` que os predicados de universo precisam. `apostas` não o carrega — ele
+    entra por join com o fact_fixtures, mesmo seam do `pit_disponivel` do analyses/taskf_teste2.sql
+    e pelo mesmo motivo: o task01_base() é o artefato que produziu os números publicados da [0.1] e
+    não é tocado por esta medição. O COALESCE evita que um `round` nulo faça o NOT(...) do universo
+    de exclusão devolver NULL e sumir com a linha em silêncio. #}
+jogos_marcados AS (
+    SELECT DISTINCT
+        a.fixture_id,
+        a.competition,
+        a.kickoff_utc,
+        COALESCE(f.round, '') AS round
+    FROM apostas AS a
+    LEFT JOIN {{ ref('fact_fixtures') }} AS f
+           ON f.fixture_id = a.fixture_id
+),
+
+{# Os dois predicados aplicados ao MESMO conjunto de jogos, lado a lado. Escrito assim — e não
+    como dois SELECT filtrados — porque o que interessa é a DIFERENÇA entre eles, e uma diferença
+    calculada por anti-join de duas listas esconde o caso em que o par não é encaixado. #}
+classificado AS (
+    SELECT
+        j.*,
+        {{ taskf_universo_predicado(u_com) }} AS no_com,
+        {{ taskf_universo_predicado(u_sem) }} AS no_sem
+    FROM jogos_marcados AS j
+),
+
+excluidos AS (
+    SELECT * FROM classificado WHERE no_com AND NOT no_sem
+),
+
+{# O piso é propriedade do JOGO: o menor entre os dois times. Mesma construção do
+    analyses/taskf_saturacao_recorte.sql, sobre o carimbo do PIT — que guarda o modelo inteiro, e
+    por isso alcança também os jogos que só existem no universo estendido. #}
+pit_por_jogo AS (
+    SELECT
+        celula,
+        fixture_id,
+        MIN(played_total_disponivel) AS min_disp
+    FROM {{ carimbos }}
+    GROUP BY celula, fixture_id
+),
+
+-- ── bloco `universo` ────────────────────────────────────────────────────────────────────────
+{# Da tabela do Teste 2, e não recontado daqui: o que interessa é o universo que a MEDIÇÃO usou.
+    Se esta análise contasse por conta própria, ela poderia discordar da tabela sem que ninguém
+    notasse — e a discordância seria justamente sobre o que se está medindo. #}
+universo_medido AS (
+    SELECT
+        celula,
+        universo,
+        ANY_VALUE(jogos_no_universo)  AS jogos,
+        ANY_VALUE(linhas_no_universo) AS linhas,
+        ANY_VALUE(janela_ini)         AS janela_ini,
+        ANY_VALUE(janela_fim)         AS janela_fim,
+        COUNT(*)                      AS linhas_de_premissa
+    FROM {{ teste2 }}
+    WHERE universo IN ('{{ u_com }}', '{{ u_sem }}')
+    GROUP BY celula, universo
+),
+
+bloco_universo AS (
+    SELECT
+        c.celula,
+        c.jogos                       AS jogos_com,
+        s.jogos                       AS jogos_sem,
+        c.jogos - s.jogos             AS jogos_removidos,
+        c.linhas                      AS linhas_com,
+        s.linhas                      AS linhas_sem,
+        c.linhas_de_premissa          AS premissas_com,
+        s.linhas_de_premissa          AS premissas_sem,
+        c.janela_ini, c.janela_fim,
+        s.janela_ini AS janela_ini_sem, s.janela_fim AS janela_fim_sem,
+        (SELECT COUNT(*) FROM excluidos)                     AS jogos_excluidos_pelo_predicado,
+        (SELECT COUNTIF(NOT no_com AND no_sem) FROM classificado) AS jogos_so_no_sem
+    FROM universo_medido AS c
+    JOIN universo_medido AS s
+      ON s.celula = c.celula AND s.universo = '{{ u_sem }}'
+    WHERE c.universo = '{{ u_com }}'
+),
+
+-- ── bloco `excluido` ────────────────────────────────────────────────────────────────────────
+{# A sobreposição entre EXCLUIR e usar PISO, que é o mecanismo por trás do veredito. Um conjunto
+    excluído que já estava quase todo abaixo do piso não tem como mudar a ordenação naquele piso —
+    e é isso que separa "a exclusão não importa" de "a exclusão não importa AQUI". #}
+bloco_excluido AS (
+    SELECT
+        p.celula,
+        COUNT(*)                                   AS jogos_excluidos,
+        ROUND(AVG(p.min_disp), 2)                  AS min_jogos_medio,
+        MAX(p.min_disp)                            AS min_jogos_max
+        {%- for piso in pisos %},
+        COUNTIF(p.min_disp >= {{ piso }})          AS excluidos_acima_p{{ piso }}
+        {%- endfor %}
+    FROM excluidos AS e
+    JOIN pit_por_jogo AS p USING (fixture_id)
+    GROUP BY p.celula
+),
+
+{# O denominador: quantos jogos do universo COM passam cada piso. Sem ele, "3 excluídos acima do
+    piso 5" não diz se isso é 3 de 92 ou 3 de 4. #}
+bloco_denominador AS (
+    SELECT
+        p.celula,
+        COUNT(*)                                   AS jogos_no_com
+        {%- for piso in pisos %},
+        COUNTIF(p.min_disp >= {{ piso }})          AS com_acima_p{{ piso }}
+        {%- endfor %}
+    FROM classificado AS c
+    JOIN pit_por_jogo AS p USING (fixture_id)
+    WHERE c.no_com
+    GROUP BY p.celula
+),
+
+-- ── bloco `fases` ───────────────────────────────────────────────────────────────────────────
+{# Por (competição, fase), SÓ nas competições que a exclusão toca. A lista inteira teria uma
+    linha por rodada de cada liga e afogaria o achado — e o achado aqui é de uma competição só:
+    quanto da presença dela no universo a exclusão de FASE de fato remove. É este bloco que mede
+    se "excluir a fase classificatória" e "excluir a competição" são a mesma coisa nesta janela,
+    em vez de supor que sejam. #}
+bloco_fases AS (
+    SELECT
+        c.competition,
+        c.round,
+        COUNT(*)                    AS jogos_no_com,
+        COUNTIF(NOT c.no_sem)       AS jogos_removidos,
+        MIN(DATE(c.kickoff_utc))    AS primeiro,
+        MAX(DATE(c.kickoff_utc))    AS ultimo
+    FROM classificado AS c
+    WHERE c.no_com
+      AND c.competition IN (SELECT DISTINCT competition FROM excluidos)
+    GROUP BY c.competition, c.round
+),
+
+-- ── bloco `ordenacao` ───────────────────────────────────────────────────────────────────────
+{# Os lados de cada contraste. Quatro contrastes de EXCLUSÃO (a mesma célula, dois universos) e
+    um de EIXO (o mesmo universo, duas células) — construídos pela mesma máquina de propósito: as
+    métricas do contraste de referência têm de ser calculadas exatamente como as das exclusões,
+    senão comparar uma com a outra não significa nada. #}
+lados AS (
+    {%- for cel in celulas %}
+    SELECT 'exclusao__{{ cel }}' AS contraste, 'A' AS lado, mercado, premissa, benchmark,
+           {% for piso in pisos %}diferenca_p{{ piso }}, peso_p{{ piso }}, n_p{{ piso }}{{ ', ' if not loop.last }}{% endfor %}
+    FROM {{ teste2 }} WHERE usado_para_peso AND celula = '{{ cel }}' AND universo = '{{ u_com }}'
+    UNION ALL
+    SELECT 'exclusao__{{ cel }}', 'B', mercado, premissa, benchmark,
+           {% for piso in pisos %}diferenca_p{{ piso }}, peso_p{{ piso }}, n_p{{ piso }}{{ ', ' if not loop.last }}{% endfor %}
+    FROM {{ teste2 }} WHERE usado_para_peso AND celula = '{{ cel }}' AND universo = '{{ u_sem }}'
+    UNION ALL
+    {%- endfor %}
+    SELECT 'eixo__{{ ref_a }}_{{ ref_b }}', 'A', mercado, premissa, benchmark,
+           {% for piso in pisos %}diferenca_p{{ piso }}, peso_p{{ piso }}, n_p{{ piso }}{{ ', ' if not loop.last }}{% endfor %}
+    FROM {{ teste2 }} WHERE usado_para_peso AND celula = '{{ ref_a }}' AND universo = '{{ u_com }}'
+    UNION ALL
+    SELECT 'eixo__{{ ref_a }}_{{ ref_b }}', 'B', mercado, premissa, benchmark,
+           {% for piso in pisos %}diferenca_p{{ piso }}, peso_p{{ piso }}, n_p{{ piso }}{{ ', ' if not loop.last }}{% endfor %}
+    FROM {{ teste2 }} WHERE usado_para_peso AND celula = '{{ ref_b }}' AND universo = '{{ u_com }}'
+),
+
+{# Os pisos viram LINHAS aqui. Mantidos como colunas, cada métrica teria de ser escrita quatro
+    vezes — e quatro escritas do mesmo cálculo não ficam iguais para sempre. #}
+longo AS (
+    SELECT
+        l.contraste, l.lado, l.mercado, l.premissa, l.benchmark,
+        p.piso, p.diferenca, p.peso, p.n
+    FROM lados AS l,
+    UNNEST([
+        {%- for piso in pisos %}
+        STRUCT({{ piso }} AS piso, l.diferenca_p{{ piso }} AS diferenca,
+               l.peso_p{{ piso }} AS peso, l.n_p{{ piso }} AS n){{ ',' if not loop.last }}
+        {%- endfor %}
+    ]) AS p
+),
+
+pareado AS (
+    SELECT
+        contraste, piso, mercado, premissa, benchmark,
+        MAX(IF(lado = 'A', diferenca, NULL)) AS dif_a,
+        MAX(IF(lado = 'B', diferenca, NULL)) AS dif_b,
+        MAX(IF(lado = 'A', peso, NULL))      AS peso_a,
+        MAX(IF(lado = 'B', peso, NULL))      AS peso_b,
+        MAX(IF(lado = 'A', n, NULL))         AS n_a,
+        MAX(IF(lado = 'B', n, NULL))         AS n_b,
+        COUNTIF(lado = 'A') AS tem_a,
+        COUNTIF(lado = 'B') AS tem_b
+    FROM longo
+    GROUP BY contraste, piso, mercado, premissa, benchmark
+),
+
+{# ⚠️ QUEM ENTRA NA CORRELAÇÃO, e por que a saída conta os dois grupos que ficam de fora.
+
+    `sem_contraparte`  a premissa existe de um lado e não do outro. Acontece quando ela não acende
+                       nenhuma vez naquele universo (o `HAVING COUNTIF(acesa) > 0` do Teste 2). É
+                       ACHADO — uma premissa que some da base é o efeito mais forte que uma
+                       exclusão pode ter —, e por isso é contada e reportada, não descartada em
+                       silêncio.
+    `sem_medida`       a premissa existe dos dois lados mas não tem diferença naquele piso
+                       (n = 0: acende, mas nunca em jogo com histórico suficiente). Correlacionar
+                       postos de NULL seria inventar ordem onde não há medida.
+
+    A correlação sai do que sobra. Se sobrar pouco, o `n_premissas` na saída denuncia. #}
+ranqueado AS (
+    SELECT
+        *,
+        RANK() OVER (PARTITION BY contraste, piso ORDER BY dif_a DESC) AS rank_a,
+        RANK() OVER (PARTITION BY contraste, piso ORDER BY dif_b DESC) AS rank_b
+    FROM pareado
+    WHERE tem_a = 1 AND tem_b = 1
+      AND dif_a IS NOT NULL AND dif_b IS NOT NULL
+),
+
+{# O TOPO por peso, com desempate DECLARADO. `ROW_NUMBER` e não `RANK` porque o topo tem de ter
+    exatamente {{ n_topo }} elementos: com `RANK`, um empate de peso devolveria seis premissas num
+    "top 5" e a contagem de trocas viraria outra coisa. O desempate por (mercado, premissa) é
+    arbitrário e estável — ele só decide entre pesos IGUAIS, e nesse caso qualquer critério é
+    arbitrário; o que não pode é ser instável entre os dois lados. #}
+topo AS (
+    SELECT
+        contraste, piso, mercado, premissa, benchmark,
+        ROW_NUMBER() OVER (PARTITION BY contraste, piso
+                           ORDER BY peso_a DESC, mercado, premissa) AS pos_a,
+        ROW_NUMBER() OVER (PARTITION BY contraste, piso
+                           ORDER BY peso_b DESC, mercado, premissa) AS pos_b
+    FROM pareado
+    WHERE tem_a = 1 AND tem_b = 1
+),
+
+trocas_topo AS (
+    SELECT
+        contraste, piso,
+        COUNTIF((pos_a <= {{ n_topo }}) != (pos_b <= {{ n_topo }})) AS entradas_e_saidas,
+        STRING_AGG(IF(pos_a <= {{ n_topo }} AND pos_b > {{ n_topo }}, premissa, NULL),
+                   ', ' ORDER BY pos_a) AS saiu_do_topo,
+        STRING_AGG(IF(pos_b <= {{ n_topo }} AND pos_a > {{ n_topo }}, premissa, NULL),
+                   ', ' ORDER BY pos_b) AS entrou_no_topo
+    FROM topo
+    GROUP BY contraste, piso
+),
+
+metricas AS (
+    SELECT
+        r.contraste,
+        r.piso,
+        COUNT(*)                                                   AS n_premissas,
+        ROUND(CORR(r.rank_a, r.rank_b), 4)                         AS rho,
+        COUNTIF(SIGN(r.dif_a) != SIGN(r.dif_b))                    AS trocas_de_sinal,
+        ROUND(AVG(ABS(r.dif_a - r.dif_b)), 2)                      AS delta_dif_medio,
+        MAX(ABS(r.rank_a - r.rank_b))                              AS max_delta_posto,
+        ROUND(AVG(r.n_a), 1)                                       AS n_medio_a,
+        ROUND(AVG(r.n_b), 1)                                       AS n_medio_b
+    FROM ranqueado AS r
+    GROUP BY r.contraste, r.piso
+),
+
+descartes AS (
+    SELECT
+        contraste, piso,
+        COUNTIF(tem_a = 0 OR tem_b = 0)                                     AS sem_contraparte,
+        COUNTIF(tem_a = 1 AND tem_b = 1
+                AND (dif_a IS NULL OR dif_b IS NULL))                       AS sem_medida,
+        STRING_AGG(IF(tem_a = 0 OR tem_b = 0, premissa, NULL), ', ')        AS quais_sem_contraparte
+    FROM pareado
+    GROUP BY contraste, piso
+),
+
+bloco_ordenacao AS (
+    SELECT
+        m.contraste,
+        m.piso,
+        m.rho,
+        t.entradas_e_saidas AS trocas_no_topo,
+        m.trocas_de_sinal,
+        m.n_premissas,
+        d.sem_contraparte,
+        d.sem_medida,
+        d.quais_sem_contraparte,
+        t.saiu_do_topo,
+        t.entrou_no_topo,
+        m.delta_dif_medio,
+        m.max_delta_posto,
+        m.n_medio_a,
+        m.n_medio_b,
+        IF(m.rho < {{ rho_minimo }}
+           OR t.entradas_e_saidas >= {{ trocas_topo_material }}
+           OR m.trocas_de_sinal   >= {{ trocas_sinal_material }},
+           'MATERIAL', 'IMATERIAL')                                          AS veredito
+    FROM metricas AS m
+    JOIN trocas_topo AS t USING (contraste, piso)
+    JOIN descartes   AS d USING (contraste, piso)
+)
+
+-- ── saída ───────────────────────────────────────────────────────────────────────────────────
+SELECT 1 AS ordem, 'universo' AS bloco,
+    celula AS chave,
+    IF(jogos_removidos > 0 AND jogos_so_no_sem = 0, 'OK', 'PAR_NAO_ENCAIXADO') AS veredito,
+    CAST(jogos_com AS FLOAT64)       AS a,
+    CAST(jogos_sem AS FLOAT64)       AS b,
+    CAST(jogos_removidos AS FLOAT64) AS c,
+    TO_JSON_STRING(STRUCT(
+        '{{ u_com }}' AS universo_com, '{{ u_sem }}' AS universo_sem,
+        linhas_com, linhas_sem, premissas_com, premissas_sem,
+        janela_ini, janela_fim, janela_ini_sem, janela_fim_sem,
+        jogos_excluidos_pelo_predicado, jogos_so_no_sem
+    )) AS detalhe
+FROM bloco_universo
+
+UNION ALL
+SELECT 2, 'excluido',
+    e.celula,
+    -- Quanto do conjunto excluído o piso 5 já removia por conta própria. É a leitura que decide
+    -- se a exclusão tem como mudar alguma coisa naquele piso.
+    FORMAT('%d de %d acima do piso 5', e.excluidos_acima_p5, e.jogos_excluidos),
+    CAST(e.jogos_excluidos AS FLOAT64),
+    e.min_jogos_medio,
+    CAST(e.excluidos_acima_p5 AS FLOAT64),
+    TO_JSON_STRING(STRUCT(
+        e.min_jogos_max,
+        {%- for piso in pisos %}
+        e.excluidos_acima_p{{ piso }}, d.com_acima_p{{ piso }},
+        {%- endfor %}
+        d.jogos_no_com
+    ))
+FROM bloco_excluido AS e
+JOIN bloco_denominador AS d USING (celula)
+
+UNION ALL
+SELECT 3, 'fases',
+    FORMAT('%s · %s', competition, round),
+    IF(jogos_removidos = jogos_no_com, 'FASE_INTEIRA',
+       IF(jogos_removidos = 0, 'INTACTA', 'PARCIAL')),
+    CAST(jogos_no_com AS FLOAT64),
+    CAST(jogos_removidos AS FLOAT64),
+    NULL,
+    TO_JSON_STRING(STRUCT(competition, round, jogos_no_com, jogos_removidos, primeiro, ultimo))
+FROM bloco_fases
+
+UNION ALL
+SELECT 4, 'ordenacao',
+    FORMAT('%s · piso %d', contraste, piso),
+    veredito,
+    rho,
+    CAST(trocas_no_topo AS FLOAT64),
+    CAST(trocas_de_sinal AS FLOAT64),
+    TO_JSON_STRING(STRUCT(
+        contraste, piso, n_premissas, sem_contraparte, sem_medida, quais_sem_contraparte,
+        saiu_do_topo, entrou_no_topo, delta_dif_medio, max_delta_posto, n_medio_a, n_medio_b,
+        {{ rho_minimo }} AS regua_rho, {{ trocas_topo_material }} AS regua_topo,
+        {{ trocas_sinal_material }} AS regua_sinal
+    ))
+FROM bloco_ordenacao
+
+ORDER BY ordem, chave

--- a/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_01.sql
@@ -188,6 +188,7 @@ medido AS (
         n_p5, diferenca_p5, diferenca_p10
     FROM {{ source('futebol_taskF', 'taskf_teste2') }}
     WHERE celula = 'base'
+      AND universo = 'completo'
       AND usado_para_peso
 ),
 

--- a/dbt_futebol/analyses/taskf_remedicao.sql
+++ b/dbt_futebol/analyses/taskf_remedicao.sql
@@ -3,8 +3,8 @@
     execução passada, campo a campo.
 
     Por que existe. Mudar o schema da tabela acumulativa obriga a dropá-la e re-medir as quatro
-    células (ver o cabeçalho de analyses/taskf_teste2.sql, FASE 0). Isso já aconteceu duas vezes —
-    na #54 e na #55 — e vai acontecer de novo. Toda vez, a mesma pergunta: a re-medição devolveu
+    células (ver o cabeçalho de analyses/taskf_teste2.sql, FASE 0). Isso já aconteceu três vezes —
+    na #54, na #55 e na #58 — e vai acontecer de novo. Toda vez, a mesma pergunta: a re-medição devolveu
     os mesmos números, ou alguma coisa andou junto?
 
     A #54 respondeu essa pergunta com uma cópia tratada como RASCUNHO — copiou as células da #53
@@ -31,6 +31,16 @@
                                              causada justamente pela criação dessa coluna. Ele é
                                              cobrado pela primeira invariante da Costura B, que é
                                              onde a pergunta dele mora.
+      universo                               idem, desde a #58: o lado de hoje é recortado no
+                                             `completo` e comparado contra a cópia inteira, que só
+                                             tinha esse universo. Ver abaixo.
+
+    ⚠️ A COMPARAÇÃO É SÓ DO UNIVERSO `completo`, E É A ÚNICA COMPARAÇÃO QUE EXISTE (#58). Os três
+    universos novos não têm lado esquerdo: eles nasceram nesta execução, e re-medição é uma
+    pergunta sobre repetir. Comparar 240 linhas de hoje contra 60 de ontem produziria 180
+    `SEM_CONTRAPARTE` que não significam nada — ruído que esconderia a divergência real, que é o
+    único motivo de esta análise existir. Na próxima mudança de schema, a cópia já terá os quatro
+    universos e este recorte deve cair junto com a var que o sustenta.
 
     A comparação passa por TO_JSON_STRING campo a campo: DATE, BOOL, INT64 e FLOAT64 convivem no
     mesmo formato longo, e NULL vira o texto `null` em vez de sumir da comparação — que é o modo
@@ -46,7 +56,7 @@
     COMO RODAR (do dbt_futebol/), depois das quatro células:
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_remedicao \
-        --vars '{taskf_remedicao_anterior: taskf_teste2_54}'
+        --vars '{taskf_remedicao_anterior: taskf_teste2_55}'
       bq query --use_legacy_sql=false --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_remedicao.sql
 
@@ -69,10 +79,11 @@
 
 {#- Qual execução anterior. É var e não nome fixo porque a próxima mudança de schema vai comparar
     contra uma cópia nova — o padrão é `taskf_teste2_<ticket>`, declarada em sources.yml. -#}
-{%- set anterior = var('taskf_remedicao_anterior', 'taskf_teste2_54') -%}
+{%- set anterior = var('taskf_remedicao_anterior', 'taskf_teste2_55') -%}
 
 WITH agora AS (
     SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    WHERE universo = 'completo'
 ),
 
 antes AS (

--- a/dbt_futebol/analyses/taskf_sobrevivencia.sql
+++ b/dbt_futebol/analyses/taskf_sobrevivencia.sql
@@ -1,0 +1,191 @@
+/*
+    [F-9] QUAIS PREMISSAS SOBREVIVEM QUANDO O HISTÓRICO É REAL — o veredito, por regra escrita.
+
+    A spec #49 (user story 6) e o critério de aceite da #58 pedem uma resposta fechada sobre as
+    QUATRO premissas de "muito sinal, pouca amostra" que abrem o problema: `clean_sheets_altos`,
+    `superioridade_xg`, `tende_golear` e `defesa_forte`. Elas são as de maior peso aparente hoje e
+    as de maior exposição a jogo sem histórico (77% a 88% das linhas com menos de 5 partidas
+    disputadas). A pergunta é se o sinal delas sobrevive quando o histórico deixa de ser
+    artificialmente curto — ou se ele era o artefato.
+
+    As #53 e #54 já publicaram os números delas célula a célula. O que esta análise acrescenta, e
+    é o que o critério de aceite pede, é o VEREDITO: uma regra escrita antes de olhar, aplicada
+    mecanicamente, para "sobrevive" não ser leitura de tabela.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A REGRA, DECLARADA
+
+    O QUE É "HISTÓRICO REAL". As células com o escopo solto — `escopo` e `ambos` —, porque a
+    hipótese do ticket de origem é sobre ESCOPO: o histórico do time está contado dentro da
+    competição do jogo, e por isso um time de Copa do Brasil com 2 jogos naquela competição é
+    tratado como time sem passado. As outras duas células entram na saída como contexto: `base` é
+    o que roda hoje e `recorte` isola o outro eixo.
+
+    ONDE. No piso 5 — o piso da spec e o que a [0.1] usa como referência. Ver a ressalva de piso
+    abaixo.
+
+    O VEREDITO, por premissa:
+
+      SOBREVIVE            `diferenca_p5` > 0 nas DUAS células de escopo solto (`escopo` e
+                           `ambos`), e n_p5 >= 25 nas duas.
+      SOBREVIVE_COM_RESSALVA   o sinal é positivo nas duas, mas em alguma delas n_p5 < 25.
+      SEM_EVIDENCIA        qualquer outro caso — inclusive sinal positivo numa célula só.
+
+    POR QUE AS DUAS, E NÃO UMA. Uma premissa que só melhora sob `ambos` melhora quando os DOIS
+    eixos se soltam, e aí não dá para dizer se o que a salvou foi juntar competição ou parar de
+    zerar na virada de temporada — que é exatamente a pergunta 9 da spec. Exigir as duas é exigir
+    que o sinal não dependa de qual eixo se mexeu.
+
+    POR QUE n >= 25. É o ponto em que o encolhimento `n/(n+50)` que o Teste 2 aplica ao peso passa
+    de 1/3 — abaixo disso, dois terços de qualquer ganho medido são descartados por falta de
+    amostra, e chamar isso de "sobreviveu" seria emprestar ao número uma confiança que a própria
+    fórmula do peso recusa. O corte sai da constante k=50 que já existe, e não de uma régua nova.
+
+    ⚠️ ISTO NÃO É RECOMENDAÇÃO DE PESO, e a distinção não é formalidade. A [0.1] mediu que ganho
+    de premissa medido in-sample não se replica out-of-sample (+10,0% virou −6,2%), e a spec #49
+    põe peso explicitamente fora de escopo. "Sobrevive" aqui quer dizer "a evidência que a [B] vai
+    ler continua de pé quando o histórico é real", e não "vale apostar nela".
+
+    ⚠️ E O VEREDITO É NO PISO 5 PORQUE A PERGUNTA É SOBRE AMOSTRA CURTA. No piso 0 as quatro
+    continuam parecendo boas — é essa aparência que a [F] existe para desmontar. A saída traz os
+    quatro pisos no detalhe para quem quiser ver a régua se mexer.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    DOIS BLOCOS
+
+      quatro     as quatro premissas que a spec nomeia, com o número em cada uma das quatro
+                 células e o veredito.
+      catalogo   a MESMA regra aplicada às 39, resumida. Existe para o veredito das quatro não ser
+                 lido isolado: se metade do catálogo "sobrevive", sobreviver não significa nada.
+                 É a conferência de que a régua discrimina.
+
+    COMO RODAR (do dbt_futebol/), depois das quatro células medidas:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_sobrevivencia
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=500 \
+        < target/compiled/dbt_futebol/analyses/taskf_sobrevivencia.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento; e sem
+    `--max_rows` ele trunca em 100 linhas sem avisar.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set universo = var('taskf_universo', 'completo') -%}
+{%- set universos_validos = [] -%}
+{%- for u in taskf_universos() -%}{%- set _ = universos_validos.append(u.nome) -%}{%- endfor -%}
+{%- if universo not in universos_validos -%}
+    {{ exceptions.raise_compiler_error(
+        "universo inválido: '" ~ universo ~ "'. Valores aceitos: " ~ universos_validos | join(' | ')) }}
+{%- endif -%}
+
+{%- set pisos = taskf_pisos() -%}
+{# As quatro que a spec #49 nomeia. Digitadas porque é uma lista da spec, não algo a derivar do
+   dado: uma regra que descobrisse sozinha "as de maior sinal" concordaria com o que quer que o
+   número estivesse dizendo hoje. #}
+{%- set as_quatro = ['clean_sheets_altos', 'superioridade_xg', 'tende_golear', 'defesa_forte'] -%}
+{# A régua, num lugar só. #}
+{%- set piso_veredito = 5  -%}
+{%- set n_minimo      = 25 -%}
+{# As células de "histórico real" — as de escopo solto. Derivadas do 2×2, não digitadas: o nome de
+   célula sai sempre de taskf_nomes_de_celula(). #}
+{%- set cel_escopo = taskf_nomes_de_celula()['todas|temporada'] -%}
+{%- set cel_ambos  = taskf_nomes_de_celula()['todas|ultimos_10'] -%}
+{%- set cel_base   = taskf_nomes_de_celula()['da_competicao|temporada'] -%}
+{%- set cel_recorte = taskf_nomes_de_celula()['da_competicao|ultimos_10'] -%}
+
+
+WITH medido AS (
+    SELECT *
+    FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    WHERE universo = '{{ universo }}'
+      AND usado_para_peso
+),
+
+{# Uma linha por premissa, com as quatro células lado a lado. O grão do Teste 2 é (mercado,
+   premissa, benchmark); no benchmark preferido cada premissa aparece uma vez por mercado, e
+   nenhuma das 39 aparece em dois mercados — mas o agrupamento carrega o mercado assim mesmo,
+   porque supor unicidade de nome é como se descobre que ela não valia. #}
+por_premissa AS (
+    SELECT
+        mercado,
+        premissa,
+        benchmark,
+        {%- for cel in [cel_base, cel_escopo, cel_recorte, cel_ambos] %}
+        MAX(IF(celula = '{{ cel }}', diferenca_p{{ piso_veredito }}, NULL)) AS dif_{{ cel }},
+        MAX(IF(celula = '{{ cel }}', n_p{{ piso_veredito }},         NULL)) AS n_{{ cel }},
+        MAX(IF(celula = '{{ cel }}', peso_p{{ piso_veredito }},      NULL)) AS peso_{{ cel }},
+        MAX(IF(celula = '{{ cel }}', pct_amostra_curta,              NULL)) AS curta_{{ cel }},
+        {%- endfor %}
+        {%- for piso in pisos %}
+        MAX(IF(celula = '{{ cel_escopo }}', diferenca_p{{ piso }}, NULL)) AS dif_escopo_p{{ piso }},
+        MAX(IF(celula = '{{ cel_ambos }}',  diferenca_p{{ piso }}, NULL)) AS dif_ambos_p{{ piso }},
+        {%- endfor %}
+        COUNT(DISTINCT celula) AS celulas
+    FROM medido
+    GROUP BY mercado, premissa, benchmark
+),
+
+{# A regra, aplicada. `celulas = 4` entra no veredito porque uma premissa que não acende numa das
+   células de histórico real não tem como ter sinal positivo nela — e sem esta linha ela sairia
+   SEM_EVIDENCIA por NULL, que é o veredito certo pelo motivo errado. #}
+julgado AS (
+    SELECT
+        p.*,
+        p.premissa IN ({{ as_quatro | map('tojson') | join(', ') }}) AS uma_das_quatro,
+        CASE
+            WHEN p.dif_{{ cel_escopo }} IS NULL OR p.dif_{{ cel_ambos }} IS NULL
+                THEN 'SEM_EVIDENCIA'
+            WHEN p.dif_{{ cel_escopo }} > 0 AND p.dif_{{ cel_ambos }} > 0
+                 AND p.n_{{ cel_escopo }} >= {{ n_minimo }}
+                 AND p.n_{{ cel_ambos }}  >= {{ n_minimo }}
+                THEN 'SOBREVIVE'
+            WHEN p.dif_{{ cel_escopo }} > 0 AND p.dif_{{ cel_ambos }} > 0
+                THEN 'SOBREVIVE_COM_RESSALVA'
+            ELSE 'SEM_EVIDENCIA'
+        END AS veredito
+    FROM por_premissa AS p
+)
+
+SELECT 1 AS ordem, 'quatro' AS bloco,
+    premissa AS chave,
+    veredito,
+    dif_{{ cel_escopo }} AS dif_escopo,
+    dif_{{ cel_ambos }}  AS dif_ambos,
+    CAST(n_{{ cel_escopo }} AS FLOAT64) AS n_escopo,
+    TO_JSON_STRING(STRUCT(
+        mercado, benchmark,
+        dif_{{ cel_base }}    AS dif_base,    n_{{ cel_base }}    AS n_base,
+        dif_{{ cel_recorte }} AS dif_recorte, n_{{ cel_recorte }} AS n_recorte,
+        n_{{ cel_ambos }} AS n_ambos,
+        peso_{{ cel_base }} AS peso_base, peso_{{ cel_escopo }} AS peso_escopo,
+        peso_{{ cel_recorte }} AS peso_recorte, peso_{{ cel_ambos }} AS peso_ambos,
+        curta_{{ cel_base }} AS curta_base, curta_{{ cel_escopo }} AS curta_escopo,
+        curta_{{ cel_recorte }} AS curta_recorte, curta_{{ cel_ambos }} AS curta_ambos,
+        {%- for piso in pisos %}
+        dif_escopo_p{{ piso }}, dif_ambos_p{{ piso }}{{ ',' if not loop.last }}
+        {%- endfor %}
+    )) AS detalhe
+FROM julgado
+WHERE uma_das_quatro
+
+UNION ALL
+{# O resumo do catálogo: quantas das 39 caem em cada veredito, e quem são. É o que impede a
+   leitura "duas das quatro sobreviveram" de ser lida sem saber que o catálogo inteiro tem N
+   sobreviventes. #}
+SELECT 2, 'catalogo',
+    veredito,
+    FORMAT('%d de %d premissas', COUNT(*), (SELECT COUNT(*) FROM julgado)),
+    CAST(COUNT(*) AS FLOAT64),
+    CAST(COUNTIF(uma_das_quatro) AS FLOAT64),
+    ROUND(AVG(dif_{{ cel_escopo }}), 2),
+    TO_JSON_STRING(STRUCT(
+        STRING_AGG(premissa, ', ' ORDER BY premissa) AS quais,
+        STRING_AGG(IF(uma_das_quatro, premissa, NULL), ', ' ORDER BY premissa) AS quais_das_quatro,
+        {{ piso_veredito }} AS piso_do_veredito, {{ n_minimo }} AS n_minimo,
+        '{{ universo }}' AS universo
+    ))
+FROM julgado
+GROUP BY veredito
+
+ORDER BY ordem, chave

--- a/dbt_futebol/analyses/taskf_sobrevivencia.sql
+++ b/dbt_futebol/analyses/taskf_sobrevivencia.sql
@@ -71,13 +71,7 @@
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */
 
-{%- set universo = var('taskf_universo', 'completo') -%}
-{%- set universos_validos = [] -%}
-{%- for u in taskf_universos() -%}{%- set _ = universos_validos.append(u.nome) -%}{%- endfor -%}
-{%- if universo not in universos_validos -%}
-    {{ exceptions.raise_compiler_error(
-        "universo inválido: '" ~ universo ~ "'. Valores aceitos: " ~ universos_validos | join(' | ')) }}
-{%- endif -%}
+{%- set universo = taskf_universo_valido(var('taskf_universo', 'completo')) -%}
 
 {%- set pisos = taskf_pisos() -%}
 {# As quatro que a spec #49 nomeia. Digitadas porque é uma lista da spec, não algo a derivar do
@@ -103,9 +97,15 @@ WITH medido AS (
 ),
 
 {# Uma linha por premissa, com as quatro células lado a lado. O grão do Teste 2 é (mercado,
-   premissa, benchmark); no benchmark preferido cada premissa aparece uma vez por mercado, e
-   nenhuma das 39 aparece em dois mercados — mas o agrupamento carrega o mercado assim mesmo,
-   porque supor unicidade de nome é como se descobre que ela não valia. #}
+   premissa, benchmark), e o agrupamento aqui carrega o mercado junto porque supor unicidade de
+   NOME é como se descobre que ela não valia.
+
+   ⚠️ E ela não vale: `defesas_vazaveis` existe em DOIS mercados — BTTS (consenso) e Gols (sharp)
+   —, com vereditos OPOSTOS. As "39 premissas" do entregável são 39 linhas de (mercado, premissa,
+   benchmark) sobre 38 nomes distintos. Este cabeçalho dizia o contrário até a medição da #58
+   desmenti-lo; a expectativa fica registrada, corrigida, porque é ela que explica por que o
+   agrupamento não é por nome. Quem agrupar só por `premissa` mistura as duas linhas e produz um
+   veredito que não é de nenhuma das duas. #}
 por_premissa AS (
     SELECT
         mercado,
@@ -126,9 +126,12 @@ por_premissa AS (
     GROUP BY mercado, premissa, benchmark
 ),
 
-{# A regra, aplicada. `celulas = 4` entra no veredito porque uma premissa que não acende numa das
-   células de histórico real não tem como ter sinal positivo nela — e sem esta linha ela sairia
-   SEM_EVIDENCIA por NULL, que é o veredito certo pelo motivo errado. #}
+{# A regra, aplicada. Uma premissa que não acende numa das duas células de histórico real cai no
+   primeiro WHEN — a diferença dela ali é NULL — e sai SEM_EVIDENCIA por ausência de medida, não
+   por sinal negativo. O teste de NULL vem PRIMEIRO de propósito: em SQL, `NULL > 0` é NULL e não
+   FALSE, então sem ele a linha escorregaria até o ELSE e sairia com o mesmo rótulo pelo motivo
+   errado. A contagem `celulas` viaja junto e sai no detalhe: ela é o diagnóstico de quantas das
+   quatro a premissa alcançou, e é o que distingue os dois casos ao ler a saída. #}
 julgado AS (
     SELECT
         p.*,
@@ -154,7 +157,7 @@ SELECT 1 AS ordem, 'quatro' AS bloco,
     dif_{{ cel_ambos }}  AS dif_ambos,
     CAST(n_{{ cel_escopo }} AS FLOAT64) AS n_escopo,
     TO_JSON_STRING(STRUCT(
-        mercado, benchmark,
+        mercado, benchmark, celulas,
         dif_{{ cel_base }}    AS dif_base,    n_{{ cel_base }}    AS n_base,
         dif_{{ cel_recorte }} AS dif_recorte, n_{{ cel_recorte }} AS n_recorte,
         n_{{ cel_ambos }} AS n_ambos,

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -27,7 +27,7 @@
     referência, com o risco de reconciliar a medição contra um bug meu.
 
     ────────────────────────────────────────────────────────────────────────────────
-    O QUE MUDA EM RELAÇÃO AO ORIGINAL — cinco coisas, e só cinco:
+    O QUE MUDA EM RELAÇÃO AO ORIGINAL — seis coisas, e só seis:
 
     1. UNIVERSO CONGELADO. `apostas` é recortada por taskf_universo_filtro(). O original rodou sem
        corte (a janela dele é o instante da execução). Ver macros/taskf_universo.sql: o teto é um
@@ -45,6 +45,33 @@
     5. O CARIMBO DA CONSTRUÇÃO DOS FATOS (#55), `odds_loaded_at`. Ver a CTE `fatos`: é ele que
        tira "as quatro rodaram na mesma execução" da disciplina e põe na linha, onde a Costura B
        consegue cobrar.
+    6. A COLUNA DE UNIVERSO (#58). O recorte do item 1 deixa de ser único: cada célula emite uma
+       linha por (universo, mercado, premissa, benchmark), com os universos de
+       macros/taskf_universos.sql. Ver a seção abaixo.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    OS QUATRO UNIVERSOS, E POR QUE ELES SAEM DO MESMO INSERT (#58)
+
+    A #58 fecha duas perguntas que são sobre QUAIS JOGOS ENTRAM NA CONTA, e não sobre o histórico
+    que cada jogo carrega: a Copa do Mundo deve sair da base de medição? E a fase classificatória
+    da Champions? As duas só se respondem medindo COM e SEM.
+
+    O universo é, portanto, um TERCEIRO EIXO — ortogonal à célula. As definições e o argumento de
+    cada variante estão em macros/taskf_universos.sql; aqui importa uma consequência de
+    engenharia: **os quatro universos de uma célula saem do MESMO INSERT**. Se `completo` e
+    `sem_copa_mundo` fossem duas execuções, a diferença entre elas carregaria dentro de si uma
+    reconstrução dos modelos — e a #55 mediu que uma reconstrução move 5 campos em 7.200 sozinha.
+    Como a comparação COM/SEM é exatamente o entregável, esse ruído entraria no lugar da resposta.
+
+    Emitidos juntos, os quatro compartilham `medido_em`, `git_sha` e `odds_loaded_at` por
+    construção (`CURRENT_TIMESTAMP()` é estável dentro de um statement no BigQuery), e a única
+    coisa que difere entre eles é o conjunto de jogos — que é a pergunta.
+
+    ⚠️ `jogos_no_universo`, `linhas_no_universo`, `janela_ini` e `janela_fim` passam a ser POR
+    UNIVERSO. Quem ler a tabela sem filtrar universo verá quatro valores para cada um deles e
+    quatro linhas por premissa — é por isso que TODO consumidor recorta o universo que quer, e a
+    Costura B cobra a invariante de universo dentro de cada um deles em vez de sobre a tabela
+    inteira.
 
     ────────────────────────────────────────────────────────────────────────────────
     AS DUAS CONTAGENS DE AMOSTRA, E QUAL DELAS O PISO CORTA (#54)
@@ -86,8 +113,9 @@
 
     ⚠️ E É POR ISSO QUE MUDAR O SCHEMA EXIGE DROPAR A TABELA. `CREATE TABLE IF NOT EXISTS` não
     acrescenta coluna a uma tabela que já existe: com o schema novo, o INSERT de lista explícita
-    falha na primeira célula. Aconteceu duas vezes — a #54 (as duas contagens de amostra) e a #55
-    (o `odds_loaded_at`) —, e nas duas a tabela foi dropada antes da primeira célula, o que só é
+    falha na primeira célula. Aconteceu três vezes — a #54 (as duas contagens de amostra), a #55
+    (o `odds_loaded_at`) e a #58 (a coluna de universo) —, e nas três a tabela foi dropada antes da
+    primeira célula, o que só é
     seguro porque as quatro são re-medidas na mesma execução, que é o que a spec exige de qualquer
     jeito. Se um ticket futuro mudar o schema de novo, é o mesmo passo, e ele NÃO é rotina: dropar
     sem re-medir as quatro deixa a tabela com células de formatos diferentes de execuções
@@ -110,8 +138,8 @@
     ────────────────────────────────────────────────────────────────────────────────
     COMO RODAR (do dbt_futebol/) — EM FASES, e a separação não é economia, é correção.
 
-    FASE 0, só quando o schema de uma das duas tabelas acumulativas muda (foi o caso na #54 e na
-    #55). Dropar só a que mudou de formato basta — a outra é reescrita célula a célula pelo
+    FASE 0, só quando o schema de uma das duas tabelas acumulativas muda (foi o caso na #54, na
+    #55 e na #58). Dropar só a que mudou de formato basta — a outra é reescrita célula a célula pelo
     DELETE + INSERT da fase 2, e a fase 2 roda inteira nas quatro de qualquer forma, então as duas
     terminam carregando a mesma execução:
 
@@ -195,7 +223,7 @@
     vezes, ela derivaria — e um INSERT posicional com colunas trocadas de lugar não dá erro, dá
     número errado. -#}
 {%- set colunas = [
-    'celula STRING', 'pit_escopo STRING', 'pit_recorte STRING',
+    'celula STRING', 'pit_escopo STRING', 'pit_recorte STRING', 'universo STRING',
     'medido_em TIMESTAMP', 'git_sha STRING', 'odds_loaded_at TIMESTAMP',
     'janela_ini DATE', 'janela_fim DATE',
     'jogos_no_universo INT64', 'linhas_no_universo INT64',
@@ -252,11 +280,25 @@ pit_disponivel AS (
           AND a.team_id    = j.away_team_id
 ),
 
-{#- O UNIVERSO CONGELADO. Por que o recorte cai aqui, em cima de `apostas`, e não num parâmetro
-    novo do task01_base(): está no cabeçalho de macros/taskf_universo.sql, junto do predicado. -#}
-apostas_congeladas AS (
+{#- AS APOSTAS COM O QUE OS UNIVERSOS PRECISAM LER. Sem recorte nenhum aqui: o recorte é o eixo
+    de universo e acontece no CTE seguinte, uma vez por variante.
+
+    `round` entra por join com o fact_fixtures porque `apostas` não o carrega, e o predicado da
+    fase classificatória da Champions é escrito por semântica de fase (ver
+    macros/taskf_universos.sql). É o mesmo seam do `pit_disponivel` acima e pelo mesmo motivo: o
+    task01_base() é o artefato que produziu os números publicados da [0.1] e não é tocado por esta
+    medição.
+
+    O COALESCE do `round` não é decoração. Sem ele, um fixture de Champions com `round` nulo
+    tornaria `NOT (competition = ... AND round LIKE ...)` nulo, e a linha sumiria do universo
+    `estendido_sem_champions_classif` calada — some do lado SEM, que é exatamente onde ninguém
+    procuraria. Com string vazia, ela cai do lado certo (não é classificatória por rótulo) e
+    aparece na contagem. Nas linhas fora da Champions o predicado já é FALSE pelo primeiro termo,
+    então nada depende do rótulo. -#}
+apostas_marcadas AS (
     SELECT
         a.*,
+        COALESCE(f.round, '')                  AS round,
         {#- O `min_jogos` que vem do task01_base() é o USADO: ele sai do played_total do PIT, que
             sob recorte de contagem já vem saturado. Ganha aqui um nome que diz isso — o `a.*`
             acima mantém o original, então as duas formas convivem no CTE e só a nomeada chega à
@@ -266,7 +308,23 @@ apostas_congeladas AS (
     FROM apostas AS a
     LEFT JOIN pit_disponivel AS d
            ON d.fixture_id = a.fixture_id
-    WHERE {{ taskf_universo_filtro('a.') }}
+    LEFT JOIN {{ ref('fact_fixtures') }} AS f
+           ON f.fixture_id = a.fixture_id
+),
+
+{#- OS UNIVERSOS, um recorte por variante, todos na mesma passada. Ver macros/taskf_universos.sql
+    para o que cada um responde. A lista vem da macro e nunca é digitada aqui: um universo que
+    existisse no predicado e não na lista (ou o contrário) produziria coluna vazia numa tabela
+    que já tem quatro dimensões, que é o tipo de buraco que ninguém encontra olhando. -#}
+apostas_universos AS (
+    {%- for u in taskf_universos() %}
+    SELECT '{{ u.nome }}' AS universo, a.*
+    FROM apostas_marcadas AS a
+    WHERE {{ taskf_universo_predicado(u.nome, 'a.') }}
+    {%- if not loop.last %}
+    UNION ALL
+    {%- endif %}
+    {%- endfor %}
 ),
 
 {#- Uma passada, grão (mercado, premissa, benchmark). Só as linhas em que a premissa ACENDEU
@@ -279,6 +337,7 @@ apostas_congeladas AS (
     artefato que matou os +9,7% da Task [0]. Ver os dois lado a lado é o ponto. -#}
 agregado AS (
     SELECT
+        a.universo,
         a.market_id,
         pl.premissa,
         a.benchmark,
@@ -292,23 +351,28 @@ agregado AS (
         AVG(IF(pl.acesa AND a.min_jogos_disponivel >= {{ piso }},
                CAST(a.ganhou AS INT64), NULL))                   AS p_real_{{ piso }}
         {%- endfor %}
-    FROM apostas_congeladas AS a
+    FROM apostas_universos AS a
     JOIN prem_long AS pl
       ON  pl.market_id                  = a.market_id
       AND pl.fixture_id                 = a.fixture_id
       AND pl.outcome_side               = a.outcome_side
       AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
-    GROUP BY a.market_id, pl.premissa, a.benchmark
+    GROUP BY a.universo, a.market_id, pl.premissa, a.benchmark
     HAVING COUNTIF(pl.acesa) > 0
 ),
 
+{#- POR UNIVERSO, e não uma linha só: cada universo tem o seu corte, então tem a sua contagem de
+    jogos e as suas duas pontas de janela. É o que deixa a Costura B cobrar a invariante de
+    universo DENTRO de cada um deles. -#}
 janela AS (
     SELECT
+        universo,
         MIN(DATE(kickoff_utc))     AS janela_ini,
         MAX(DATE(kickoff_utc))     AS janela_fim,
         COUNT(DISTINCT fixture_id) AS jogos_no_universo,
         COUNT(*)                   AS linhas_no_universo
-    FROM apostas_congeladas
+    FROM apostas_universos
+    GROUP BY universo
 ),
 
 {#- QUAL CONSTRUÇÃO DOS FATOS ESTA CÉLULA LEU (#55). O `fact_odds_snapshot` é `materialized:
@@ -353,6 +417,7 @@ SELECT
     '{{ c.nome }}'                                          AS celula,
     '{{ c.escopo }}'                                        AS pit_escopo,
     '{{ c.recorte }}'                                       AS pit_recorte,
+    r.universo,
     CURRENT_TIMESTAMP()                                     AS medido_em,
     '{{ var("taskf_git_sha", "desconhecido") }}'            AS git_sha,
     -- A construção dos fatos que esta célula leu; ver a CTE `fatos`. É o que deixa "as quatro
@@ -395,5 +460,5 @@ SELECT
        ROUND(GREATEST((r.p_real_0 - r.p_odd_0) * 100, 0), 2),
        NULL)                                                AS peso_p0_k0
 FROM rotulado AS r
-CROSS JOIN janela AS j
+JOIN janela AS j ON j.universo = r.universo
 CROSS JOIN fatos AS f

--- a/dbt_futebol/analyses/taskf_universo_congelado.sql
+++ b/dbt_futebol/analyses/taskf_universo_congelado.sql
@@ -7,7 +7,7 @@
     ANTES de materializar célula nenhuma, porque descobrir que o universo se mexeu depois de
     construir a camada de premissas é caro e tarde.
 
-    Quatro variantes de propósito, e não só a congelada:
+    Cinco variantes de propósito, e não só a congelada:
 
       A_sem_corte          o que a [0.1] rodou — todo jogo liquidado com odd, sem corte. Hoje ele
                            é MAIOR que o publicado, porque o tempo passou; a diferença entre A e
@@ -24,6 +24,23 @@
                            base, então qualquer instante da faixa devolve os mesmos 169. C e D
                            idênticos é o que torna o corte robusto; se um dia divergirem, apareceu
                            jogo no vão e o teto precisa ser re-argumentado.
+      E_estendido          o universo SECUNDÁRIO da spec (#58): o mesmo piso, sem teto nenhum.
+                           Acrescentado porque a pergunta da Champions não tem amostra no
+                           congelado — os únicos jogos dela no período são os 8 de 04/08 à noite,
+                           que o teto remove. Ele é o predicado `estendido` de
+                           macros/taskf_universos.sql, lido de lá e não redigitado aqui.
+
+    ⚠️ E É A MESMA CONTA DO `A_sem_corte`, com uma diferença que importa: A não tem piso NEM teto e
+    existe para mostrar o que o congelamento remove; E declara o piso e é o universo que a #58 de
+    fato mede. Que os dois deem o mesmo número hoje é consequência de a coleta de odds ser
+    forward-only e ter começado em 16/06 — o piso é no-op, como o cabeçalho do macro já registra.
+    Se um dia divergirem, apareceu odd de jogo anterior a 16/06 na base.
+
+    ⚠️ O QUE LIMITA O `E_estendido` NÃO É UMA DATA, É A CONSTRUÇÃO DOS FATOS. Rodado com
+    `--target taskF`, ele alcança o que a ancestria daquele dataset contém — que é o mesmo
+    `fact_odds_snapshot` que as quatro células leram. Rodado com `--target dev`, alcança produção,
+    que anda. Os dois são legítimos e respondem perguntas diferentes; o que não se pode é comparar
+    número de um com número do outro.
 
     E o piso: A e B devolvem `janela_ini = 2026-06-16` sem que ninguém peça, porque a coleta de
     odds é forward-only e começou nesse dia. O piso declarado é no-op — e fica declarado assim
@@ -69,6 +86,17 @@ variantes AS (
     FROM apostas
     WHERE kickoff_utc >= TIMESTAMP('{{ j.ini }}')
       AND kickoff_utc <  TIMESTAMP('2026-08-04 06:00:00')
+
+    UNION ALL
+
+    {# O predicado vem da macro dos universos, não de uma segunda escrita do mesmo intervalo: é
+       o MESMO recorte que o Teste 2 grava sob o rótulo `estendido`, e duas escritas que precisam
+       ficar iguais para sempre não ficam. NB: comentário sem traço nas pontas de propósito — o
+       `{#-` comeria a quebra de linha e compilaria `UNION ALLSELECT`, que é o defeito que a #55
+       encontrou em master (PR #48). #}
+    SELECT 'E_estendido', fixture_id, kickoff_utc, competition, benchmark
+    FROM apostas
+    WHERE {{ taskf_universo_predicado('estendido') }}
 )
 
 SELECT

--- a/dbt_futebol/macros/taskf_universos.sql
+++ b/dbt_futebol/macros/taskf_universos.sql
@@ -95,6 +95,31 @@
 
 
 {#-
+    A VALIDAÇÃO DO NOME, num lugar só — e devolvendo o nome, para caber numa linha no consumidor:
+
+        {%- set universo = taskf_universo_valido(var('taskf_universo', 'completo')) -%}
+
+    Existe pelo mesmo argumento que a ADR 0007 usa para a lista de valores de eixo em
+    `taskf_eixos()`: a LISTA já morava num lugar só, mas o VALIDADOR estava copiado em cada
+    consumidor, e quatro cópias de uma checagem que precisa ficar igual para sempre não ficam. A
+    divergência aqui seria muda das duas formas — um consumidor aceitando um nome que outro recusa
+    lê universo vazio, e universo vazio se parece com "essa premissa não acende aqui".
+
+    Fail-closed: nome desconhecido levanta erro de compilação em vez de virar filtro que não casa
+    com linha nenhuma.
+-#}
+{% macro taskf_universo_valido(nome) %}
+    {%- set nomes = [] -%}
+    {%- for u in taskf_universos() -%}{%- set _ = nomes.append(u.nome) -%}{%- endfor -%}
+    {%- if nome not in nomes -%}
+        {{ exceptions.raise_compiler_error(
+            "universo inválido: '" ~ nome ~ "'. Valores aceitos: " ~ nomes | join(' | ')) }}
+    {%- endif -%}
+    {{ return(nome) }}
+{% endmacro %}
+
+
+{#-
     O PREDICADO DE CADA UNIVERSO. `alias` inclui o ponto: taskf_universo_predicado('completo', 'a.')
 
     O alias precisa expor `kickoff_utc`, `competition` e `round`. Os dois primeiros vêm de
@@ -107,12 +132,7 @@
 -#}
 {% macro taskf_universo_predicado(nome, alias='') %}
     {%- set j = taskf_universo() -%}
-    {%- set nomes = [] -%}
-    {%- for u in taskf_universos() -%}{%- set _ = nomes.append(u.nome) -%}{%- endfor -%}
-    {%- if nome not in nomes -%}
-        {{ exceptions.raise_compiler_error(
-            "universo inválido: '" ~ nome ~ "'. Valores aceitos: " ~ nomes | join(' | ')) }}
-    {%- endif -%}
+    {%- set _ = taskf_universo_valido(nome) -%}
     {%- if nome == 'completo' -%}
         {{ taskf_universo_filtro(alias) }}
     {%- elif nome == 'sem_copa_mundo' -%}

--- a/dbt_futebol/macros/taskf_universos.sql
+++ b/dbt_futebol/macros/taskf_universos.sql
@@ -1,0 +1,157 @@
+{#
+    OS UNIVERSOS DE MEDIÇÃO da task [F] (issue #49, ticket #58), escritos UMA vez.
+
+    Um UNIVERSO diz QUAIS JOGOS entram na conta. É o terceiro eixo da medição, e ele não tem
+    relação com os outros dois:
+
+      universo   quais jogos são MEDIDOS               (esta macro)
+      célula     qual HISTÓRICO cada jogo carrega      (macros/taskf_celula.sql — escopo × recorte)
+      janela     qual coleta de ODDS foi lida          (daily/t24h/t1h/t15m — nada a ver com [F])
+
+    Até a #57 existia um universo só, o congelado da [0.1] (macros/taskf_universo.sql). A #58
+    precisa de quatro porque as duas perguntas que ela fecha são perguntas sobre o UNIVERSO, e não
+    sobre o histórico: "a Copa do Mundo deve sair da base de medição?" e a mesma sobre a fase
+    classificatória da Champions. Uma pergunta dessas só se responde medindo COM e SEM — e as duas
+    medições têm de sair da MESMA construção dos fatos e da MESMA materialização da célula, senão
+    a diferença entre elas carrega dentro de si um rebuild. Por isso os universos são uma coluna
+    da tabela do Teste 2, emitidos todos pelo mesmo INSERT, e não execuções separadas.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    OS QUATRO, e o que cada um existe para responder:
+
+      completo                          o universo congelado da [0.1] — 16/06 a 04/08, 169 jogos.
+                                        É o PRIMÁRIO: é dele que sai tudo o que as #51–#55
+                                        mediram, e é ele que as guardas da Costura B cobram.
+
+      sem_copa_mundo                    o mesmo, menos a Copa do Mundo (79 jogos, 46,7%). O par
+                                        `completo` × `sem_copa_mundo` é a resposta empírica que a
+                                        spec pede: a recomendação sai do efeito na ORDENAÇÃO das
+                                        premissas, não do bom senso.
+
+      estendido                         de 16/06 até onde os fatos alcançam, SEM teto. Reportado
+                                        à parte (user story 5 da #58) e, sobretudo, é o único
+                                        universo em que a Champions existe.
+
+      estendido_sem_champions_classif   o estendido menos a FASE CLASSIFICATÓRIA da Champions —
+                                        a exclusão candidata que a spec nomeia. Não é "menos a
+                                        Champions": ver o predicado abaixo.
+
+    ⚠️ POR QUE A PERGUNTA DA CHAMPIONS SÓ CABE NO ESTENDIDO. O universo congelado não tem UM jogo
+    de Champions: os únicos do período são os 8 de 04/08 à noite, e o teto do congelado (04/08
+    12:00 UTC) os remove. Medido na #51. Sem o estendido, a user story 24 da spec #49 não teria
+    amostra nenhuma.
+
+    ⚠️ O ESTENDIDO NÃO TEM TETO, E ISSO É ESCOLHA. Um teto datado seria um segundo número a
+    calibrar, e ele mentiria: o que limita o estendido não é uma data, é a CONSTRUÇÃO DOS FATOS
+    que as quatro células leram (o `odds_loaded_at` carimbado na linha). Rebuildar a ancestria
+    para o estendido alcançar hoje custaria re-medir as quatro células e quebraria a única coisa
+    que faz a comparação entre elas significar algo. Sem teto, o universo é "o que os fatos
+    contêm", o `janela_fim` da linha diz até onde ele foi, e o `odds_loaded_at` ao lado diz por
+    quê. É o mesmo espírito da variante `A_sem_corte` do analyses/taskf_universo_congelado.sql.
+
+    ⚠️ E O ESTENDIDO NÃO É COMPARÁVEL COM O CONGELADO COMO SE FOSSE OUTRA CÉLULA. Ele contém os
+    169 mais o que veio depois; as duas linhas do Teste 2 não são um A/B de um eixo, são dois
+    recortes encaixados. O que se compara DENTRO dele é o par com/sem Champions. A tolerância de
+    0,5 pp declarada na #51 para `linha_subindo`/`linha_descendo` volta a ter mordida aqui: no
+    congelado a coleta de odds já tinha parado (zero capturas após 04/08, medido), no estendido
+    não.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O GABARITO (`jogos_esperados`), e por que só dois dos quatro têm um.
+
+    Os dois universos congelados têm contagem FIXA: 169 e 90 (169 − 79 da Copa do Mundo). Uma
+    guarda que compare contra eles pega jogo que apareceu ou sumiu — que num universo congelado é
+    sempre erro, e a #51 mostrou que ele se move sozinho (resultado que entra tarde, jogo
+    remarcado). Os dois estendidos crescem legitimamente a cada construção dos fatos, então
+    gabarito neles seria um número a atualizar toda execução — cobrança que só ensina a ignorar
+    guarda. `none` aqui quer dizer "não há número a declarar", e não "ninguém conferiu": a
+    invariante que vale para os quatro — as quatro células medirem o MESMO universo — é cobrada em
+    tests/assert_taskf_celulas_mesmo_universo.sql para TODOS eles.
+
+    Uso:
+
+        {%- for u in taskf_universos() %}
+        SELECT '{{ u.nome }}' AS universo, ... WHERE {{ taskf_universo_predicado(u.nome, 'a.') }}
+        {%- endfor %}
+#}
+
+{% macro taskf_universos() %}
+    {%- set j = taskf_universo() -%}
+    {{ return([
+        {'nome': 'completo',
+         'jogos_esperados': j.jogos_esperados,
+         'descricao': 'O universo congelado da [0.1]: 16/06 a 04/08, 169 jogos. O primário.'},
+        {'nome': 'sem_copa_mundo',
+         'jogos_esperados': j.jogos_esperados - 79,
+         'descricao': 'O congelado menos a Copa do Mundo — o lado SEM do par que a #58 mede.'},
+        {'nome': 'estendido',
+         'jogos_esperados': none,
+         'descricao': 'De 16/06 até onde a construção dos fatos alcança, sem teto.'},
+        {'nome': 'estendido_sem_champions_classif',
+         'jogos_esperados': none,
+         'descricao': 'O estendido menos a fase classificatória da Champions.'}
+    ]) }}
+{% endmacro %}
+
+
+{#-
+    O PREDICADO DE CADA UNIVERSO. `alias` inclui o ponto: taskf_universo_predicado('completo', 'a.')
+
+    O alias precisa expor `kickoff_utc`, `competition` e `round`. Os dois primeiros vêm de
+    `apostas` (task01_base); `round` NÃO vem — ele é juntado do fact_fixtures no site que consome,
+    do mesmo jeito que a contagem disponível do PIT entra no analyses/taskf_teste2.sql. O macro
+    compartilhado não é tocado: ele é o artefato que produziu os números publicados da [0.1].
+
+    Fail-closed pelo mesmo motivo de taskf_eixos(): um nome digitado errado devolveria universo
+    vazio, e universo vazio se parece com "essa premissa não acende aqui".
+-#}
+{% macro taskf_universo_predicado(nome, alias='') %}
+    {%- set j = taskf_universo() -%}
+    {%- set nomes = [] -%}
+    {%- for u in taskf_universos() -%}{%- set _ = nomes.append(u.nome) -%}{%- endfor -%}
+    {%- if nome not in nomes -%}
+        {{ exceptions.raise_compiler_error(
+            "universo inválido: '" ~ nome ~ "'. Valores aceitos: " ~ nomes | join(' | ')) }}
+    {%- endif -%}
+    {%- if nome == 'completo' -%}
+        {{ taskf_universo_filtro(alias) }}
+    {%- elif nome == 'sem_copa_mundo' -%}
+        ({{ taskf_universo_filtro(alias) }} AND {{ alias }}competition <> 'copa_mundo')
+    {%- elif nome == 'estendido' -%}
+        ({{ alias }}kickoff_utc >= TIMESTAMP('{{ j.ini }}'))
+    {%- elif nome == 'estendido_sem_champions_classif' -%}
+        ({{ alias }}kickoff_utc >= TIMESTAMP('{{ j.ini }}')
+         AND NOT {{ taskf_champions_classificatoria(alias) }})
+    {%- endif -%}
+{%- endmacro %}
+
+
+{#-
+    A FASE CLASSIFICATÓRIA DA CHAMPIONS, escrita por SEMÂNTICA DE FASE e não por competição.
+
+    A spec é explícita: a exclusão candidata é a FASE, não a competição — "a mesma pergunta da
+    Copa do Mundo respondida também para a fase classificatória da Champions" (#49, user story
+    24; critério de aceite da #58). Escrever `competition = 'champions_league'` responderia outra
+    pergunta, e responderia igual HOJE por acidente: na janela medida a Champions só tem
+    qualificatória (a fase de liga começa em setembro). Que as duas coisas coincidam nesta janela
+    é MEDIÇÃO, e sai como número no analyses/taskf_exclusao.sql — não é premissa deste predicado.
+
+    ⚠️ A ARMADILHA DO 'Play-offs'. O `round` do fact_fixtures tem DOIS rótulos com a palavra:
+
+        'Play-offs'                 agosto — o último degrau da CLASSIFICATÓRIA, antes da fase de
+                                    liga. É classificatória.
+        'Knockout Round Play-offs'  fevereiro — o mata-mata de acesso às oitavas, DEPOIS da fase
+                                    de liga. NÃO é classificatória.
+
+    Por isso o casamento do primeiro é por IGUALDADE e não por LIKE '%Play-off%', que pegaria os
+    dois. Conferido no fact_fixtures: as temporadas 2024 e 2025 têm os dois rótulos, em meses
+    opostos do calendário. Na janela desta medição só o de agosto existe — mas um LIKE aqui seria
+    uma bomba armada para a primeira vez que alguém rodar isto sobre uma janela de fevereiro.
+
+    As três qualificatórias ('1st/2nd/3rd Qualifying Round') casam por LIKE porque o número muda e
+    a semântica não.
+-#}
+{% macro taskf_champions_classificatoria(alias='') %}
+    ({{ alias }}competition = 'champions_league'
+     AND ({{ alias }}round LIKE '%Qualifying Round%' OR {{ alias }}round = 'Play-offs'))
+{%- endmacro %}

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -614,6 +614,7 @@ sources:
               ⚠️ TODO consumidor precisa recortar o universo. Sem o filtro, cada premissa aparece
               quatro vezes e `jogos_no_universo` tem quatro valores. O default de quem lê é
               `completo`, que é o universo congelado da [0.1] e o primário da medição.
+          - name: medido_em
             description: >
               Quando a célula foi materializada. Existe porque a spec exige que as quatro rodem na
               MESMA execução — `linha_subindo`/`linha_descendo` leem odds ao vivo e viram sozinhas
@@ -632,8 +633,10 @@ sources:
               construção) e anterior ao `medido_em` de cada uma (os fatos vieram antes).
           - name: jogos_no_universo
             description: >
-              Jogos distintos do universo congelado (169). Idêntico nas quatro células por
-              construção — é a primeira invariante da Costura B.
+              Jogos distintos do universo DESTA LINHA. Desde a #58 ele é por universo — 169 no
+              `completo`, 90 no `sem_copa_mundo`, e os dois estendidos crescem com a construção
+              dos fatos. O que continua idêntico por construção, e é a primeira invariante da
+              Costura B, é o valor entre as QUATRO CÉLULAS de um MESMO universo.
           - name: usado_para_peso
             description: >
               A linha está no benchmark PREFERIDO do mercado (sharp p/ 1X2, Handicap e Gols;

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -573,12 +573,23 @@ sources:
           mudança de schema futura exigir outra re-medição, o caminho é copiar a acumulativa para
           uma tabela nova com o número do ticket, não sobrescrever esta.
 
+      - name: taskf_teste2_55
+        description: >
+          As quatro células como a #55 as mediu (execução de 12/08 19:55–20:05, commit b535130),
+          copiadas ANTES de a #58 dropar a acumulativa para acrescentar a coluna `universo`. Não
+          tem essa coluna, e é a única diferença de schema — o que ela contém equivale ao universo
+          `completo` de hoje, que é contra o que a re-medição a compara.
+
+          Mesmo papel e mesmas regras da taskf_teste2_54 acima: registro histórico, não se escreve
+          nela, e a próxima mudança de schema cria a sua própria cópia com o número do ticket.
+
       - name: taskf_teste2
         description: >
-          A saída do Teste 2 da medição, uma linha por (célula, mercado, premissa, benchmark).
+          A saída do Teste 2 da medição, uma linha por (célula, UNIVERSO, mercado, premissa,
+          benchmark).
           Acumulativa: cada execução de analyses/taskf_teste2.sql substitui SÓ a sua célula
-          (DELETE + INSERT), e as quatro convivem — é sobre esta tabela que a Costura B (#55)
-          verifica as três invariantes. Também não é modelo, pelo mesmo motivo dos baselines
+          (DELETE + INSERT), com os quatro universos dentro dela, e as quatro células convivem —
+          é sobre esta tabela que a Costura B (#55) verifica as suas invariantes. Também não é modelo, pelo mesmo motivo dos baselines
           acima: o destino está escrito no SQL e fixo em futebol_taskF, então um `dbt build`
           distraído não tem como publicá-la no dataset do board.
         columns:
@@ -590,7 +601,19 @@ sources:
             description: "O eixo de escopo que produziu a linha (da_competicao | todas)"
           - name: pit_recorte
             description: "O eixo de recorte que produziu a linha (temporada | ultimos_10)"
-          - name: medido_em
+          - name: universo
+            description: >
+              QUAIS JOGOS entram na conta desta linha (#58): completo | sem_copa_mundo |
+              estendido | estendido_sem_champions_classif. É um eixo ORTOGONAL à célula — a célula
+              diz qual HISTÓRICO cada jogo carrega, o universo diz quais jogos são medidos —, e
+              não tem relação nenhuma com `janela`, que neste repositório é a janela de coleta de
+              odds. Os quatro universos de uma célula saem do MESMO INSERT, para que a diferença
+              entre dois deles não carregue uma reconstrução dos modelos dentro de si. Definições
+              e predicados em macros/taskf_universos.sql.
+
+              ⚠️ TODO consumidor precisa recortar o universo. Sem o filtro, cada premissa aparece
+              quatro vezes e `jogos_no_universo` tem quatro valores. O default de quem lê é
+              `completo`, que é o universo congelado da [0.1] e o primário da medição.
             description: >
               Quando a célula foi materializada. Existe porque a spec exige que as quatro rodem na
               MESMA execução — `linha_subindo`/`linha_descendo` leem odds ao vivo e viram sozinhas

--- a/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+++ b/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
@@ -8,6 +8,12 @@
 -- células não têm como significar coisa alguma. É a única das três invariantes que compara a
 -- medição contra algo de FORA dela.
 --
+-- ⚠️ E É `base` NO UNIVERSO `completo` (#58). Esta é a única das quatro guardas que NÃO se
+-- generaliza para os outros universos, e a razão não é economia: o lado esquerdo da comparação são
+-- os números PUBLICADOS da [0.1], que existem para um recorte só — os 169 jogos de 16/06 a 04/08.
+-- Não há [0.1] "sem Copa do Mundo" nem [0.1] estendida contra a qual reproduzir. Cobrar os outros
+-- universos aqui seria compará-los com o gabarito errado.
+--
 -- ⚠️ ESTA GUARDA NÃO SUBSTITUI A `analyses/taskf_reconciliacao_01.sql`, e as duas não são cópia
 -- uma da outra. A reconciliação EXPLICA a divergência: mede se o mecanismo de deriva de odds
 -- existe na janela (`capturas_apos_o_teto`), se a correção da spec #22 alcança o benchmark
@@ -124,6 +130,7 @@ medido AS (
         {%- endfor %}
     FROM {{ source('futebol_taskF', 'taskf_teste2') }}
     WHERE celula = 'base'
+      AND universo = 'completo'
       AND usado_para_peso
 ),
 

--- a/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
+++ b/dbt_futebol/tests/assert_taskf_celulas_mesmo_universo.sql
@@ -8,20 +8,29 @@
 -- de valor entre builds, e nada no número denuncia. Até a #54 isso era disciplina de execução
 -- (a receita do analyses/taskf_teste2.sql); aqui vira cobrança.
 --
--- O QUE É COBRADO, em quatro blocos, e cada um tem um modo de falha próprio:
+-- ⚠️ O GRÃO DA COBRANÇA É (UNIVERSO × CÉLULA) DESDE A #58. A tabela ganhou uma coluna de
+-- universo — quais JOGOS entram na conta —, ortogonal à célula, que diz qual HISTÓRICO cada jogo
+-- carrega. A invariante não é "a tabela inteira tem o mesmo universo": os universos têm contagens
+-- diferentes DE PROPÓSITO, e é justamente essa diferença que a #58 mede. O que continua valendo,
+-- e é o que sustenta toda comparação entre células, é que DENTRO de cada universo as quatro
+-- células meçam os mesmos jogos. Ver macros/taskf_universos.sql.
 --
---   celulas_faltando     as quatro células existem, com os nomes que taskf_nomes_de_celula()
---                        define. É também a guarda de NÃO-VACUIDADE de tudo o que vem abaixo:
---                        uma comparação "todas iguais" sobre uma tabela com uma célula só passa
---                        em branco, e é exatamente esse o estado da tabela no meio de uma
---                        medição interrompida.
+-- O QUE É COBRADO, em cinco blocos, e cada um tem um modo de falha próprio:
+--
+--   celulas_faltando     as quatro células existem EM CADA UNIVERSO, com os nomes que
+--                        taskf_nomes_de_celula() define. É também a guarda de NÃO-VACUIDADE de
+--                        tudo o que vem abaixo: uma comparação "todas iguais" sobre uma tabela
+--                        com uma célula só passa em branco, e é exatamente esse o estado da
+--                        tabela no meio de uma medição interrompida.
 --   rotulo_nao_casa_...  e o nome de cada célula casa com o par de eixos gravado ao lado dele.
---   universo_divergente  jogos, linhas e as duas pontas do corte idênticos nas quatro.
---   jogos_fora_do_gabarito  e os jogos são os 169 que o universo congelado declara
---                        (taskf_universo().jogos_esperados). Sem isto, quatro células medidas
+--   universo_divergente  jogos, linhas e as duas pontas do corte idênticos nas quatro células
+--                        DAQUELE universo.
+--   jogos_fora_do_gabarito  e os jogos são os que o universo declara, nos universos que declaram
+--                        um número (macros/taskf_universos.sql: os dois congelados têm gabarito,
+--                        os dois estendidos não — ver o bloco). Sem isto, quatro células medidas
 --                        sobre o mesmo universo ERRADO passariam juntas.
---   execucao_divergente  as quatro leram a MESMA construção dos fatos, leram ANTES de medir, e
---                        saíram do MESMO commit (com procedência declarada).
+--   execucao_divergente  todas as linhas da tabela leram a MESMA construção dos fatos, leram
+--                        ANTES de medir, e saíram do MESMO commit (com procedência declarada).
 --
 -- ⚠️ AS QUATRO CÉLULAS NÃO PRECISAM TER O MESMO NÚMERO DE LINHAS DE PREMISSA, e por isso isso não
 -- é cobrado. Uma premissa entra na tabela quando acende pelo menos uma vez (`HAVING
@@ -58,11 +67,14 @@
 
 {% set j = taskf_universo() %}
 {% set nomes = taskf_nomes_de_celula().values() | list %}
--- Os 169 jogos e os quatro nomes de célula acima saem de macro (macros/taskf_universo.sql e
--- macros/taskf_celula.sql): esta guarda não tem número nem rótulo digitado.
+{% set universos = taskf_universos() %}
+-- Os jogos esperados e os quatro nomes de célula acima saem de macro (macros/taskf_universo.sql,
+-- macros/taskf_universos.sql e macros/taskf_celula.sql): esta guarda não tem número nem rótulo
+-- digitado.
 
 WITH celulas AS (
     SELECT
+        universo,
         celula,
         ANY_VALUE(jogos_no_universo)  AS jogos_no_universo,
         ANY_VALUE(linhas_no_universo) AS linhas_no_universo,
@@ -86,26 +98,38 @@ WITH celulas AS (
             jogos_no_universo, linhas_no_universo,
             janela_ini, janela_fim, odds_loaded_at, git_sha))) AS versoes_na_celula
     FROM {{ source('futebol_taskF', 'taskf_teste2') }}
-    GROUP BY celula
+    GROUP BY universo, celula
 ),
 
+-- O produto (universo × célula) é o grão da cobrança desde a #58: cada universo tem de ter as
+-- quatro células, e cada universo é conferido DENTRO de si. Cobrar sobre a tabela inteira daria
+-- vermelho permanente pelo motivo errado — os universos têm contagens de jogos diferentes de
+-- propósito, é exatamente essa diferença que a #58 mede.
 esperadas AS (
-    SELECT nome FROM UNNEST({{ nomes | tojson }}) AS nome
+    SELECT universo, nome
+    FROM UNNEST({{ universos | map(attribute='nome') | list | tojson }}) AS universo
+    CROSS JOIN UNNEST({{ nomes | tojson }}) AS nome
 ),
 
--- 1. AS QUATRO EXISTEM. Nos dois sentidos: célula que falta e célula com nome que o 2×2 não
---    define (que só aparece se alguém escrever na tabela por fora do taskf_celula()).
+-- 1. AS QUATRO EXISTEM, EM CADA UNIVERSO. Nos dois sentidos: par que falta e célula com nome que
+--    o 2×2 não define (que só aparece se alguém escrever na tabela por fora do taskf_celula()).
+--    Também pega universo que sumiu — um `--vars` que não passasse pela lista de macros/
+--    taskf_universos.sql deixaria a tabela com três dos quatro, e "não medimos esse" se parece
+--    demais com "esse deu igual".
 presenca AS (
     SELECT
         'celulas_faltando' AS motivo,
         TO_JSON_STRING(STRUCT(
+            e.universo                                          AS universo_esperado,
+            c.universo                                          AS universo_encontrado,
             e.nome                                              AS celula_esperada,
             c.celula                                            AS celula_encontrada,
-            (SELECT COUNT(*) FROM celulas)                      AS celulas_na_tabela,
-            {{ nomes | length }}                                AS celulas_esperadas
+            (SELECT COUNT(*) FROM celulas)                      AS pares_na_tabela,
+            {{ (nomes | length) * (universos | length) }}       AS pares_esperados
         )) AS linha
     FROM esperadas AS e
-    FULL OUTER JOIN celulas AS c ON c.celula = e.nome
+    FULL OUTER JOIN celulas AS c
+      ON c.celula = e.nome AND c.universo = e.universo
     WHERE e.nome IS NULL OR c.celula IS NULL
 ),
 
@@ -130,16 +154,20 @@ rotulos AS (
     END
 ),
 
--- 2. O MESMO UNIVERSO. Comparação contra a primeira célula em ordem alfabética — um par por
---    célula divergente, e não um produto cartesiano de reclamações sobre a mesma diferença.
+-- 2. O MESMO UNIVERSO — DENTRO DE CADA UNIVERSO. Comparação contra a primeira célula em ordem
+--    alfabética DAQUELE universo: um par por célula divergente, e não um produto cartesiano de
+--    reclamações sobre a mesma diferença. Entre universos diferentes a contagem DEVE divergir, e
+--    é por isso que a referência é por universo e não uma linha só da tabela.
 referencia AS (
-    SELECT * FROM celulas ORDER BY celula LIMIT 1
+    SELECT * FROM celulas
+    QUALIFY ROW_NUMBER() OVER (PARTITION BY universo ORDER BY celula) = 1
 ),
 
 universo AS (
     SELECT
         'universo_divergente' AS motivo,
         TO_JSON_STRING(STRUCT(
+            c.universo,
             c.celula, r.celula AS referencia,
             c.jogos_no_universo,  r.jogos_no_universo  AS jogos_ref,
             c.linhas_no_universo, r.linhas_no_universo AS linhas_ref,
@@ -148,7 +176,7 @@ universo AS (
             c.versoes_na_celula
         )) AS linha
     FROM celulas AS c
-    CROSS JOIN referencia AS r
+    JOIN referencia AS r ON r.universo = c.universo
     WHERE c.jogos_no_universo  IS DISTINCT FROM r.jogos_no_universo
        OR c.linhas_no_universo IS DISTINCT FROM r.linhas_no_universo
        OR c.janela_ini         IS DISTINCT FROM r.janela_ini
@@ -156,17 +184,30 @@ universo AS (
        OR c.versoes_na_celula  <> 1
 ),
 
--- 3. E É O UNIVERSO DECLARADO. `jogos_esperados` mora em macros/taskf_universo.sql, junto do
---    predicado que produz o recorte — as duas pontas não têm como divergir.
+-- 3. E É O UNIVERSO DECLARADO — onde há número a declarar. `jogos_esperados` mora em
+--    macros/taskf_universos.sql, junto do predicado que produz cada recorte, e as duas pontas não
+--    têm como divergir.
+--
+--    ⚠️ Só os DOIS UNIVERSOS CONGELADOS têm gabarito; os estendidos entram na lista com `none` e
+--    ficam de fora deste bloco. Não é lacuna: eles crescem legitimamente a cada construção dos
+--    fatos, e um número aqui viraria cobrança a atualizar toda execução — a espécie de guarda que
+--    só ensina a ignorar guarda. O que vale para os quatro é o bloco 2 (as células concordarem
+--    entre si dentro do universo), e ele não depende de gabarito nenhum.
 gabarito AS (
     SELECT
         'jogos_fora_do_gabarito' AS motivo,
         TO_JSON_STRING(STRUCT(
-            celula, jogos_no_universo, {{ j.jogos_esperados }} AS jogos_esperados,
+            c.universo, c.celula, c.jogos_no_universo, g.jogos_esperados,
             '{{ j.ini }}' AS universo_ini, '{{ j.teto_utc }}' AS universo_teto_utc
         )) AS linha
-    FROM celulas
-    WHERE jogos_no_universo IS DISTINCT FROM {{ j.jogos_esperados }}
+    FROM celulas AS c
+    JOIN (
+        {%- for u in universos if u.jogos_esperados is not none %}
+        SELECT '{{ u.nome }}' AS universo, {{ u.jogos_esperados }} AS jogos_esperados
+        {{ "UNION ALL" if not loop.last }}
+        {%- endfor %}
+    ) AS g ON g.universo = c.universo
+    WHERE c.jogos_no_universo IS DISTINCT FROM g.jogos_esperados
 ),
 
 -- 4. A MESMA EXECUÇÃO, em TRÊS pontas: mesma construção dos fatos nas quatro, fatos construídos
@@ -190,10 +231,19 @@ gabarito AS (
 --    em 7.200 mudando entre duas medições sobre os mesmos fatos, todos empates de arredondamento
 --    do `AVG`. Nenhuma guarda distingue esse empate de um efeito real de 0,1 — quem quiser a
 --    diferença mede com `analyses/taskf_remedicao.sql`, que é onde ela é visível.
+-- A referência aqui é UMA linha da tabela inteira, e não uma por universo: os quatro universos de
+-- uma célula saem do MESMO INSERT (compartilham `medido_em`, `git_sha` e `odds_loaded_at` por
+-- construção), então "mesma execução" é uma afirmação sobre a tabela toda. Uma referência por
+-- universo deixaria passar quatro medições feitas em quatro dias, cada uma internamente coerente.
+referencia_global AS (
+    SELECT * FROM celulas ORDER BY universo, celula LIMIT 1
+),
+
 execucao AS (
     SELECT
         'execucao_divergente' AS motivo,
         TO_JSON_STRING(STRUCT(
+            c.universo,
             c.celula, r.celula AS referencia,
             c.odds_loaded_at, r.odds_loaded_at AS odds_loaded_at_ref,
             c.medido_em, c.git_sha, r.git_sha AS git_sha_ref,
@@ -203,7 +253,7 @@ execucao AS (
             c.git_sha = 'desconhecido'                          AS sem_procedencia
         )) AS linha
     FROM celulas AS c
-    CROSS JOIN referencia AS r
+    CROSS JOIN referencia_global AS r
     WHERE c.odds_loaded_at IS DISTINCT FROM r.odds_loaded_at
        OR c.odds_loaded_at IS NULL
        OR NOT (c.odds_loaded_at < c.medido_em)

--- a/dbt_futebol/tests/assert_taskf_contagens_por_recorte.sql
+++ b/dbt_futebol/tests/assert_taskf_contagens_por_recorte.sql
@@ -26,6 +26,12 @@
 -- médias sairiam iguais, legitimamente. Cobrar 60/60 seria congelar o dado de hoje como se fosse
 -- regra — o mesmo erro que esta task existe para não cometer.
 --
+-- ⚠️ A COBRANÇA É POR (UNIVERSO × CÉLULA) DESDE A #58. O comportamento das duas contagens é
+-- propriedade do RECORTE da célula e vale em qualquer universo, então generalizar custou uma
+-- coluna no GROUP BY e multiplicou por quatro o que é conferido. E fechou um buraco: cobrada só
+-- sobre a tabela inteira, a ponta `ultimos_10_sem_teto` ficaria verde por uma célula com teto num
+-- universo só, mesmo que nos outros três o carimbo tivesse rodado fora de ordem.
+--
 -- ⚠️ NÃO É A MESMA CONFERÊNCIA DA `analyses/taskf_saturacao_recorte.sql`, e as duas não se
 -- substituem. Aquela mede a identidade `usado = LEAST(disponível, 10)` PAR A PAR, nos 21.054
 -- pares de (jogo, time) do carimbo do PIT; esta cobra o comportamento das duas colunas na tabela
@@ -40,13 +46,14 @@
 
 WITH por_celula AS (
     SELECT
+        universo,
         celula,
         ANY_VALUE(pit_recorte) AS pit_recorte,
         COUNT(*)               AS linhas,
         COUNTIF(jogos_medios_disp IS DISTINCT FROM jogos_medios_usado) AS linhas_com_teto,
         COUNT(DISTINCT pit_recorte) AS recortes_na_celula
     FROM {{ source('futebol_taskF', 'taskf_teste2') }}
-    GROUP BY celula
+    GROUP BY universo, celula
 ),
 
 divergencias AS (
@@ -57,7 +64,7 @@ divergencias AS (
             ELSE                                 'recorte_desconhecido'
         END AS motivo,
         TO_JSON_STRING(STRUCT(
-            celula, pit_recorte, linhas, linhas_com_teto, recortes_na_celula
+            universo, celula, pit_recorte, linhas, linhas_com_teto, recortes_na_celula
         )) AS linha
     FROM por_celula
     WHERE (pit_recorte = 'temporada'  AND linhas_com_teto > 0)
@@ -73,11 +80,11 @@ detalhe AS (
     SELECT
         'temporada_com_teto_detalhe' AS motivo,
         TO_JSON_STRING(STRUCT(
-            t.celula, t.mercado, t.premissa, t.benchmark,
+            t.universo, t.celula, t.mercado, t.premissa, t.benchmark,
             t.jogos_medios_disp, t.jogos_medios_usado
         )) AS linha
     FROM {{ source('futebol_taskF', 'taskf_teste2') }} AS t
-    JOIN por_celula AS c USING (celula)
+    JOIN por_celula AS c USING (universo, celula)
     WHERE c.pit_recorte = 'temporada'
       AND t.jogos_medios_disp IS DISTINCT FROM t.jogos_medios_usado
 )

--- a/dbt_futebol/tests/assert_taskf_premissas_de_tabela_identicas.sql
+++ b/dbt_futebol/tests/assert_taskf_premissas_de_tabela_identicas.sql
@@ -12,6 +12,12 @@
 -- Falha = ou o eixo de escopo alcançou uma premissa que a ADR diz que ele não alcança, ou a
 -- célula foi gravada com o rótulo de outra. As duas são graves e nenhuma se vê no número.
 --
+-- ⚠️ A COBRANÇA É DENTRO DE CADA UNIVERSO (#58). A identidade que a ADR 0008 promete é entre
+-- CÉLULAS — o histórico que cada jogo carrega. Entre UNIVERSOS as três mudam de propósito, porque
+-- são outros jogos sendo medidos, e cobrar identidade lá daria vermelho em cima justamente do
+-- efeito que a #58 existe para medir. Generalizada assim, a guarda ficou mais forte e não mais
+-- fraca: são quatro vezes mais comparações, uma por universo.
+--
 -- ────────────────────────────────────────────────────────────────────────────────
 -- SÃO TRÊS PREMISSAS, E A IDENTIDADE É NO PISO 0. As duas coisas divergem do enunciado literal
 -- do critério de aceite da #55, que fala em quatro premissas sem qualificar o piso — e as duas
@@ -70,7 +76,7 @@
 
 WITH medido AS (
     SELECT
-        celula, mercado, premissa, benchmark, usado_para_peso,
+        universo, celula, mercado, premissa, benchmark, usado_para_peso,
         {{ campos | join(', ') }}
     FROM {{ source('futebol_taskF', 'taskf_teste2') }}
     WHERE premissa IN ({{ premissas_de_tabela | map('tojson') | join(', ') }})
@@ -79,6 +85,11 @@ WITH medido AS (
 -- A referência é a célula base do 2×2 quando ela existe (é a que não muda nada); na falta dela, a
 -- primeira em ordem alfabética, para a guarda não passar em branco por causa da ausência. O nome
 -- vem de taskf_nomes_de_celula(), como em toda parte: rótulo de célula não se digita.
+--
+-- ⚠️ UMA REFERÊNCIA POR UNIVERSO (#58). A identidade que a ADR 0008 promete é entre CÉLULAS, e ela
+-- vale dentro de cada universo pela mesma construção: as premissas de tabela leem o agregado
+-- competição-scoped do PIT, que não segue os eixos. Entre universos elas MUDAM de propósito — são
+-- outros jogos —, então uma referência global daria vermelho em cima do efeito que a #58 mede.
 referencia AS (
     SELECT * FROM medido
     -- `WHERE TRUE` não é enfeite: o BigQuery só aceita QUALIFY quando há WHERE, GROUP BY ou
@@ -86,7 +97,7 @@ referencia AS (
     -- várias linhas adiante.
     WHERE TRUE
     QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY mercado, premissa, benchmark
+        PARTITION BY universo, mercado, premissa, benchmark
         ORDER BY IF(celula = '{{ taskf_nomes_de_celula()['da_competicao|temporada'] }}', 0, 1), celula
     ) = 1
 ),
@@ -95,6 +106,7 @@ divergencias AS (
     SELECT
         'numero_divergente' AS motivo,
         TO_JSON_STRING(STRUCT(
+            m.universo,
             m.mercado, m.premissa, m.benchmark, m.usado_para_peso,
             m.celula, r.celula AS referencia,
             {%- for campo in campos %}
@@ -103,7 +115,8 @@ divergencias AS (
         )) AS linha
     FROM medido AS m
     JOIN referencia AS r
-      ON  r.mercado   = m.mercado
+      ON  r.universo  = m.universo
+      AND r.mercado   = m.mercado
       AND r.premissa  = m.premissa
       AND r.benchmark = m.benchmark
     WHERE {% for campo in campos -%}
@@ -125,9 +138,12 @@ ausentes AS (
     WHERE NOT EXISTS (SELECT 1 FROM medido WHERE premissa = p)
 ),
 
--- NÃO-VACUIDADE 2: cada linha de grão existe nas quatro células. Compara-se contra a contagem de
--- células que a tabela de fato tem (que a invariante 1 cobra ser 4), e não contra um 4 digitado:
--- as duas guardas ficam com um dono cada, e esta não repete a cobrança da outra com número solto.
+-- NÃO-VACUIDADE 2: cada linha de grão existe nas quatro células DO SEU UNIVERSO. Compara-se contra
+-- a contagem de células que a tabela de fato tem (que a invariante 1 cobra ser 4), e não contra um
+-- 4 digitado: as duas guardas ficam com um dono cada, e esta não repete a cobrança da outra com
+-- número solto. Uma premissa que não acenda nenhuma vez num universo simplesmente não tem grão
+-- ali, e isso não é cobrado aqui — o `HAVING COUNTIF(acesa) > 0` do Teste 2 é resultado, não
+-- defeito; o que este bloco pega é a premissa existir em UMAS células do universo e não em todas.
 celulas_na_tabela AS (
     SELECT COUNT(DISTINCT celula) AS n FROM {{ source('futebol_taskF', 'taskf_teste2') }}
 ),
@@ -136,17 +152,17 @@ grao_incompleto AS (
     SELECT
         'grao_incompleto' AS motivo,
         TO_JSON_STRING(STRUCT(
-            g.mercado, g.premissa, g.benchmark,
+            g.universo, g.mercado, g.premissa, g.benchmark,
             g.celulas_com_a_linha, t.n AS celulas_na_tabela,
             g.quais_celulas
         )) AS linha
     FROM (
         SELECT
-            mercado, premissa, benchmark,
+            universo, mercado, premissa, benchmark,
             COUNT(DISTINCT celula) AS celulas_com_a_linha,
             STRING_AGG(DISTINCT celula, ', ' ORDER BY celula) AS quais_celulas
         FROM medido
-        GROUP BY mercado, premissa, benchmark
+        GROUP BY universo, mercado, premissa, benchmark
     ) AS g
     CROSS JOIN celulas_na_tabela AS t
     WHERE g.celulas_com_a_linha <> t.n

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -2084,12 +2084,16 @@ UTC porque é até ali que vai o `fact_odds_snapshot` que as quatro células ler
 a única coisa que faz a comparação entre células significar algo. O universo é, por construção, "o
 que os fatos contêm" — e o `janela_fim` na linha diz até onde ele foi.
 
-| competição | jogos | % | · | competição | jogos | % |
-|---|---|---|---|---|---|---|
-| copa_mundo | 79 | **34,6%** | · | sudamericana | 17 | 7,5% |
-| serie_b | 49 | 21,5% | · | copa_do_brasil | 16 | 7,0% |
-| brasileirao | 38 | 16,7% | · | primeira_liga | 9 | 3,9% |
-| champions_league | 18 | 7,9% | · | libertadores | 2 | 0,9% |
+| competição | jogos | % do estendido |
+|---|---|---|
+| copa_mundo | 79 | **34,6%** |
+| serie_b | 49 | 21,5% |
+| brasileirao | 38 | 16,7% |
+| champions_league | 18 | **7,9%** |
+| sudamericana | 17 | 7,5% |
+| copa_do_brasil | 16 | 7,0% |
+| primeira_liga | 9 | 3,9% |
+| libertadores | 2 | 0,9% |
 
 **Ele acrescenta pouco, e o pouco é mensurável.** A spec estimava "~37 jogos"; foram **59** — a
 estimativa envelheceu, e o número medido é o que vale. Mas o efeito que se poderia esperar dele

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1963,6 +1963,9 @@ que a troca é, medido: **uma permuta adjacente na fronteira do top 5** —
 | `completo` | `clean_sheets_altos` (peso 4,36) | `defesas_firmes` (3,32) |
 | `sem_copa_mundo` | `defesas_firmes` (3,84) | `clean_sheets_altos` (3,18) |
 
+(bloco `topo` da mesma análise — ele emite posição e peso dos dois lados de quem entra ou sai,
+justamente para que "2 trocas no topo" não fique sendo um número sem conteúdo.)
+
 O veredito não é suavizado: a régua caiu **em cima** do corte, e amaciar um MATERIAL depois de
 vê-lo é exatamente o pós-hoc que o cabeçalho da análise proíbe. O que sustenta a recomendação
 apesar dele são as outras duas pernas, que a própria régua fornece: a referência de eixo (0,648
@@ -1970,6 +1973,11 @@ contra 0,992) e o mecanismo dos 2 jogos em 79. **Se alguém quiser litigar essa 
 declarado é o universo de placebo — remover 79 jogos sorteados por hash e comparar a exclusão real
 contra a distribuição do placebo. Ele continua não tendo sido rodado, e continua sendo a única
 coisa que mudaria a leitura desta linha.
+
+**De passagem, a mesma tabela mostra que a Copa do Mundo jogou 88 e não 79.** Nove partidas
+encerradas dela ficam fora do universo: oito por status (5 PEN e 3 AET — mata-mata decidido fora
+do tempo normal, o caso da issue #71) e **uma** por não ter preço coletado, na primeira rodada de
+grupos. O deserto de histórico dela, portanto, é medido sobre 79 dos 88 jogos que aconteceram.
 
 ⚠️ **E a exclusão não é aleatória no tempo.** Tirar a Copa do Mundo não tira 47% dos jogos
 espalhados pela janela: tira **os primeiros 24 dias dela**. O universo `sem_copa_mundo` começa em
@@ -2035,19 +2043,34 @@ princípio também é real e fica declarada: a qualificatória traz clubes de li
 coletamos**, e por isso o adversário deles é invisível — se uma janela futura tiver a Champions com
 peso maior que 7,9%, a pergunta se re-mede, e o par de universos já está construído para isso.
 
-⚠️ **7,9% e não 22% — as duas contas não medem a mesma coisa.** A spec #49 atribui à fase
-classificatória "22% da janela". A diferença tem mecanismo, não é erro de ninguém: a spec contou
-**fixtures** do calendário, e o universo de medição exige **preço coletado**. A coleta de odds da
-UCL entrou no ar em **31/07** (rollout da liga 2), então as 56 partidas de Q1 e Q2, de julho,
-existem no `fact_fixtures` e não existem em `apostas` — que é também a razão de a Champions ter
-zero jogo no universo congelado. É o mesmo tipo de reconciliação do "69 contra 67" da #53: nenhum
-dos dois números está errado, eles contam populações diferentes.
+⚠️ **7,9% e não 22% — e a conta inteira sai de uma tabela.** A spec #49 atribui à fase
+classificatória "22% da janela". A diferença tem mecanismo, não é erro de ninguém, e o bloco
+`fora_do_universo` a fecha partida a partida — ele lista as encerradas que o universo **não**
+alcança, por fase e por status:
 
-⚠️ **18 de 20: os dois que faltam são AET.** A Q3 de 2026 tem 20 partidas encerradas com odds nos
-nossos dados; duas delas — as de 11/08 — terminaram na prorrogação. O `jogos_encerrados` do
-`task01_base()` filtra `status_short = 'FT'`, então AET e PEN não entram no universo. É o achado
-de passagem da #56, que virou a [issue #71](https://github.com/tech-lamjav/analytics-engineering/issues/71);
-aqui ele aparece com nome e sobrenome num conjunto de 20.
+| fase | status | partidas | com preço coletado | veredito |
+|---|---|---|---|---|
+| 1st Qualifying Round | FT | 27 | **0** | sem preço coletado |
+| 1st Qualifying Round | AET | 1 | **0** | sem preço coletado |
+| 2nd Qualifying Round | FT | 24 | **0** | sem preço coletado |
+| 2nd Qualifying Round | PEN | 3 | **0** | sem preço coletado |
+| 2nd Qualifying Round | AET | 1 | **0** | sem preço coletado |
+| 3rd Qualifying Round | AET | 2 | **2** | só o status |
+
+A temporada 2026 da Champions tem **76** partidas encerradas desde 16/06 (28 + 28 + 20); o
+universo mede **18**. As 56 de Q1 e Q2, de julho, não têm preço nenhum: a coleta de odds da UCL
+entrou no ar em **31/07** (rollout da liga 2), e ela é forward-only. É também a razão de a
+Champions ter zero jogo no universo congelado. A spec contou **fixtures**; o universo de medição
+exige **preço**. Mesmo tipo de reconciliação do "69 contra 67" da #53: nenhum dos dois números
+está errado, eles contam populações diferentes.
+
+⚠️ **E as duas últimas linhas da tabela são um segundo mecanismo, não o mesmo.** Os 2 jogos de Q3
+que ficaram de fora **têm** preço coletado: eles caem pelo `status_short = 'FT'` do
+`jogos_encerrados`, porque terminaram na prorrogação. É o achado de passagem da #56, que virou a
+[issue #71](https://github.com/tech-lamjav/analytics-engineering/issues/71) — aqui ele aparece com
+nome e sobrenome: **18 dos 20** jogos de Q3 entram, e os 2 que faltam são AET de 11/08. A coluna
+`com_preco` do bloco existe exatamente para separar as duas causas sem precisar de uma segunda
+consulta.
 
 ### ⚠️ A previsão da spec sobre `escopo` e a Champions virou medição
 
@@ -2152,6 +2175,21 @@ três últimas. As duas cobranças que esse argumento não alcança foram quebra
 
 As duas foram desfeitas e as quatro guardas voltaram ao verde; a tabela foi reconferida depois, e
 os 16 pares (universo × célula) devolvem exatamente os mesmos números de antes das quebras.
+
+### ⚠️ O que a revisão pegou, e que nenhuma guarda pegaria
+
+A revisão de standards encontrou um defeito que passou por `dbt parse`, por quatro guardas verdes
+e por uma medição inteira: a edição do `sources.yml` que documentou a coluna `universo` **comeu a
+linha `- name: medido_em`**, deixando duas chaves `description:` sob o mesmo item. Em YAML a
+última vence, então a coluna `universo` passou a ser documentada como *"Quando a célula foi
+materializada…"* e a descrição do universo sumiu.
+
+O dbt avisa (`DuplicateYAMLKeysDeprecation`) e **não** falha. É metadado de documentação, não
+muda número nenhum — mas é exatamente o tipo de erro que vive para sempre: o schema YAML não é
+lido por teste nenhum, e quem for consultar a coluna daqui a seis meses lê a descrição errada com
+cara de certa. Corrigido antes do merge, junto com a descrição de `jogos_no_universo`, que ainda
+dizia "universo congelado (169), idêntico nas quatro células" — verdade que a coluna deixou de
+ter quando ela passou a ser por universo.
 
 ### A re-medição reproduz a #55: 6 campos em 7.200
 

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1809,3 +1809,408 @@ argumento.
 
 ⚠️ `bq query` com o SQL como argumento trava nesta máquina; por redirecionamento ou heredoc,
 funciona. E sem `--max_rows` ele corta em 100 linhas sem avisar.
+
+---
+
+## Ticket #58 — As três respostas fechadas, e a Champions medida onde ela existe
+
+`analyses/taskf_exclusao.sql` + `taskf_sobrevivencia.sql` + `taskf_saturacao_recorte.sql` +
+`taskf_universo_congelado.sql` · execução 2026-08-13 17:49–18:13 UTC · **células** do commit
+`7fdd1a3`, **análises** do `f293962` · dataset `futebol_taskF`
+
+As três perguntas que a spec #49 cobra fechadas, mais a extensão que o grilling acrescentou. Duas
+delas — a da Copa do Mundo e a da Champions — são perguntas sobre **quais jogos entram na conta**,
+e não sobre o histórico que cada jogo carrega. Por isso o universo passou a ser um terceiro eixo da
+medição, e as quatro células foram re-medidas com ele.
+
+### Veredito
+
+**Nenhuma das duas exclusões se sustenta na medição.** A da Copa do Mundo é imaterial em três das
+quatro células no piso 5 e **idêntica** (ρ = 1,000) no piso 10; a da fase classificatória da
+Champions é **idêntica** no piso 5 e no 10 nas duas células que refletem produção. Nos dois casos o
+piso de amostra já faz o trabalho que a exclusão faria: dos 79 jogos de Copa do Mundo, **2** estão
+acima do piso 5; dos 18 de Champions, **zero** — em `base` e em `escopo`.
+
+Das quatro premissas de amostra curta, **duas sobrevivem** quando o histórico é real
+(`clean_sheets_altos` e `defesa_forte`) e duas continuam sem evidência (`superioridade_xg` e
+`tende_golear`).
+
+E o eixo que a [F] mede continua sendo muito maior que as duas exclusões juntas: no piso 5, soltar
+a competição move a ordenação para ρ = 0,648, enquanto a maior das exclusões a move para 0,964.
+
+### O universo é um terceiro eixo — e não uma quinta célula
+
+| | o que varia | onde mora |
+|---|---|---|
+| **célula** | qual HISTÓRICO cada jogo carrega | `macros/taskf_celula.sql` (escopo × recorte) |
+| **universo** | quais JOGOS são medidos | `macros/taskf_universos.sql` (#58) |
+| **janela** | qual coleta de ODDS foi lida | glossário do `CONTEXT.md` — nada a ver com a [F] |
+
+Os quatro universos de uma célula saem do **mesmo INSERT**. Se `completo` e `sem_copa_mundo`
+fossem duas execuções, a diferença entre elas carregaria uma reconstrução dos modelos dentro de si
+— e a #55 mediu que uma reconstrução move 5 campos em 7.200 sozinha. Como a comparação COM/SEM
+**é** o entregável, esse ruído entraria no lugar da resposta.
+
+| universo | jogos | linhas | janela | por que existe |
+|---|---|---|---|---|
+| `completo` | **169** | 8.567 | 16/06 → 04/08 | o congelado da [0.1], o primário |
+| `sem_copa_mundo` | **90** | 4.428 | **10/07** → 04/08 | o lado SEM da pergunta 7 da spec |
+| `estendido` | **228** | 11.554 | 16/06 → 12/08 | o secundário, e o único onde a Champions existe |
+| `estendido_sem_champions_classif` | **210** | 10.606 | 16/06 → 12/08 | o lado SEM da pergunta 24 |
+
+Os quatro carregam o mesmo `odds_loaded_at` (12/08 13:24:15) e o mesmo `git_sha` — conferido pela
+Costura B, que desde este ticket cobra por (universo × célula).
+
+### Resposta 1 — quantos jogos passam a satisfazer o piso de 5, célula a célula
+
+`analyses/taskf_saturacao_recorte.sql`, bloco `piso` · re-derivado nesta execução
+
+| piso | `base` | `escopo` | `recorte` | `ambos` |
+|---|---|---|---|---|
+| 0 | 169 | 169 | 169 | 169 |
+| 3 | 90 | **113** | 103 | **113** |
+| 5 | **69** | **92** | **81** | **92** |
+| 10 | 67 | 76 | 73 | **83** |
+
+Com o histórico junto, o piso 5 vai de **69 para 92 jogos** — 41% → 54% do universo — sem
+descartar nada. O eixo de escopo faz sozinho todo esse ganho; soltar só a temporada leva a 81, e
+soltar os dois não acrescenta nem um jogo ao que a competição já tinha aberto. A tabela reproduz a
+#54 e a #55 número a número, agora sobre células re-medidas com o eixo de universo dentro.
+
+⚠️ **Os 77 jogos que continuam abaixo do piso 5 na `base` são a Copa do Mundo inteira menos dois.**
+Isso não é leitura da tabela acima — é o bloco `excluido` do `taskf_exclusao.sql`: dos 79 jogos de
+Copa do Mundo, **2** têm `min_jogos` ≥ 5 em qualquer das quatro células, e o maior `min_jogos` do
+conjunto é **6**. É esse número que decide a resposta 3.
+
+### Resposta 2 — quais das quatro premissas sobrevivem quando o histórico é real
+
+`analyses/taskf_sobrevivencia.sql` · universo `completo`, piso 5
+
+A regra foi escrita antes de olhar: **sobrevive** quem tem `diferenca_p5` > 0 nas **duas** células
+de escopo solto (`escopo` e `ambos`) com n ≥ 25 nas duas. As duas células, e não uma, porque uma
+premissa que só melhora sob `ambos` melhora quando os dois eixos se soltam — e aí não dá para
+dizer qual deles a salvou, que é a pergunta 9 da spec. O n = 25 é o ponto em que o encolhimento
+`n/(n+50)` do próprio Teste 2 passa de 1/3; ele sai da constante que já existe, não de uma régua
+nova.
+
+| premissa | `base` | `escopo` | `recorte` | `ambos` | veredito |
+|---|---|---|---|---|---|
+| `clean_sheets_altos` | −1,7 (24) | **+6,3** (35) | +7,8 (63) | **+30,0** (34) | **SOBREVIVE** |
+| `defesa_forte` | −3,3 (12) | **+10,3** (28) | +5,7 (29) | **+15,1** (25) | **SOBREVIVE** |
+| `superioridade_xg` | −8,9 (31) | −4,1 (44) | +1,7 (45) | −5,6 (60) | SEM EVIDÊNCIA |
+| `tende_golear` | −18,5 (18) | −22,7 (21) | −20,3 (49) | +2,0 (52) | SEM EVIDÊNCIA |
+
+E a amostra curta delas, de `base` para as três outras células: `clean_sheets_altos` 77,1% →
+62,4% / 49,6% / 63,0%; `defesa_forte` 82,9% → 60,6% / 62,3% / 63,2%; `superioridade_xg` 71,6% →
+61,1% / 61,5% / 53,5%; `tende_golear` 88,3% → 83,6% / 70,7% / **67,3%**.
+
+As duas que caem, caem por motivos diferentes: `superioridade_xg` é **negativa nas duas** células
+de escopo solto (o sinal não aparece, ele some), e `tende_golear` é positiva **só em `ambos`**
+(+2,0), depois de −22,7 em `escopo` — exatamente o caso que a regra das duas células existe para
+não deixar passar.
+
+⚠️ **`defesa_forte` passa com n = 25 exatamente na `ambos`** — em cima da borda da régua. Uma linha
+a menos e ela sairia com ressalva. Fica dito porque a borda é da regra deste documento, não do
+dado.
+
+**A régua discrimina**: aplicada às 39 linhas do benchmark preferido, **10 sobrevivem** e 29 ficam
+sem evidência — nenhuma com ressalva. Se metade do catálogo "sobrevivesse", sobreviver não
+significaria nada. As dez: `adversario_limitado`, `clean_sheets_altos`, `defesa_forte`,
+`defesas_firmes`, `defesas_vazaveis` (BTTS), `favorito_irregular`, `historico_under`,
+`linha_descendo`, `raramente_perde_por_2`, `xg_baixo_combinado`.
+
+⚠️ Isto **não** é recomendação de peso, pelo mesmo motivo das seções anteriores: a [0.1] mediu que
+ganho in-sample não se replica out-of-sample (+10,0% virou −6,2%). "Sobrevive" quer dizer que a
+evidência que a [B] vai ler continua de pé quando o histórico deixa de ser artificialmente curto.
+
+### Resposta 3 — a Copa do Mundo, medida com e sem
+
+`analyses/taskf_exclusao.sql` · `completo` × `sem_copa_mundo`
+
+**A régua foi declarada antes de medir**, no cabeçalho da análise: a exclusão é MATERIAL num
+(célula, piso) quando `rho < 0,90` **ou** `trocas_no_topo ≥ 2` **ou** `trocas_de_sinal ≥ 4`. E
+junto vem o **contraste de referência** — as mesmas três métricas para `base` → `escopo` dentro do
+universo COM —, porque um ρ de 0,93 não diz nada sozinho: a referência é o efeito que a [F] existe
+para medir.
+
+| contraste | piso 0 | piso 3 | piso 5 | piso 10 |
+|---|---|---|---|---|
+| exclusão na `base` | 0,753 · MAT | 0,555 · MAT | **0,964 · IMAT** | **1,000 · IMAT** |
+| exclusão na `escopo` | 0,563 · MAT | 0,618 · MAT | **0,982 · IMAT** | **1,000 · IMAT** |
+| exclusão na `recorte` | 0,806 · MAT | 0,830 · MAT | **0,992 · MAT** | **1,000 · IMAT** |
+| exclusão na `ambos` | 0,858 · MAT | 0,884 · MAT | **0,986 · IMAT** | **1,000 · IMAT** |
+| **referência** `base`→`escopo` | 0,813 · MAT | 0,747 · MAT | **0,648 · MAT** | 0,644 · MAT |
+
+A leitura é uma linha: **a exclusão decide muito no piso 0 e 3, e não decide nada no piso 5 e 10 —
+onde o eixo que a task mede continua decidindo tudo.** No piso 3 da `base` a exclusão chega a mexer
+MAIS na ordenação (ρ = 0,555) do que o próprio eixo de escopo (0,747); no piso 5 a relação se
+inverte por completo (0,964 contra 0,648).
+
+**O mecanismo não é estatístico, é aritmético.** Dos 79 jogos removidos, **2** estão acima do piso
+5 e **nenhum** acima do piso 10 — `min_jogos` médio de 1,94 e máximo de 6. No piso 10 os dois
+universos são literalmente a mesma medição, e é por isso que ρ dá 1,000 exato com zero de
+diferença em todos os campos: não é uma correlação alta, é a mesma tabela. Excluir a Copa do Mundo
+e usar piso 5 fazem, em 77 dos 79 jogos, **o mesmo trabalho** — e o piso o faz sem precisar nomear
+competição nenhuma. Em número de jogos medidos, a exclusão custa 2 em cada célula: 69 → 67 na
+`base`, 92 → 90 na `escopo` e na `ambos`, 81 → 79 na `recorte`.
+
+⚠️ **A célula `recorte` sai MATERIAL no piso 5, e ela fica assim.** A régua disparou por uma das
+três pontas (`trocas_no_topo = 2`), com as outras duas limpas (ρ = 0,992, zero trocas de sinal). O
+que a troca é, medido: **uma permuta adjacente na fronteira do top 5** —
+
+| | 5º | 6º |
+|---|---|---|
+| `completo` | `clean_sheets_altos` (peso 4,36) | `defesas_firmes` (3,32) |
+| `sem_copa_mundo` | `defesas_firmes` (3,84) | `clean_sheets_altos` (3,18) |
+
+O veredito não é suavizado: a régua caiu **em cima** do corte, e amaciar um MATERIAL depois de
+vê-lo é exatamente o pós-hoc que o cabeçalho da análise proíbe. O que sustenta a recomendação
+apesar dele são as outras duas pernas, que a própria régua fornece: a referência de eixo (0,648
+contra 0,992) e o mecanismo dos 2 jogos em 79. **Se alguém quiser litigar essa célula**, o passo
+declarado é o universo de placebo — remover 79 jogos sorteados por hash e comparar a exclusão real
+contra a distribuição do placebo. Ele continua não tendo sido rodado, e continua sendo a única
+coisa que mudaria a leitura desta linha.
+
+⚠️ **E a exclusão não é aleatória no tempo.** Tirar a Copa do Mundo não tira 47% dos jogos
+espalhados pela janela: tira **os primeiros 24 dias dela**. O universo `sem_copa_mundo` começa em
+**10/07**, não em 16/06 — de 16/06 a 09/07 não há na base um único jogo que não seja de seleção.
+Quem for comparar as duas colunas em qualquer outro corte precisa saber que elas não cobrem o
+mesmo pedaço de calendário.
+
+**Recomendação: manter a Copa do Mundo na base de medição**, com uma condição explícita — que a
+[B] leia no piso 5 ou acima. É onde a exclusão não decide nada. Se a [B] optar por ler no piso 0 ou
+3, a exclusão passa a mudar a ordenação de forma material em todas as quatro células, e aí ela
+deve sair; mas nesse cenário a decisão que importa é **o piso**, não a competição. O argumento de
+princípio fica declarado como reserva, e ele é real: o deserto da Copa do Mundo não é acidente de
+amostra, as seleções não jogam outra coisa na nossa base, e a #53 mediu que o merge lhes empresta
+**exatamente zero** partida. Ele diz por que esses jogos são estruturalmente diferentes; o piso é o
+instrumento que já os remove.
+
+### Resposta 4 — a Champions, no único universo em que ela existe
+
+`analyses/taskf_exclusao.sql` · `estendido` × `estendido_sem_champions_classif`
+
+A #51 já tinha registrado que a Champions **não tem um jogo** no universo congelado. Ela existe no
+estendido: **18 jogos, 7,9% dos 228**.
+
+**Excluir a fase classificatória é, nesta janela, excluir a competição — e isso é medido.** O
+bloco `fases` devolve **uma única linha** de Champions no universo estendido:
+
+| competição · fase | jogos | removidos | período | veredito |
+|---|---|---|---|---|
+| `champions_league` · 3rd Qualifying Round | 18 | **18** | 04/08 → 11/08 | FASE_INTEIRA |
+
+Não há fase de liga na janela (ela começa em setembro), então o predicado de fase e o de competição
+selecionam o mesmo conjunto. O predicado continua escrito por **semântica de fase**, e não por
+competição, porque a coincidência é da janela e não da definição — e porque `'Play-offs'` (agosto,
+classificatória) e `'Knockout Round Play-offs'` (fevereiro, mata-mata) convivem no mesmo campo
+`round` nas temporadas 2024 e 2025. Casar o primeiro por igualdade, e não por `LIKE '%Play-off%'`,
+é o que impede a mesma consulta de mentir numa janela de fevereiro.
+
+| contraste | piso 0 | piso 3 | piso 5 | piso 10 |
+|---|---|---|---|---|
+| exclusão na `base` | 0,947 · MAT | 0,934 · MAT | **1,000 · IMAT** | **1,000 · IMAT** |
+| exclusão na `escopo` | 0,966 · MAT | 0,933 · MAT | **1,000 · IMAT** | **1,000 · IMAT** |
+| exclusão na `recorte` | 0,968 · MAT | 0,958 · MAT | 0,970 · MAT | 0,992 · MAT |
+| exclusão na `ambos` | 0,965 · MAT | 0,958 · MAT | **0,984 · IMAT** | 0,992 · MAT |
+| **referência** `base`→`escopo` | 0,790 · MAT | 0,745 · MAT | **0,696 · MAT** | 0,608 · MAT |
+
+Em `base` e em `escopo` o ρ de 1,000 no piso 5 tem a mesma origem do caso da Copa do Mundo no piso
+10: **nenhum** dos 18 jogos passa o piso ali, então os dois universos são a mesma medição. Nas duas
+células com recorte de contagem a exclusão mexe em alguma coisa — e mexe porque ali esses jogos
+**passam** a ter histórico:
+
+| célula | `min_jogos` médio dos 18 | máximo | acima do piso 3 | acima do piso 5 |
+|---|---|---|---|---|
+| `base` | 1,78 | 4 | 5 de 123 | **0 de 91** |
+| `escopo` | **1,78** | **4** | 5 de 150 | **0 de 124** |
+| `recorte` | 3,89 | 10 | 11 de 153 | 6 de 123 |
+| `ambos` | **5,44** | **15** | 13 de 165 | **8 de 139** |
+
+**Recomendação: manter a fase classificatória da Champions na base de medição.** Onde ela poderia
+importar — o piso que a [B] vai usar, nas células que refletem produção — a exclusão é literalmente
+sem efeito. E onde ela tem efeito (`recorte` e `ambos`), removê-la jogaria fora justamente os jogos
+que o merge acabou de resgatar, que é o oposto do que a [F] existe para fazer. A reserva de
+princípio também é real e fica declarada: a qualificatória traz clubes de ligas que **não
+coletamos**, e por isso o adversário deles é invisível — se uma janela futura tiver a Champions com
+peso maior que 7,9%, a pergunta se re-mede, e o par de universos já está construído para isso.
+
+⚠️ **7,9% e não 22% — as duas contas não medem a mesma coisa.** A spec #49 atribui à fase
+classificatória "22% da janela". A diferença tem mecanismo, não é erro de ninguém: a spec contou
+**fixtures** do calendário, e o universo de medição exige **preço coletado**. A coleta de odds da
+UCL entrou no ar em **31/07** (rollout da liga 2), então as 56 partidas de Q1 e Q2, de julho,
+existem no `fact_fixtures` e não existem em `apostas` — que é também a razão de a Champions ter
+zero jogo no universo congelado. É o mesmo tipo de reconciliação do "69 contra 67" da #53: nenhum
+dos dois números está errado, eles contam populações diferentes.
+
+⚠️ **18 de 20: os dois que faltam são AET.** A Q3 de 2026 tem 20 partidas encerradas com odds nos
+nossos dados; duas delas — as de 11/08 — terminaram na prorrogação. O `jogos_encerrados` do
+`task01_base()` filtra `status_short = 'FT'`, então AET e PEN não entram no universo. É o achado
+de passagem da #56, que virou a [issue #71](https://github.com/tech-lamjav/analytics-engineering/issues/71);
+aqui ele aparece com nome e sobrenome num conjunto de 20.
+
+### ⚠️ A previsão da spec sobre `escopo` e a Champions virou medição
+
+Este é o achado incidental mais forte do ticket.
+
+A spec #49 afirma, na seção "o que já se sabe antes de rodar", que **`escopo` não conserta a
+Champions na janela medida** — porque os rótulos de `season` se sucedem, e um jogo de
+qualificatória em agosto está sob a temporada nova enquanto o histórico doméstico daquele time
+ainda está sob a anterior. A #53 e a #54 registraram isso como **não verificável**: sem jogo de
+Champions no universo primário, não havia o que medir.
+
+No estendido, há. E a previsão se confirma **no número exato**: `base` e `escopo` dão o **mesmo**
+`min_jogos` médio para os 18 jogos — 1,78 —, o mesmo máximo — 4 — e os mesmos zero jogos acima do
+piso 5. Soltar a competição sem soltar a temporada não empresta **uma única partida** a esses
+times. Quem alcança o caso é `ambos`, que triplica a média (5,44) e leva 8 dos 18 acima do piso 5.
+
+⚠️ E a leitura que continua **não** podendo ser tirada daqui é "escopo sozinho nunca ajuda a
+Europa". Isto é específico da virada de temporada: em janeiro, um time de Bundesliga tem o
+campeonato nacional e a Champions sob o mesmo rótulo de `season`, e `escopo` junta os dois
+normalmente. A janela desta medição cai inteira na virada.
+
+### O universo estendido, reportado à parte
+
+`analyses/taskf_universo_congelado.sql`, variante `E_estendido`
+
+| variante | período | jogos | vs publicado |
+|---|---|---|---|
+| `C_universo_congelado` | 16/06 → 04/08 | 169 | 0 |
+| `E_estendido` | 16/06 → **12/08** | **228** | **+59** |
+
+⚠️ **O que limita o estendido não é uma data, é a construção dos fatos.** Ele alcança 12/08 00:30
+UTC porque é até ali que vai o `fact_odds_snapshot` que as quatro células leram (`odds_loaded_at`
+12/08 13:24:15). Rebuildar a ancestria para ele alcançar "hoje" custaria re-medir tudo e quebraria
+a única coisa que faz a comparação entre células significar algo. O universo é, por construção, "o
+que os fatos contêm" — e o `janela_fim` na linha diz até onde ele foi.
+
+| competição | jogos | % | · | competição | jogos | % |
+|---|---|---|---|---|---|---|
+| copa_mundo | 79 | **34,6%** | · | sudamericana | 17 | 7,5% |
+| serie_b | 49 | 21,5% | · | copa_do_brasil | 16 | 7,0% |
+| brasileirao | 38 | 16,7% | · | primeira_liga | 9 | 3,9% |
+| champions_league | 18 | 7,9% | · | libertadores | 2 | 0,9% |
+
+**Ele acrescenta pouco, e o pouco é mensurável.** A spec estimava "~37 jogos"; foram **59** — a
+estimativa envelheceu, e o número medido é o que vale. Mas o efeito que se poderia esperar dele
+**não** acontece: a Copa do Mundo continua sendo mais de um terço da amostra (34,6%, contra 46,7%
+no congelado), e das seis ligas europeias do portfólio **uma única** aparece — a Primeira Liga, com
+9 jogos. Bundesliga, La Liga, Ligue 1, Premier League e Serie A ITA seguem em **zero**. A família
+split-year, que a #53 e a #54 deixaram registrada como "sem amostra", continua sem amostra
+suficiente para deixar de ser degenerada.
+
+E aqui a tolerância de 0,5 pp declarada na #51 **volta a ter mordida**: no congelado, a coleta de
+odds já tinha parado (zero capturas após 04/08, medido); no estendido, não. Toda leitura de
+`linha_subindo`/`linha_descendo` nas linhas de universo estendido está sujeita a ela.
+
+### ⚠️ `defesas_vazaveis` é a única premissa em dois mercados — e os dois vereditos são opostos
+
+O cabeçalho do `taskf_sobrevivencia.sql` diz, antes de rodar, que agrupa por mercado "porque supor
+unicidade de nome é como se descobre que ela não valia". Valeu a pena:
+
+| mercado · benchmark | `base` | `escopo` | `recorte` | `ambos` | veredito |
+|---|---|---|---|---|---|
+| BTTS · consenso | +8,7 (31) | +1,6 (36) | +7,3 (32) | +6,3 (44) | **SOBREVIVE** |
+| Gols · sharp | −5,8 (158) | −5,8 (201) | −6,2 (181) | −7,7 (214) | SEM EVIDÊNCIA |
+
+As "39 premissas" do entregável são **39 linhas de (mercado, premissa, benchmark) sobre 38 nomes
+distintos**. Quem ler a tabela final da #59 por nome de premissa vai encontrar `defesas_vazaveis`
+duas vezes, com sinais opostos, e isso não é duplicata: são dois mercados, dois benchmarks
+preferidos e duas medições legítimas.
+
+### As guardas: quatro verdes, e duas quebras novas
+
+```
+dbt test --target taskF --select tag:costura_b     →  PASS=4 ERROR=0
+```
+
+Três das quatro mudaram de grão nesta task — passaram a cobrar por (universo × célula) — e ficaram
+**mais fortes**, não mais fracas: são quatro vezes mais comparações. A quarta,
+`assert_taskf_base_reproduz_01`, foi recortada no universo `completo` de propósito: o lado esquerdo
+dela são os números publicados da [0.1], que existem para um recorte só. Não há [0.1] "sem Copa do
+Mundo" contra a qual reproduzir.
+
+Que os quatro universos tenham passado com contagens **diferentes** (169, 90, 228, 210) já é a
+prova viva de que a referência é por universo — uma referência global teria ficado vermelha nas
+três últimas. As duas cobranças que esse argumento não alcança foram quebradas de propósito:
+
+| quebra | guarda que caiu | saída |
+|---|---|---|
+| `SET jogos_no_universo = +1 WHERE universo='sem_copa_mundo' AND celula='ambos'` | `celulas_mesmo_universo` | **4 linhas**: 1 `jogos_fora_do_gabarito` (91 contra o gabarito 90) e 3 `universo_divergente` — as outras três células daquele universo denunciando a quarta |
+| `SET universo='completo_v2' WHERE universo='estendido' AND celula='recorte'` | `celulas_mesmo_universo` **e** `premissas_de_tabela_identicas` | **2 linhas** (`celulas_faltando`, nos dois sentidos: o universo que não devia existir e o par que sumiu) e **10 linhas** de grão incompleto |
+
+As duas foram desfeitas e as quatro guardas voltaram ao verde; a tabela foi reconferida depois, e
+os 16 pares (universo × célula) devolvem exatamente os mesmos números de antes das quebras.
+
+### A re-medição reproduz a #55: 6 campos em 7.200
+
+`analyses/taskf_remedicao.sql` contra `taskf_teste2_55` — a cópia declarada em `sources.yml` antes
+de a acumulativa ser dropada para ganhar a coluna de universo.
+
+| célula | linhas | sem contraparte | linhas divergentes | campos divergentes | campos comparados |
+|---|---|---|---|---|---|
+| `base` | 60 | 0 | 2 | 3 | 1.800 |
+| `escopo` | 60 | 0 | 1 | 1 | 1.800 |
+| `recorte` | 60 | 0 | **0** | **0** | 1.800 |
+| `ambos` | 60 | 0 | 2 | 2 | 1.800 |
+
+Cinco dos seis campos são os **mesmos** empates de arredondamento que a #53, a #54 e a #55 já
+tinham medido e provado (55/80 = 68,75; 308/320 = 96,25; 51/400 = 12,75). O sexto é novo —
+`clean_sheets_altos` · `jogos_medios_usado` na `ambos`, 5,2 → 5,3 — e foi provado do mesmo jeito, e
+não presumido: **92 linhas, soma 483, média exata 483/92 = 5,25**, em cima do meio da grade de
+`ROUND(·, 1)`.
+
+A comparação é só do universo `completo`, e não é lacuna: os três universos novos nasceram nesta
+execução e não têm lado esquerdo. Comparar 240 linhas de hoje contra 60 de ontem produziria 180
+`SEM_CONTRAPARTE` que esconderiam a divergência real.
+
+E as conferências de fora não se moveram: a reconciliação contra a [0.1] segue **38 EXATO / 1
+INVESTIGAR**, com `linha_descendo` nos mesmos −2 de `n`; saturação, piso, monotonicidade e chaves
+seguem `OK` nos quatro blocos, com os mesmos 21.054 pares nas quatro células.
+
+### Reprodução
+
+```bash
+cd dbt_futebol
+
+# FASE 0 — só porque a #58 mudou o schema da acumulativa (a coluna `universo`)
+bq cp -f smartbetting-dados:futebol_taskF.taskf_teste2 \
+         smartbetting-dados:futebol_taskF.taskf_teste2_55   # a cópia que sobrevive
+bq rm -f -t smartbetting-dados:futebol_taskF.taskf_teste2
+
+# as quatro células, cada uma com build -> carimbo -> Teste 2 e as MESMAS vars. Nada de `+`.
+# (a ancestria NÃO foi reconstruída: ela já estava no dataset e nenhum modelo dela mudou —
+#  e é ela que fixa até onde o universo estendido alcança)
+# base    : --vars '{}'                                        (sem exclusão: a Costura A roda)
+# escopo  : --vars '{pit_escopo: todas}'                       --exclude assert_taskf_pit_default_igual_baseline
+# recorte : --vars '{pit_recorte: ultimos_10}'                 idem
+# ambos   : --vars '{pit_escopo: todas, pit_recorte: ultimos_10}' idem
+
+# FASE 3 — o portão
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt test --target taskF --select tag:costura_b
+
+# resposta 1 (o piso célula a célula)
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_saturacao_recorte
+
+# resposta 2 (a sobrevivência das quatro)
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_sobrevivencia
+
+# resposta 3 (Copa do Mundo) — o default do taskf_exclusao
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_exclusao
+
+# resposta 4 (Champions) — o mesmo arquivo, outro par de universos
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_exclusao \
+  --vars '{taskf_universo_com: estendido, taskf_universo_sem: estendido_sem_champions_classif}'
+
+# o universo estendido, à parte
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_universo_congelado
+
+bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=500 \
+  < target/compiled/dbt_futebol/analyses/<a análise>.sql
+```
+
+Os quatro `dbt build` fecham **43/43** (`base`, incluindo a Costura A) e **42/42** (as outras
+três), com `ERROR=0` e `SKIP=0` — iguais aos da #54 e da #55.
+
+⚠️ **Sem `--max_rows` o `bq query` corta em 100 linhas sem avisar**, e o `taskf_exclusao` emite
+mais do que isso. É o mesmo corte silencioso que a #57 documentou.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -2084,6 +2084,13 @@ UTC porque é até ali que vai o `fact_odds_snapshot` que as quatro células ler
 a única coisa que faz a comparação entre células significar algo. O universo é, por construção, "o
 que os fatos contêm" — e o `janela_fim` na linha diz até onde ele foi.
 
+**E o que esse teto custa está medido, não estimado.** A mesma análise rodada com `--target dev`,
+que lê produção e portanto alcança a data de execução, devolve **233 jogos** contra os 228 do
+dataset de medição: a diferença é de **5 jogos**, todos de 12/08 à noite e 13/08. É a resposta
+literal da user story 5 ("o universo estendido **até a data de execução**"), e ela mostra que a
+escolha de não reconstruir a ancestria custou 2,2% de amostra — bem menos do que custaria perder a
+comparabilidade entre as quatro células.
+
 | competição | jogos | % do estendido |
 |---|---|---|
 | copa_mundo | 79 | **34,6%** |
@@ -2206,8 +2213,10 @@ DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_exclu
 DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_exclusao \
   --vars '{taskf_universo_com: estendido, taskf_universo_sem: estendido_sem_champions_classif}'
 
-# o universo estendido, à parte
+# o universo estendido, à parte — no dataset de medição (228) e, com --target dev, contra
+# produção, que alcança a data de execução (233). A diferença é o que o teto dos fatos custa.
 DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_universo_congelado
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target dev   --select taskf_universo_congelado
 
 bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=500 \
   < target/compiled/dbt_futebol/analyses/<a análise>.sql

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -1815,8 +1815,19 @@ funciona. E sem `--max_rows` ele corta em 100 linhas sem avisar.
 ## Ticket #58 — As três respostas fechadas, e a Champions medida onde ela existe
 
 `analyses/taskf_exclusao.sql` + `taskf_sobrevivencia.sql` + `taskf_saturacao_recorte.sql` +
-`taskf_universo_congelado.sql` · execução 2026-08-13 17:49–18:13 UTC · **células** do commit
-`7fdd1a3`, **análises** do `f293962` · dataset `futebol_taskF`
+`taskf_universo_congelado.sql` · execução 2026-08-13 17:49–18:31 UTC · dataset `futebol_taskF`
+
+O carimbo é de **três** commits, e a distinção não é burocracia — é a lição da #56, que teve de
+corrigir um carimbo apontando para um sha que não continha o código que produziu a saída:
+
+| o que | commit | quando |
+|---|---|---|
+| as quatro **células** (a medição propriamente dita) | `7fdd1a3` | 17:49–17:56 |
+| ordenação, sobrevivência, piso e composição do universo | `f293962` | 18:03–18:13 |
+| os blocos `topo` e `fora_do_universo`, acrescentados pela revisão | `d1fe3a2` | 18:25–18:31 |
+
+As células **não** foram re-medidas para os blocos novos: eles só leem, e os números de ordenação
+foram conferidos idênticos antes e depois de eles existirem.
 
 As três perguntas que a spec #49 cobra fechadas, mais a extensão que o grilling acrescentou. Duas
 delas — a da Copa do Mundo e a da Champions — são perguntas sobre **quais jogos entram na conta**,


### PR DESCRIPTION
Fecha as três respostas que a spec #49 cobra, mais a extensão do grilling: a mesma pergunta da
Copa do Mundo aplicada à fase classificatória da Champions.

## As respostas

| | |
|---|---|
| **piso 5, célula a célula** | 69 → **92** jogos com o histórico junto (81 só com recorte, 92 com os dois eixos) |
| **as quatro premissas de amostra curta** | sobrevivem `clean_sheets_altos` e `defesa_forte`; seguem sem evidência `superioridade_xg` e `tende_golear` |
| **Copa do Mundo** | **manter** — imaterial no piso 5, e no piso 10 os dois universos são a MESMA medição |
| **Champions (fase classificatória)** | **manter** — ρ = 1,000 no piso 5 em `base` e `escopo`: zero dos 18 jogos passa o piso ali |

O motivo é o mesmo nas duas: **o piso de amostra já faz o trabalho que a exclusão faria.** Dos 79
jogos de Copa do Mundo, **2** passam o piso 5; dos 18 de Champions, **zero** nas duas células que
refletem produção.

```
ordenacao no piso 5   exclusao da Copa do Mundo   rho 0,964 a 0,992
                      exclusao da Champions       rho 1,000 (a mesma medicao)
                      eixo base->escopo (referencia)  rho 0,648
```

A régua — `rho < 0,90` **ou** 2 trocas no top 5 **ou** 4 trocas de sinal — foi declarada no
cabeçalho da análise **antes** de medir, e o contraste de eixo veio junto para dar escala.

⚠️ **A célula `recorte` no piso 5 sai MATERIAL e fica assim.** A régua disparou por uma ponta
(2 trocas no topo) com as outras duas limpas. Amaciar um MATERIAL depois de vê-lo é o pós-hoc que
o próprio cabeçalho proíbe, então o veredito saiu como caiu — com o conteúdo da troca ao lado
(uma permuta adjacente na fronteira do top 5) e com o placebo declarado como o passo para quem
quiser litigar essa linha.

## O desenho

O **universo** vira um terceiro eixo, ortogonal à célula: a célula diz qual HISTÓRICO cada jogo
carrega, o universo diz QUAIS JOGOS são medidos. Os quatro universos de uma célula saem do **mesmo
INSERT** — se COM e SEM fossem duas execuções, a diferença entre elas carregaria uma reconstrução
dos modelos dentro de si, e a #55 mediu que uma reconstrução move 5 campos em 7.200 sozinha.

A exclusão da Champions é escrita por **semântica de fase**, não por competição: `'Play-offs'`
(agosto, classificatória) e `'Knockout Round Play-offs'` (fevereiro, mata-mata) convivem no mesmo
campo `round`. Que as duas coisas coincidam nesta janela é **medido** (18 de 18 numa única fase),
não suposto.

## Achados de percurso

- **a previsão da spec sobre `escopo` e a Champions virou medição**: `base` e `escopo` dão o mesmo
  `min_jogos` médio (1,78), o mesmo máximo (4) e os mesmos zero jogos acima do piso 5 — soltar a
  competição sem soltar a temporada não empresta uma única partida. A #53 e a #54 tinham registrado
  isso como não verificável;
- **7,9% e não os 22% da spec**: ela contou fixtures, o universo exige preço, e a coleta da UCL
  entrou em 31/07 — 56 partidas de Q1/Q2 sem preço nenhum. A conta inteira sai do bloco
  `fora_do_universo`, que também mostra que a Copa do Mundo jogou 88 e não 79;
- **`defesas_vazaveis` é a única premissa em DOIS mercados, com vereditos opostos** — as "39
  premissas" são 39 linhas sobre 38 nomes. O cabeçalho da análise afirmava o contrário e foi
  corrigido pela medição que o desmentiu;
- **o estendido acrescenta 59 jogos** (a spec estimava ~37) e não dilui a Copa do Mundo como se
  poderia supor: 46,7% → 34,6%. O teto dos fatos custa 5 jogos, medido contra produção.

## Guardas

`dbt test --select tag:costura_b` → **PASS=4**. Três das quatro passaram a cobrar por
(universo × célula) e ficaram mais fortes; a que reproduz a [0.1] ficou recortada no `completo`,
porque não existe [0.1] "sem Copa do Mundo" contra a qual reproduzir. Duas quebras novas
falsificadas e desfeitas. `tag:guarda` (o agendado) segue 16/16 verde, e a Costura A confirma que
o default continua reproduzindo o baseline congelado.

## Revisão

A revisão de standards pegou um defeito que passou por `dbt parse`, por quatro guardas verdes e
por uma medição inteira: **chave YAML duplicada** no `sources.yml` — a edição comeu a linha
`- name: medido_em` e a coluna `universo` passou a ser documentada como outra coisa. O dbt avisa e
não falha. Corrigido, junto com o validador de universo que estava copiado em quatro lugares e com
dois números do documento que não saíam de query commitada — os dois blocos novos (`topo` e
`fora_do_universo`) que fecham isso valem mais do que a correção.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)