### PR TITLE
[F-10] O entregável: as 39 linhas, e o que o merge não conserta

### DIFF
--- a/dbt_futebol/analyses/taskf_delta_celulas.sql
+++ b/dbt_futebol/analyses/taskf_delta_celulas.sql
@@ -116,9 +116,11 @@
 {#- As premissas de tabela do catálogo medido (ADR 0008). O veredito delas é o piso 0; ver o
     cabeçalho. -#}
 {%- set premissas_de_tabela = ['superioridade_tabela', 'supremacia', 'sem_rodizio'] -%}
-{#- Campos que, mudando, contam como "a premissa se mexeu". `n_p0` entra porque mudança no
-    conjunto de linhas em que a premissa acende é efeito, não ruído. -#}
-{%- set campos_piso0 = ['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'dif_p0'] -%}
+{#- Campos que, mudando, contam como "a premissa se mexeu" — declarados em taskf_campos_do_piso0()
+    porque o entregável da #59 emite o MESMO veredito sobre a MESMA linha, e duas listas fariam as
+    duas análises discordarem em silêncio. A macro devolve os nomes de coluna da tabela gravada; o
+    `juntado` daqui renomeia `diferenca_p0` para `dif_p0`, e a tradução é feita aqui, uma vez. -#}
+{%- set campos_piso0 = taskf_campos_do_piso0() | map('replace', 'diferenca_', 'dif_') | list -%}
 
 WITH a AS (
     SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }}

--- a/dbt_futebol/analyses/taskf_entregavel.sql
+++ b/dbt_futebol/analyses/taskf_entregavel.sql
@@ -63,11 +63,13 @@
     COMO RODAR (do dbt_futebol/):
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_entregavel
-      bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=100 \
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=200 \
         < target/compiled/dbt_futebol/analyses/taskf_entregavel.sql
 
-    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento. E
-    sem `--max_rows` ele trunca em 100 linhas, que é menos do que as 60 do anexo mais as 39.)
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento. O
+    `--max_rows` fica explícito por margem, não por necessidade de hoje: são 39 linhas mais 21 de
+    anexo, abaixo do corte silencioso de 100 — mas o anexo cresce a cada benchmark novo, e o corte
+    não avisa quando morde.)
 
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */
@@ -81,7 +83,10 @@
     da [0.1], que é contra o qual o ticket contesta os números. O efeito de EXCLUIR jogos (Copa do
     Mundo, fase classificatória da Champions) é outra pergunta, e ela tem análise própria desde a
     #58 — analyses/taskf_exclusao.sql. -#}
-{%- set universo  = 'completo' -%}
+{#- Validado pela mesma macro que os predicados usam, mesmo sendo literal: o dia em que um nome de
+    universo for renomeado, isto quebra alto em vez de filtrar a tabela por um valor que não existe
+    mais — que devolveria zero linha e pareceria "a medição não tem estas premissas". -#}
+{%- set universo  = taskf_universo_valido('completo') -%}
 {#- Os nomes das duas células saem da macro que os define, e são CONFERIDOS: um nome que não
     existe vira Undefined, que o Jinja renderiza como string vazia — e `WHERE celula = ''`
     devolve zero linha, que nesta tabela se parece com "a medição não tem esta premissa". Aconteceu
@@ -95,10 +100,11 @@
         ~ "', junto='" ~ cel_junta ~ "'. Chaves aceitas: "
         ~ nomes_de_celula.keys() | join(' | ')) }}
 {%- endif -%}
-{#- Os mesmos quatro campos que a analyses/taskf_delta_celulas.sql usa para decidir se a premissa
-    se mexeu no piso 0. Uma segunda definição de "mexeu" faria as duas análises discordarem sobre
-    a mesma linha. -#}
-{%- set campos_piso0 = ['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'diferenca_p0'] -%}
+{#- "Mexeu no piso 0" é o mesmo veredito que a analyses/taskf_delta_celulas.sql emite sobre a mesma
+    linha, então os quatro campos saem da macro que os declara — e não de uma segunda lista aqui,
+    que faria as duas análises discordarem em silêncio. Aqui os nomes são lidos direto da tabela
+    gravada; lá eles passam pelo alias local. -#}
+{%- set campos_piso0 = taskf_campos_do_piso0() -%}
 
 WITH {{ task01_base() }},
 
@@ -112,8 +118,8 @@ declaracao AS (
         STRUCT<mercado STRING, premissa STRING, fonte STRING, predicado STRING,
                escopo_hoje STRING, juntavel STRING, impedimento STRING, ressalva STRING>
         {%- for f in fontes %}
-        ('{{ f.mercado }}', '{{ f.premissa }}',
-         '{{ f.fonte | replace("'", "''") }}', '{{ f.predicado }}',
+        ('{{ f.mercado | replace("'", "''") }}', '{{ f.premissa | replace("'", "''") }}',
+         '{{ f.fonte | replace("'", "''") }}', '{{ f.predicado | replace("'", "''") }}',
          '{{ f.escopo_hoje }}', '{{ f.juntavel }}',
          '{{ f.impedimento | replace("'", "''") }}',
          '{{ f.ressalva | replace("'", "''") }}'){{ "," if not loop.last }}
@@ -122,9 +128,13 @@ declaracao AS (
 ),
 
 {#- ── A quebra por família ────────────────────────────────────────────────────────── -#}
+{#- O predicado sai do MESMO nome de universo que filtra a tabela de medição acima. Escrever
+    `taskf_universo_filtro()` direto daria o mesmo SQL hoje e deixaria as duas metades livres para
+    divergir amanhã — a quebra por família passaria a descrever outro conjunto de jogos que o dos
+    números ao lado. -#}
 apostas_congeladas AS (
     SELECT * FROM apostas
-    WHERE {{ taskf_universo_filtro() }}
+    WHERE {{ taskf_universo_predicado(universo) }}
 ),
 
 familia_do_universo AS (
@@ -289,4 +299,14 @@ SELECT
 FROM juntado AS j
 CROSS JOIN familia_resumo AS fr
 CROSS JOIN lote AS l
-ORDER BY bloco, j.mercado, j.premissa
+{#- `benchmark` entra na ordenação porque é parte do grão: sem ele, as duas linhas de uma premissa
+    do Gols (sharp e consenso) saem em ordem indefinida entre execuções, e a comparação linha a
+    linha de duas rodadas passaria a acusar diferença onde não há.
+    ⚠️ Este comentário fecha SEM o traço: com ele, o Jinja come a quebra de linha e cola o
+    ORDER BY no CROSS JOIN acima. Foi assim que o comentário da #37 quebrou o task01_base()
+    (commit b535130), e foi assim que este ORDER BY quebrou na primeira tentativa.
+    ⚠️ E o texto de um comentário não pode conter a sequência que o fecha — descrevê-la em
+    palavras é o jeito de falar dela aqui dentro; escrevê-la encerra o comentário no meio e
+    despeja o resto como SQL.
+ #}
+ORDER BY bloco, j.mercado, j.premissa, j.benchmark

--- a/dbt_futebol/analyses/taskf_entregavel.sql
+++ b/dbt_futebol/analyses/taskf_entregavel.sql
@@ -1,0 +1,292 @@
+/*
+    [F-10] O ENTREGÁVEL DA TASK [F]: as 39 linhas que o ticket de origem pediu, uma por premissa,
+    no benchmark preferido de cada mercado — mais o anexo com as linhas de benchmark não-preferido,
+    marcadas como não usadas para peso.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    AS QUATRO COLUNAS DO TICKET, E DE ONDE CADA UMA SAI
+
+      1. de onde puxa o histórico            `fonte`, `predicado`     declaração (macro)
+      2. se a janela é limitada à competição  `escopo_hoje`            declaração (macro)
+      3. se dá para juntar, e o que impede    `juntavel`,`impedimento` declaração (macro)
+      4. o que o número vira                  as colunas `_hoje`/`_junto`   MEDIÇÃO
+
+    Mais a quebra por FAMÍLIA de competição, que a spec #49 pede como coluna adicional.
+
+    As três primeiras são leitura de código e moram em macros/taskf_fontes_de_historico.sql, com
+    a validação de cobertura em tempo de compilação. A quarta sai da tabela acumulativa das quatro
+    células (futebol_taskF.taskf_teste2), no par que responde à pergunta literal do ticket —
+    "juntar os campeonatos" é o eixo de ESCOPO:
+
+        `base`   escopo na competição do jogo   = o que roda hoje
+        `escopo` escopo em todas as competições = o histórico junto
+
+    O 2×2 completo (com o eixo de recorte) e a atribuição por eixo já estão publicados nas seções
+    das #53 e #54 do docs/TASKF_RESULTADOS.md; esta análise não os repete.
+
+    ⚠️ ESTA ANÁLISE NÃO MEDE NADA — ELA LÊ. Nenhuma célula é reconstruída aqui, e não deve ser:
+    as quatro saíram da mesma execução (#58) e um rebuild hoje produziria um lote novo, quebrando
+    a invariante que torna o 2×2 comparável. `dbt compile` + `bq query`, e nada de `dbt build`.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A DECLARAÇÃO É CONFRONTADA COM A MEDIÇÃO, e é isso que separa esta tabela de uma opinião
+    bem formatada. Duas conferências, ambas na saída:
+
+      `cobertura`     a declaração e a medição cobrem o MESMO conjunto de premissas. A macro já
+                      confere isso contra futebol_insumos_premissa() ao compilar; aqui a
+                      contraparte é o que a medição REALMENTE produziu, que é outra coisa — uma
+                      premissa que não acende nenhuma vez some do taskf_teste2 (o `HAVING` dele)
+                      e sairia como `SEM_MEDICAO`, não como linha faltando.
+
+      `confere`       quem está declarado como NÃO juntável tem de sair IMÓVEL no piso 0, e quem
+                      está declarado juntável tem de se MEXER. É o que pega declaração errada:
+                      nenhuma checagem de nome alcançaria uma linha que diz "não dá para juntar"
+                      sobre uma premissa cujo número muda.
+
+    ⚠️ IMÓVEL É NO PISO 0, e só. Nos pisos maiores até as premissas de tabela mudam, porque o
+    `min_jogos` segue a célula — é a seção *Consequences* da ADR 0008, e cobrar igualdade nos
+    demais pisos acusaria de defeito o comportamento que a ADR promete.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    ⚠️ A QUEBRA POR FAMÍLIA É DEGENERADA NESTA JANELA, E ISSO É CONTEÚDO, NÃO FALHA. A janela
+    congelada (16/06 a 04/08) pega o meio da virada de temporada europeia: as ligas split-year
+    ainda não tinham começado e a Champions só aparece em 04/08 à noite, depois do teto. O
+    resultado é um universo 100% ano-calendário. A coluna sai assim mesmo, com o número ao lado,
+    porque `sem amostra` e `efeito nulo` são coisas diferentes e a segunda seria uma conclusão
+    falsa sobre as europeias. A regra é a mesma da analyses/taskf_familia_e_mecanismo.sql.
+
+    O universo da família sai do task01_base() sobre a camada MATERIALIZADA agora — que é a
+    última célula que rodou —, enquanto o resto da tabela sai do carimbo. Por isso a coluna
+    `confere_universo` compara os dois: se a materialização atual não for do mesmo lote que
+    produziu a medição, o número de jogos denuncia.
+
+    COMO RODAR (do dbt_futebol/):
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_entregavel
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=100 \
+        < target/compiled/dbt_futebol/analyses/taskf_entregavel.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento. E
+    sem `--max_rows` ele trunca em 100 linhas, que é menos do que as 60 do anexo mais as 39.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
+*/
+
+{%- set fontes = taskf_fontes_de_historico() -%}
+{#- A tabela de medição é lida por `source()`, como todo o resto do dataset de medição
+    (CODING_STANDARDS.md: "Relations only via ref() / source()"). -#}
+{%- set medicao = source('futebol_taskF', 'taskf_teste2') -%}
+
+{#- O universo é o PRIMÁRIO e é fixo aqui, sem var: o entregável é a tabela do universo congelado
+    da [0.1], que é contra o qual o ticket contesta os números. O efeito de EXCLUIR jogos (Copa do
+    Mundo, fase classificatória da Champions) é outra pergunta, e ela tem análise própria desde a
+    #58 — analyses/taskf_exclusao.sql. -#}
+{%- set universo  = 'completo' -%}
+{#- Os nomes das duas células saem da macro que os define, e são CONFERIDOS: um nome que não
+    existe vira Undefined, que o Jinja renderiza como string vazia — e `WHERE celula = ''`
+    devolve zero linha, que nesta tabela se parece com "a medição não tem esta premissa". Aconteceu
+    na primeira execução desta análise, com uma chave escrita com `_` no lugar do `|`. -#}
+{%- set nomes_de_celula = taskf_nomes_de_celula() -%}
+{%- set cel_hoje  = nomes_de_celula['da_competicao|temporada'] | default('', true) -%}
+{%- set cel_junta = nomes_de_celula['todas|temporada']         | default('', true) -%}
+{%- if cel_hoje not in nomes_de_celula.values() or cel_junta not in nomes_de_celula.values() -%}
+    {{ exceptions.raise_compiler_error(
+        "célula não resolvida a partir de taskf_nomes_de_celula(): hoje='" ~ cel_hoje
+        ~ "', junto='" ~ cel_junta ~ "'. Chaves aceitas: "
+        ~ nomes_de_celula.keys() | join(' | ')) }}
+{%- endif -%}
+{#- Os mesmos quatro campos que a analyses/taskf_delta_celulas.sql usa para decidir se a premissa
+    se mexeu no piso 0. Uma segunda definição de "mexeu" faria as duas análises discordarem sobre
+    a mesma linha. -#}
+{%- set campos_piso0 = ['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'diferenca_p0'] -%}
+
+WITH {{ task01_base() }},
+
+{{ taskf_familia_competicao() }},
+
+{#- ── A declaração, transcrita para SQL ──────────────────────────────────────────────
+    As aspas simples são escapadas na transcrição: um apóstrofo num texto de `ressalva` fecharia
+    o literal e quebraria a query com erro de sintaxe a 200 linhas do problema. -#}
+declaracao AS (
+    SELECT * FROM UNNEST([
+        STRUCT<mercado STRING, premissa STRING, fonte STRING, predicado STRING,
+               escopo_hoje STRING, juntavel STRING, impedimento STRING, ressalva STRING>
+        {%- for f in fontes %}
+        ('{{ f.mercado }}', '{{ f.premissa }}',
+         '{{ f.fonte | replace("'", "''") }}', '{{ f.predicado }}',
+         '{{ f.escopo_hoje }}', '{{ f.juntavel }}',
+         '{{ f.impedimento | replace("'", "''") }}',
+         '{{ f.ressalva | replace("'", "''") }}'){{ "," if not loop.last }}
+        {%- endfor %}
+    ])
+),
+
+{#- ── A quebra por família ────────────────────────────────────────────────────────── -#}
+apostas_congeladas AS (
+    SELECT * FROM apostas
+    WHERE {{ taskf_universo_filtro() }}
+),
+
+familia_do_universo AS (
+    SELECT
+        f.familia,
+        COUNT(DISTINCT a.fixture_id) AS jogos
+    FROM apostas_congeladas AS a
+    JOIN familia_competicao AS f USING (competition)
+    GROUP BY f.familia
+),
+
+{#- Uma linha só, para entrar por CROSS JOIN em todas as premissas. A família é propriedade do
+    UNIVERSO, e não da premissa: as 39 são medidas sobre os mesmos jogos. -#}
+familia_resumo AS (
+    SELECT
+        COALESCE(SUM(IF(familia = 'ano_calendario', jogos, 0)), 0) AS jogos_ano_calendario,
+        COALESCE(SUM(IF(familia = 'split_year',     jogos, 0)), 0) AS jogos_split_year,
+        COALESCE(SUM(jogos), 0)                                    AS jogos_materializados
+    FROM familia_do_universo
+),
+
+{#- ── A medição ──────────────────────────────────────────────────────────────────── -#}
+hoje AS (
+    SELECT * FROM {{ medicao }}
+    WHERE celula = '{{ cel_hoje }}' AND universo = '{{ universo }}'
+),
+
+junto AS (
+    SELECT * FROM {{ medicao }}
+    WHERE celula = '{{ cel_junta }}' AND universo = '{{ universo }}'
+),
+
+{#- O lote inteiro, não só as duas células lidas: se alguém re-mediu UMA célula depois da #58, as
+    quatro deixam de ser comparáveis e o 2×2 já não é um 2×2 — mesmo que as duas lidas aqui
+    tenham vindo juntas. É a conferência de leitura da mesma coisa que a Costura B cobra por
+    execução. -#}
+lote AS (
+    SELECT
+        COUNT(DISTINCT git_sha)                       AS n_git_sha,
+        COUNT(DISTINCT FORMAT('%t', odds_loaded_at))  AS n_odds_loaded_at,
+        COUNT(DISTINCT CONCAT(celula, '|', universo)) AS n_grupos,
+        MAX(git_sha)                                  AS git_sha,
+        MAX(odds_loaded_at)                           AS odds_loaded_at
+    FROM {{ medicao }}
+),
+
+{#- FULL OUTER nos dois níveis: entre as células (premissa que existe numa e não na outra) e
+    entre declaração e medição. Linha que sumiria em silêncio é achado, não ruído. -#}
+medido AS (
+    SELECT
+        COALESCE(h.mercado, j.mercado)     AS mercado,
+        COALESCE(h.premissa, j.premissa)   AS premissa,
+        COALESCE(h.benchmark, j.benchmark) AS benchmark,
+        COALESCE(h.usado_para_peso, j.usado_para_peso) AS usado_para_peso,
+        h.celula IS NULL AS so_no_junto,
+        j.celula IS NULL AS so_no_hoje,
+        h.jogos_no_universo AS jogos_no_universo,
+        h.janela_ini, h.janela_fim,
+        h.medido_em AS medido_em_hoje, j.medido_em AS medido_em_junto,
+        ({% for campo in campos_piso0 -%}
+         IF(h.{{ campo }} IS DISTINCT FROM j.{{ campo }}, 1, 0){{ " + " if not loop.last }}
+         {%- endfor %})                    AS campos_piso0_mudados,
+        h.n_p0  AS n_p0_hoje,  j.n_p0  AS n_p0_junto,
+        h.n_p5  AS n_p5_hoje,  j.n_p5  AS n_p5_junto,
+        h.diferenca_p0 AS dif_p0_hoje, j.diferenca_p0 AS dif_p0_junto,
+        h.diferenca_p5 AS dif_p5_hoje, j.diferenca_p5 AS dif_p5_junto,
+        h.peso_p5 AS peso_p5_hoje, j.peso_p5 AS peso_p5_junto,
+        h.jogos_medios_disp AS jogos_hoje, j.jogos_medios_disp AS jogos_junto,
+        h.pct_amostra_curta AS curta_hoje, j.pct_amostra_curta AS curta_junto
+    FROM hoje AS h
+    FULL OUTER JOIN junto AS j USING (mercado, premissa, benchmark)
+),
+
+juntado AS (
+    SELECT
+        COALESCE(m.mercado, d.mercado)   AS mercado,
+        COALESCE(m.premissa, d.premissa) AS premissa,
+        m.* EXCEPT (mercado, premissa),
+        d.* EXCEPT (mercado, premissa),
+        d.premissa IS NULL AS sem_declaracao,
+        m.premissa IS NULL AS sem_medicao
+    FROM medido AS m
+    FULL OUTER JOIN declaracao AS d USING (mercado, premissa)
+)
+
+SELECT
+    IF(COALESCE(j.usado_para_peso, TRUE), 'principal', 'anexo')  AS bloco,
+    j.mercado,
+    j.premissa,
+    j.benchmark,
+    j.usado_para_peso,
+
+    -- COLUNA 1 do ticket: de onde puxa o histórico.
+    j.fonte,
+    j.predicado,
+    -- COLUNA 2: se a janela é limitada à competição do jogo.
+    j.escopo_hoje,
+    -- COLUNA 3: se dá para juntar, e o que impede quando não dá.
+    j.juntavel,
+    j.impedimento,
+    j.ressalva,
+
+    -- COLUNA 4: o que o número vira. `hoje` = célula `base`; `junto` = célula `escopo`.
+    j.n_p0_hoje,   j.n_p0_junto,
+    j.dif_p0_hoje, j.dif_p0_junto,
+    ROUND(j.dif_p0_junto - j.dif_p0_hoje, 1)      AS delta_dif_p0,
+    j.n_p5_hoje,   j.n_p5_junto,
+    j.dif_p5_hoje, j.dif_p5_junto,
+    ROUND(j.dif_p5_junto - j.dif_p5_hoje, 1)      AS delta_dif_p5,
+    j.peso_p5_hoje, j.peso_p5_junto,
+    j.jogos_hoje,  j.jogos_junto,
+    ROUND(j.jogos_junto - j.jogos_hoje, 1)        AS delta_jogos,
+    j.curta_hoje,  j.curta_junto,
+    ROUND(j.curta_junto - j.curta_hoje, 1)        AS delta_curta,
+
+    -- COLUNA ADICIONAL: a quebra por família de competição. Ver o cabeçalho — nesta janela ela é
+    -- degenerada, e o número ao lado é o que impede de ler isso como efeito nulo nas europeias.
+    FORMAT('ano_calendario %d (%.1f%%) · split_year %d%s',
+           fr.jogos_ano_calendario,
+           SAFE_DIVIDE(fr.jogos_ano_calendario, fr.jogos_materializados) * 100,
+           fr.jogos_split_year,
+           IF(fr.jogos_split_year = 0, ' — SEM AMOSTRA', ''))                AS familia,
+    fr.jogos_ano_calendario,
+    fr.jogos_split_year,
+
+    -- As duas conferências. Ver o cabeçalho.
+    CASE
+        WHEN j.sem_declaracao THEN 'SEM_DECLARACAO'
+        WHEN j.sem_medicao    THEN 'SEM_MEDICAO'
+        ELSE                       'CONFERE'
+    END                                                                       AS cobertura,
+    CASE
+        WHEN j.so_no_hoje OR j.so_no_junto     THEN 'SEM_CONTRAPARTE'
+        WHEN j.campos_piso0_mudados = 0        THEN 'IMOVEL_NO_PISO0'
+        ELSE                                        'MUDOU'
+    END                                                                       AS veredito_medicao,
+    CASE
+        WHEN j.sem_declaracao OR j.sem_medicao
+          OR j.so_no_hoje OR j.so_no_junto     THEN 'NAO_COMPARAVEL'
+        WHEN (j.juntavel = 'sim') = (j.campos_piso0_mudados > 0)
+                                               THEN 'CONFERE'
+        ELSE                                        'DIVERGE'
+    END                                                                       AS confere,
+
+    -- Carimbo. O lote é o da #58 e esta análise não o move; as colunas existem para que quem ler
+    -- a tabela saiba de qual medição ela saiu sem ter de acreditar no doc.
+    j.jogos_no_universo,
+    fr.jogos_materializados,
+    IF(j.jogos_no_universo = fr.jogos_materializados, 'CONFERE',
+       FORMAT('DIVERGE (medido %d, materializado %d)',
+              j.jogos_no_universo, fr.jogos_materializados))                  AS confere_universo,
+    j.janela_ini,
+    j.janela_fim,
+    j.medido_em_hoje,
+    j.medido_em_junto,
+    l.git_sha,
+    l.odds_loaded_at,
+    IF(l.n_git_sha = 1 AND l.n_odds_loaded_at = 1,
+       FORMAT('HOMOGENEO (%d grupos)', l.n_grupos),
+       FORMAT('MISTURADO (%d shas, %d odds_loaded_at)', l.n_git_sha, l.n_odds_loaded_at))
+                                                                              AS lote
+FROM juntado AS j
+CROSS JOIN familia_resumo AS fr
+CROSS JOIN lote AS l
+ORDER BY bloco, j.mercado, j.premissa

--- a/dbt_futebol/macros/taskf_fontes_de_historico.sql
+++ b/dbt_futebol/macros/taskf_fontes_de_historico.sql
@@ -21,6 +21,12 @@
       erro de compilação, no padrão fail-closed de taskf_eixos(). É o que pega premissa NOVA (o
       caso provável: alguém acrescenta uma premissa e ninguém lembra desta tabela).
 
+      ⚠️ E ela NÃO depende de alguém compilar a análise à mão: o erro sobe já no `dbt parse`,
+      porque a análise é nó do manifesto e o Jinja dela é renderizado ali. Medido, trocando
+      `ritmo_alto` por um nome inexistente — `dbt parse` sai com código 2 e a mensagem desta
+      macro. Como o workflow de docs roda `dbt docs generate`, que parseia o projeto inteiro, a
+      quebra aparece no CI mesmo que ninguém rode esta análise.
+
       LEITURA (analyses/taskf_entregavel.sql). A declaração é confrontada com a MEDIÇÃO: quem
       está declarado como imóvel (`nao` / `ja_junto` / `nao_se_aplica`) tem de sair com número
       idêntico entre `base` e `escopo` no piso 0, e quem está declarado `sim` tem de se mexer. É

--- a/dbt_futebol/macros/taskf_fontes_de_historico.sql
+++ b/dbt_futebol/macros/taskf_fontes_de_historico.sql
@@ -1,0 +1,354 @@
+{#- DE ONDE CADA PREMISSA PUXA O HISTÓRICO — as três colunas QUALITATIVAS do entregável da
+    task [F] (#59), declaradas num lugar só.
+
+    O ticket de origem (ClickUp `wdx6zevnhy`) pede quatro colunas por premissa:
+
+      1. de onde puxa o histórico          -> `fonte` + `predicado`
+      2. se a janela é limitada à competição -> `escopo_hoje`
+      3. se dá para juntar, e o que impede -> `juntavel` + `impedimento`
+      4. o que o número vira               -> NÃO mora aqui: sai da medição
+                                              (futebol_taskF.taskf_teste2, células `base` e
+                                              `escopo`), lida por analyses/taskf_entregavel.sql
+
+    A quarta é medida e as três primeiras são lidas do código — por isso elas são declaração, e
+    não query. Mas declaração que ninguém confere apodrece no primeiro modelo que mudar, e o
+    apodrecimento aqui seria MUDO: a tabela do entregável continuaria com 39 linhas bonitas
+    descrevendo um pipeline que já não é o que roda. Duas defesas, nesta ordem:
+
+      COMPILAÇÃO (aqui). O conjunto (mercado, premissa) declarado tem de ser EXATAMENTE o que
+      futebol_insumos_premissa() lista como `tipo = 'premissa'`, traduzido de modelo para mercado
+      por task01_markets() — as duas fontes que a própria medição já usa. Sobra ou falta levanta
+      erro de compilação, no padrão fail-closed de taskf_eixos(). É o que pega premissa NOVA (o
+      caso provável: alguém acrescenta uma premissa e ninguém lembra desta tabela).
+
+      LEITURA (analyses/taskf_entregavel.sql). A declaração é confrontada com a MEDIÇÃO: quem
+      está declarado como imóvel (`nao` / `ja_junto` / `nao_se_aplica`) tem de sair com número
+      idêntico entre `base` e `escopo` no piso 0, e quem está declarado `sim` tem de se mexer. É
+      o que pega declaração ERRADA — o caso que nenhuma checagem de nome alcança.
+
+    ⚠️ CHAVE É (mercado, premissa), NUNCA premissa sozinha. `defesas_vazaveis` existe no BTTS e
+    no Gols, com vereditos opostos na [0.1], e chavear por nome ou funde as duas ou multiplica a
+    tabela — as 39 linhas viram 38 ou 40 sem ninguém notar.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    OS NOVE PREDICADOS DE ESCOPO (#52). O eixo `pit_escopo` da medição solta `competition_id`
+    em nove sites, e é a eles que a coluna `predicado` aponta:
+
+      team_form_pit          o join do `team_log` (dois ramos: `pares` sob recorte de contagem,
+                             `pit` sob temporada) — a fonte de longe mais consumida
+      premissas_1x2.spine    o spine de xG do 1X2
+      premissas_ah.margin    o `margin_stats` (⚠️ o único SEM filtro de season no default)
+      premissas_btts.last5   os últimos 5 de BTTS
+      premissas_dc.hist      o `team_hist` (thrash_rate + last5_lost)
+      premissas_ou.spine     o spine de xG e de ritmo do Gols
+      premissas_ou.pool      o histórico dos times do pool da mediana de ritmo
+      premissas_ou.last5     os últimos 5 de gols
+
+    `nenhum` marca as fontes que o eixo NÃO alcança, e elas são de três tipos diferentes — a
+    tabela do campeonato (ADR 0008), o `fact_h2h` (já cruza) e o que não é histórico (boletim de
+    desfalques e preço). A distinção está em `juntavel`, não em `predicado`.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    VALORES ACEITOS
+
+    `escopo_hoje` — a resposta à segunda coluna do ticket:
+      competicao_e_temporada  o histórico é filtrado por competição E season (o caso comum)
+      competicao              filtrado só por competição: já atravessa temporada hoje
+      cruza_tudo              não é filtrado por nenhum dos dois
+      sem_historico           a premissa não lê passado
+      misto                   insumos de escopos diferentes na mesma premissa
+
+    `juntavel` — a resposta à terceira:
+      sim            o eixo de escopo alcança e o número muda
+      nao            há impedimento de definição; `impedimento` diz qual (obrigatório)
+      ja_junto       não há o que juntar: a fonte já cruza campeonatos hoje
+      nao_se_aplica  não lê histórico, então a pergunta não incide
+
+    `ressalva` é o que o leitor precisa saber para não tirar a conclusão errada da linha. Fica
+    separado de `impedimento` de propósito: impedimento é o que BARRA o merge, ressalva é o que
+    qualifica um merge que acontece.
+-#}
+
+{% macro taskf_fontes_de_historico() %}
+
+    {%- set fontes = [
+        {'mercado': '1X2', 'premissa': 'forca_mismatch',
+         'fonte': 'int_futebol_team_form_pit · gols pró/contra por venue',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': '1X2', 'premissa': 'superioridade_xg',
+         'fonte': 'int_futebol_premissas_1x2 · spine de xG sobre fact_fixture_stats',
+         'predicado': 'premissas_1x2.spine',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'xG não é coletado em toda competição; juntar o escopo não cria a cobertura que falta'},
+        {'mercado': '1X2', 'premissa': 'mando',
+         'fonte': 'int_futebol_team_form_pit · aproveitamento em casa e fora',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': '1X2', 'premissa': 'desfalque_adversario',
+         'fonte': 'int_futebol_desfalques · boletim do próprio jogo',
+         'predicado': 'nenhum',
+         'escopo_hoje': 'sem_historico', 'juntavel': 'nao_se_aplica',
+         'impedimento': '',
+         'ressalva': 'conta desfalque importante no jogo avaliado; não lê passado nenhum'},
+        {'mercado': '1X2', 'premissa': 'superioridade_tabela',
+         'fonte': 'int_futebol_team_form_pit · CTE `tabela` (rank e ppg)',
+         'predicado': 'nenhum',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'nao',
+         'impedimento': 'classificação só existe dentro de uma competição: não há rank num histórico juntado (ADR 0008)',
+         'ressalva': 'a alternativa séria — eleger uma competição principal por time — muda a definição da premissa e ficou para a [B]'},
+        {'mercado': '1X2', 'premissa': 'forma',
+         'fonte': 'int_futebol_team_form_pit · vitórias nos 5 jogos anteriores',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': '1X2', 'premissa': 'h2h_favoravel',
+         'fonte': 'fact_h2h · confronto direto',
+         'predicado': 'nenhum',
+         'escopo_hoje': 'cruza_tudo', 'juntavel': 'ja_junto',
+         'impedimento': '',
+         'ressalva': 'o join é por par de times e kickoff anterior, sem competição nem season — é a única fonte imune ao efeito medido'},
+
+        {'mercado': 'Handicap', 'premissa': 'supremacia',
+         'fonte': 'int_futebol_team_form_pit · CTE `tabela` (rank e ppg)',
+         'predicado': 'nenhum',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'nao',
+         'impedimento': 'classificação só existe dentro de uma competição: não há rank num histórico juntado (ADR 0008)',
+         'ressalva': ''},
+        {'mercado': 'Handicap', 'premissa': 'tende_golear',
+         'fonte': 'int_futebol_team_form_pit · gols pró/contra por venue',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Handicap', 'premissa': 'adversario_fragil_fora',
+         'fonte': 'int_futebol_team_form_pit · gols sofridos do adversário por venue',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Handicap', 'premissa': 'mando_forte',
+         'fonte': 'int_futebol_team_form_pit · aproveitamento em casa',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Handicap', 'premissa': 'sem_rodizio',
+         'fonte': 'int_futebol_team_form_pit · CTE `tabela` (rank) e tamanho da liga',
+         'predicado': 'nenhum',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'nao',
+         'impedimento': 'compara o rank contra o número de times da liga — nem o rank nem o `n_teams` existem num histórico juntado (ADR 0008)',
+         'ressalva': 'é a mais rígida das quatro de tabela: só acende em liga de pontos corridos, e por isso não se mexe em nenhum piso'},
+        {'mercado': 'Handicap', 'premissa': 'raramente_perde_por_2',
+         'fonte': 'int_futebol_premissas_ah · `margin_stats` sobre resultados anteriores',
+         'predicado': 'premissas_ah.margin',
+         'escopo_hoje': 'competicao', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'o `margin_stats` não filtra season nem hoje: já atravessa temporada, então aqui o eixo de recorte ENCOLHE o histórico em vez de alargá-lo'},
+        {'mercado': 'Handicap', 'premissa': 'defesa_fora_solida',
+         'fonte': 'int_futebol_team_form_pit · gols sofridos por venue',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Handicap', 'premissa': 'favorito_irregular',
+         'fonte': 'int_futebol_premissas_ah · `margin_stats` sobre resultados anteriores',
+         'predicado': 'premissas_ah.margin',
+         'escopo_hoje': 'competicao', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'mesma do `raramente_perde_por_2`: a fonte já atravessa temporada, e sob recorte ela encolhe'},
+
+        {'mercado': 'BTTS', 'premissa': 'ambos_marcam',
+         'fonte': 'int_futebol_team_form_pit · failed-to-score% dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'BTTS', 'premissa': 'ataque_dos_dois',
+         'fonte': 'int_futebol_team_form_pit · gols feitos por venue',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'BTTS', 'premissa': 'defesas_vazaveis',
+         'fonte': 'int_futebol_team_form_pit · clean sheet% dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'homônima da do Gols, com insumo e veredito próprios — as duas linhas não são a mesma premissa'},
+        {'mercado': 'BTTS', 'premissa': 'historico_btts',
+         'fonte': 'int_futebol_premissas_btts · últimos 5 jogos com os dois marcando',
+         'predicado': 'premissas_btts.last5',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'BTTS', 'premissa': 'defesa_forte',
+         'fonte': 'int_futebol_team_form_pit · clean sheet% dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'BTTS', 'premissa': 'ataque_trava',
+         'fonte': 'int_futebol_team_form_pit · failed-to-score% dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'BTTS', 'premissa': 'historico_seco',
+         'fonte': 'int_futebol_premissas_btts · últimos 5 jogos sem os dois marcarem',
+         'predicado': 'premissas_btts.last5',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+
+        {'mercado': 'Dupla Chance', 'premissa': 'lado_coberto_forte',
+         'fonte': 'int_futebol_premissas_1x2 · reuso de forca_mismatch OU superioridade_tabela',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'misto', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'metade juntável: `forca_mismatch` segue o eixo, `superioridade_tabela` não (ADR 0008) — e o OR basta para a premissa se mexer'},
+        {'mercado': 'Dupla Chance', 'premissa': 'equilibrio_defensivo',
+         'fonte': 'int_futebol_team_form_pit · gols sofridos + `team_hist` do DC (goleadas)',
+         'predicado': 'premissas_dc.hist',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Dupla Chance', 'premissa': 'adversario_limitado',
+         'fonte': 'int_futebol_team_form_pit · aproveitamento do adversário OU h2h reusado do 1X2',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'misto', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'reusa a única fonte imune (h2h) e ainda assim se mexe: imunidade só se herda quando TODOS os insumos são imunes'},
+        {'mercado': 'Dupla Chance', 'premissa': 'invicto_recente',
+         'fonte': 'int_futebol_premissas_dc · `team_hist` (derrotas nos últimos 5)',
+         'predicado': 'premissas_dc.hist',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+
+        {'mercado': 'Gols', 'premissa': 'ataque_combinado',
+         'fonte': 'int_futebol_team_form_pit · gols feitos por venue dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Gols', 'premissa': 'defesas_vazaveis',
+         'fonte': 'int_futebol_team_form_pit · gols sofridos por venue dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'homônima da do BTTS, com insumo e veredito próprios — as duas linhas não são a mesma premissa'},
+        {'mercado': 'Gols', 'premissa': 'xg_combinado_alto',
+         'fonte': 'int_futebol_premissas_ou · spine de xG sobre fact_fixture_stats',
+         'predicado': 'premissas_ou.spine',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'xG não é coletado em toda competição; juntar o escopo não cria a cobertura que falta'},
+        {'mercado': 'Gols', 'premissa': 'ritmo_alto',
+         'fonte': 'int_futebol_premissas_ou · ritmo dos dois times contra a mediana da liga',
+         'predicado': 'premissas_ou.pool',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'o POOL de times da mediana segue a competição do jogo em qualquer célula (é o benchmark "a liga em que estou jogando"); o que junta é o histórico de cada time do pool'},
+        {'mercado': 'Gols', 'premissa': 'ambos_vazam',
+         'fonte': 'int_futebol_team_form_pit · clean sheet% dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Gols', 'premissa': 'historico_over',
+         'fonte': 'int_futebol_premissas_ou · total de gols dos últimos 5 jogos',
+         'predicado': 'premissas_ou.last5',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Gols', 'premissa': 'linha_subindo',
+         'fonte': 'fact_odds_snapshot · consenso das casas de t24h para t15m',
+         'predicado': 'nenhum',
+         'escopo_hoje': 'sem_historico', 'juntavel': 'nao_se_aplica',
+         'impedimento': '',
+         'ressalva': 'lê preço, não passado: é a única família das 39 cujo insumo não é jogo anterior'},
+        {'mercado': 'Gols', 'premissa': 'defesas_firmes',
+         'fonte': 'int_futebol_team_form_pit · gols sofridos por venue dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Gols', 'premissa': 'clean_sheets_altos',
+         'fonte': 'int_futebol_team_form_pit · clean sheet% dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Gols', 'premissa': 'xg_baixo_combinado',
+         'fonte': 'int_futebol_premissas_ou · spine de xG sobre fact_fixture_stats',
+         'predicado': 'premissas_ou.spine',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '',
+         'ressalva': 'xG não é coletado em toda competição; juntar o escopo não cria a cobertura que falta'},
+        {'mercado': 'Gols', 'premissa': 'ataques_fracos',
+         'fonte': 'int_futebol_team_form_pit · failed-to-score% dos dois times',
+         'predicado': 'team_form_pit',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Gols', 'premissa': 'historico_under',
+         'fonte': 'int_futebol_premissas_ou · total de gols dos últimos 5 jogos',
+         'predicado': 'premissas_ou.last5',
+         'escopo_hoje': 'competicao_e_temporada', 'juntavel': 'sim',
+         'impedimento': '', 'ressalva': ''},
+        {'mercado': 'Gols', 'premissa': 'linha_descendo',
+         'fonte': 'fact_odds_snapshot · consenso das casas de t24h para t15m',
+         'predicado': 'nenhum',
+         'escopo_hoje': 'sem_historico', 'juntavel': 'nao_se_aplica',
+         'impedimento': '',
+         'ressalva': 'lê preço, não passado: é a única família das 39 cujo insumo não é jogo anterior'}
+    ] -%}
+
+    {#- ── A validação, nos DOIS sentidos ──────────────────────────────────────────────
+        O conjunto declarado tem de ser idêntico ao que a medição mede. As duas listas de
+        referência são as MESMAS que o taskf_teste2 usa: futebol_insumos_premissa() diz quais
+        colunas são premissa, e task01_markets() traduz modelo em mercado. Nenhuma terceira
+        cópia é digitada aqui — cópia que precisa ficar igual para sempre não fica. -#}
+    {%- set modelo_para_mercado = {} -%}
+    {%- for _, m in task01_markets().items() -%}
+        {%- do modelo_para_mercado.update({m.model: m.nome}) -%}
+    {%- endfor -%}
+
+    {%- set esperadas = [] -%}
+    {%- for p in futebol_insumos_premissa() if p.tipo == 'premissa' -%}
+        {%- do esperadas.append(modelo_para_mercado[p.modelo] ~ ' · ' ~ p.nome) -%}
+    {%- endfor -%}
+
+    {%- set declaradas = [] -%}
+    {%- for f in fontes -%}
+        {%- do declaradas.append(f.mercado ~ ' · ' ~ f.premissa) -%}
+    {%- endfor -%}
+
+    {%- set faltando = esperadas | reject('in', declaradas) | list -%}
+    {%- set sobrando = declaradas | reject('in', esperadas) | list -%}
+    {%- if faltando or sobrando -%}
+        {{ exceptions.raise_compiler_error(
+            "taskf_fontes_de_historico() saiu de sincronia com as premissas medidas. "
+            ~ "Sem declaração: [" ~ faltando | join(', ') ~ "]. "
+            ~ "Declarada mas não medida: [" ~ sobrando | join(', ') ~ "]. "
+            ~ "A fonte da verdade é futebol_insumos_premissa() (tipo='premissa') traduzida por "
+            ~ "task01_markets(); acrescente ou remova a linha aqui.") }}
+    {%- endif -%}
+    {#- Duplicata passaria pelas duas listas acima (as duas direções ficariam vazias) e só
+        apareceria como linha repetida na tabela do entregável. -#}
+    {%- if declaradas | unique | list | length != declaradas | length -%}
+        {{ exceptions.raise_compiler_error(
+            "taskf_fontes_de_historico() tem (mercado, premissa) repetido — a chave é o par, e "
+            ~ "duplicata vira linha a mais na tabela de 39.") }}
+    {%- endif -%}
+
+    {%- for f in fontes -%}
+        {%- if f.escopo_hoje not in ['competicao_e_temporada', 'competicao', 'cruza_tudo',
+                                     'sem_historico', 'misto'] -%}
+            {{ exceptions.raise_compiler_error(
+                "escopo_hoje inválido em '" ~ f.mercado ~ " · " ~ f.premissa ~ "': '"
+                ~ f.escopo_hoje ~ "'.") }}
+        {%- endif -%}
+        {%- if f.juntavel not in ['sim', 'nao', 'ja_junto', 'nao_se_aplica'] -%}
+            {{ exceptions.raise_compiler_error(
+                "juntavel inválido em '" ~ f.mercado ~ " · " ~ f.premissa ~ "': '"
+                ~ f.juntavel ~ "'.") }}
+        {%- endif -%}
+        {#- "o que impede" é metade da terceira coluna do ticket: um `nao` sem motivo entregaria
+            meia resposta, e um motivo em linha que junta confundiria quem lê. -#}
+        {%- if (f.juntavel == 'nao') != (f.impedimento | length > 0) -%}
+            {{ exceptions.raise_compiler_error(
+                "'" ~ f.mercado ~ " · " ~ f.premissa ~ "': `impedimento` tem de estar preenchido "
+                ~ "quando juntavel='nao' e vazio nos demais casos.") }}
+        {%- endif -%}
+    {%- endfor -%}
+
+    {{ return(fontes) }}
+
+{% endmacro %}

--- a/dbt_futebol/macros/taskf_pisos.sql
+++ b/dbt_futebol/macros/taskf_pisos.sql
@@ -25,3 +25,35 @@
 {% macro taskf_pisos() %}
     {{ return([0, 3, 5, 10]) }}
 {% endmacro %}
+
+
+{#
+    O QUE CONTA COMO "A PREMISSA SE MEXEU" NO PISO 0 — os quatro campos, escritos UMA vez.
+
+        n_p0            em quantas linhas de aposta a premissa acendeu
+        a_odd_dava_p0   o que o preço prometia nelas
+        aconteceu_p0    o que aconteceu de fato
+        diferenca_p0    a diferença entre os dois — o número do Teste 2
+
+    São os NOMES DE COLUNA da tabela acumulativa (`futebol_taskF.taskf_teste2`), e não os aliases
+    que cada análise cria depois de juntar duas células. Quem alia (a comparação entre células
+    chama `diferenca_p0` de `dif_p0`) traduz na hora de usar, e a tradução fica visível.
+
+    Por que num lugar só: "mexeu" é o veredito que a comparação entre células
+    (analyses/taskf_delta_celulas.sql) e o entregável (analyses/taskf_entregavel.sql) emitem sobre
+    a MESMA linha. Duas listas fariam as duas análises discordarem sobre a mesma premissa — e a
+    discordância seria muda, porque cada uma continuaria internamente coerente. É o mesmo
+    argumento do taskf_pisos() acima e da lista de valores aceitos do taskf_eixos().
+
+    ⚠️ `n_p0` entra de propósito: mudança no CONJUNTO de linhas em que a premissa acende é efeito,
+    não ruído. E o veredito é do piso 0 e só dele — nos pisos maiores até as premissas de tabela
+    mudam, porque o `min_jogos` segue a célula (ADR 0008, seção *Consequences*).
+
+    Uso:
+
+        {%- for campo in taskf_campos_do_piso0() %} ... {%- endfor %}
+#}
+
+{% macro taskf_campos_do_piso0() %}
+    {{ return(['n_p0', 'a_odd_dava_p0', 'aconteceu_p0', 'diferenca_p0']) }}
+{% endmacro %}

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -23,8 +23,9 @@ O escopo por competição existe, e é mais amplo do que o ticket supunha: não 
 `fact_standings_snapshot` (substituída pela correção da Task 0), e não é um lugar só. São **nove
 predicados** em seis modelos — o `int_futebol_team_form_pit` e as fontes de histórico próprias de
 cada mercado (os `last5` de Gols, BTTS e Dupla Chance, o `margin_stats` do Handicap, os spines de
-xG e de ritmo). **32 das 39 premissas** mudam de número quando ele é solto; as outras 7 não mudam,
-e cada uma tem motivo declarado.
+xG e de ritmo). **32 das 39 premissas** mudam de número quando ele é solto; as outras 7 ficam
+imóveis **no piso 0**, cada uma com motivo declarado — e ⚠️ *imóvel no piso 0 não quer dizer
+imóvel*: **cinco delas mudam no piso 5**, porque o `min_jogos` segue a célula (ADR 0008).
 
 O que o merge entrega é **amostra**: o universo que satisfaz `min_jogos >= 5` sobe de **69 para 92
 jogos** sem jogar nada fora, a amostra curta média cai de **45,5% para 34,5%** e os jogos médios
@@ -44,8 +45,9 @@ evidência (`superioridade_xg` e `tende_golear`).
 sem conserto.** Na Copa do Mundo o deserto é real e não artefato: **0% dos pares (jogo, time)
 ganham uma única partida** ao soltar a competição, porque seleção não joga mais nada na nossa base;
 dos 79 jogos dela no universo, 2 passam o piso 5, antes e depois. A Champions não tem **um** jogo
-no universo congelado — os 8 do período caem depois do teto —, e no universo estendido, onde ela
-existe, nenhum dos 18 passa o piso.
+no universo congelado, e por dois mecanismos somados: as **56 partidas** que ela jogou dentro da
+janela não têm preço coletado (a coleta da UCL entrou em 31/07) e as 8 que têm preço caem depois do
+teto. No universo estendido, onde ela existe, nenhum dos 18 passa o piso.
 
 ⚠️ **E a quebra por família não tem o que dizer nesta janela.** O universo congelado é **100%
 ano-calendário**: as ligas split-year não tinham começado em 16/06–04/08. Célula vazia é *sem
@@ -148,11 +150,18 @@ sudamericana 15 (8,9%), copa_do_brasil 8 (4,7%). Os 46,7% da Copa do Mundo batem
 amostra" que a spec #49 atribui a ela, e Copa do Brasil + Sudamericana somam 23, contra os "cerca
 de 24 jogos" que a spec estima que o merge recupera.
 
-⚠️ **A Champions não tem UM jogo no universo primário.** Os únicos jogos dela na janela são os 8
-de 04/08 à noite, e o corte os remove. A pergunta da spec sobre a fase classificatória da
-Champions (user story 24) não tem amostra nenhuma no universo congelado — quem for executar a
-#58 precisa saber disso antes de desenhar a resposta, porque ela terá de sair do universo
-estendido ou de lugar nenhum.
+⚠️ **A Champions não tem UM jogo no universo primário.** Os únicos jogos dela **com preço
+coletado** na janela são os 8 de 04/08 à noite, e o corte os remove. A pergunta da spec sobre a
+fase classificatória da Champions (user story 24) não tem amostra nenhuma no universo congelado —
+quem for executar a #58 precisa saber disso antes de desenhar a resposta, porque ela terá de sair
+do universo estendido ou de lugar nenhum.
+
+⚠️ *Precisado na #59.* Esta frase dizia "os únicos jogos dela na janela", sem o qualificador, e
+assim ela é falsa: a Champions **jogou 56 partidas dentro da janela**, de 07/07 a 29/07, todas
+encerradas e todas **antes** do teto. Nenhuma delas tem uma linha em `fact_odds_snapshot` — a
+coleta da UCL entrou no ar em 31/07 —, e o universo exige preço. São **dois** mecanismos
+independentes zerando a Champions, e só o segundo estava escrito: 56 jogos sem preço, mais 8 com
+preço depois do teto. A conclusão não muda; a explicação, sim.
 
 ### A tolerância, declarada
 
@@ -518,9 +527,11 @@ mesmo rótulo, e `escopo` junta os dois normalmente. **A [B] não deve herdar "e
 ajuda a Europa" como regra** — o que esta medição mostra é que, nesta janela, não há como
 verificar.
 
-Some-se a isso o que a #51 já registrou: os únicos jogos de Champions do período são os 8 de 04/08
-à noite, removidos pelo teto do universo congelado. A pergunta da spec sobre a fase
-classificatória da Champions (user story 24) segue sem amostra no universo primário.
+Some-se a isso o que a #51 já registrou: os únicos jogos de Champions do período **com preço
+coletado** são os 8 de 04/08 à noite, removidos pelo teto do universo congelado (as 56 partidas
+que ela jogou dentro da janela não têm preço nenhum — ver a precisão feita na #59, na seção da
+#51). A pergunta da spec sobre a fase classificatória da Champions (user story 24) segue sem
+amostra no universo primário.
 
 ### O que mudou nas 39 premissas
 
@@ -2384,9 +2395,27 @@ jogo, e se dá para juntar. `dbt compile` + `bq query`, e nada de `dbt build`.
 
 **As 39 linhas fecham, e a metade declarada delas está conferida contra a medição, não afirmada.**
 Das 39 premissas do catálogo, **32 se mexem** quando o histórico deixa de ser limitado à competição
-do jogo, **3** não se mexem por definição (as de tabela, ADR 0008), **1** já cruza campeonatos hoje
-(`h2h_favoravel`) e **3** não leem histórico nenhum (`desfalque_adversario` e as duas de movimento
-de linha). As 39 linhas da declaração batem uma a uma com o que a medição fez: **zero `DIVERGE`**.
+do jogo. As outras 7 ficam imóveis **no piso 0**: **3** por definição (as de tabela, ADR 0008),
+**1** porque já cruza campeonatos hoje (`h2h_favoravel`) e **3** porque não leem histórico nenhum
+(`desfalque_adversario` e as duas de movimento de linha). As 39 linhas da declaração batem uma a
+uma com o que a medição fez: **zero `DIVERGE`**.
+
+⚠️ **Imóvel no piso 0 não quer dizer imóvel.** **Cinco das sete** mudam no piso 5, porque o piso é
+propriedade do **jogo** e não da premissa: com o histórico junto, jogos que não passavam passam a
+passar, e a premissa é avaliada sobre um conjunto maior de linhas.
+
+| imóvel no piso 0 | n no piso 5 | diferença no piso 5 | mexe no piso 5? |
+|---|---|---|---|
+| `h2h_favoravel` (1X2) | 41 → 52 | −12,9 → −10,7 | **sim** |
+| `superioridade_tabela` (1X2) | 35 → 47 | −8,2 → −6,1 | **sim** |
+| `supremacia` (Handicap) | 95 → 121 | −6,0 → −6,4 | **sim** |
+| `linha_descendo` (Gols) | 213 → 296 | +5,5 → +3,8 | **sim** |
+| `linha_subindo` (Gols) | 96 → 116 | +0,8 → −6,6 | **sim** |
+| `sem_rodizio` (Handicap) | 188 → 188 | −2,7 → −2,7 | não |
+| `desfalque_adversario` (1X2) | 7 → 7 | −24,9 → −24,9 | não |
+
+As duas que não se mexem em piso nenhum são as de ponta oposta: `sem_rodizio` só acende em jogo com
+histórico longo (188 linhas nos quatro pisos) e `desfalque_adversario` acende em 7 linhas no total.
 
 O ganho de amostra é o que a spec previu e maior do que ela estimou no piso: o universo que
 satisfaz `min_jogos >= 5` sobe de **69 para 92 jogos** sem jogar nada fora, e a soma dos `n` do
@@ -2511,8 +2540,9 @@ segunda mão e **se mexe** (`n_p0` 160 → 165), porque a outra metade da defini
 
 A coluna "família" das 39 linhas vale `ano-calendário` nas 39 porque **o universo congelado inteiro
 é ano-calendário**. A janela (16/06 a 04/08) cai na virada de temporada europeia: as cinco ligas
-split-year ainda não tinham começado, e os únicos jogos de Champions do período são os 8 de 04/08 à
-noite, que o teto do universo remove.
+split-year ainda não tinham começado, e a Champions — que jogou 56 partidas de qualificatória
+dentro da janela — não entra no universo porque nenhuma delas tem preço coletado (a coleta da UCL
+entrou em 31/07); as 8 que têm preço são de 04/08 à noite, depois do teto.
 
 ⚠️ **Célula vazia é SEM AMOSTRA, nunca efeito nulo.** Não se pode concluir daqui que juntar
 campeonato não ajuda as europeias. O que se sabe sobre elas é mecânico, não medido: nesta janela o
@@ -2545,8 +2575,38 @@ do ticket original.
 | o **universo congelado** medido (169 jogos com linha de aposta) | 79 | **0** | 79 | 46,7% |
 
 A afirmação da spec é verdadeira sobre a **janela de jogos encerrados**, não sobre o universo em
-que as 39 linhas foram medidas — ali a Champions vale zero, porque o teto das 12:00 UTC de 04/08
-remove os 8 jogos dela e não sobra nenhum.
+que as 39 linhas foram medidas — ali a Champions vale zero.
+
+⚠️ **E o motivo do zero não é o teto, ou não só ele.** As 56 partidas de Champions da janela são
+todas encerradas e todas **anteriores** ao corte (07/07 a 29/07); o que as mantém fora do universo
+é não terem **uma linha sequer** em `fact_odds_snapshot` — a coleta da UCL entrou no ar em 31/07, e
+o universo é jogo com preço. O teto explica os **outros 8**, de 04/08 à noite, esses sim com preço.
+Os dois mecanismos são disjuntos e somam 64; medido:
+
+| jogos de Champions | partidas | encerradas | com preço coletado | período |
+|---|---|---|---|---|
+| dentro do teto (na janela medida) | **56** | 56 | **0** | 07/07 → 29/07 |
+| depois do teto | 8 | 8 | 8 | 04/08 |
+
+E não é um caso especial da Champions: **o universo é aposta, não partida**, e os dois filtros que
+o produzem — status `FT` (o `jogos_encerrados` do `task01_base()`) e ter preço coletado —
+reconstroem a composição dos 169 exatamente, competição a competição:
+
+| competição | encerradas na janela | `FT` | com preço | **`FT` + preço** | no universo (#51) |
+|---|---|---|---|---|---|
+| copa_mundo | 89 | 80 | 88 | **79** | 79 |
+| serie_b | 73 | 73 | 39 | **39** | 39 |
+| champions_league | 56 | 51 | **0** | **0** | 0 |
+| brasileirao | 28 | 28 | 28 | **28** | 28 |
+| sudamericana | 16 | 15 | 16 | **15** | 15 |
+| copa_do_brasil | 8 | 8 | 8 | **8** | 8 |
+| **total** | **270** | 255 | 179 | **169** | **169** |
+
+A Série B é a segunda demonstração: 73 jogos disputados e **39** no universo, porque a coleta dela
+entrou em 09/07 e a janela começa em 16/06. Quem ler "a Champions não tem amostra" como "a
+Champions não jogou" tira a conclusão errada sobre o que falta — **falta preço, não futebol**, e é
+por isso que ampliar a coleta (a task [C]) e juntar o histórico (esta) são alavancas diferentes
+sobre o mesmo problema.
 
 E "seguem de amostra curta" é literal nas duas:
 
@@ -2644,6 +2704,27 @@ nada mais depende do número (a recomendação de manter a Copa do Mundo se apoi
 piso 5 dentro dos 79, que não mudam). O aprendizado é o que a `taskf_publicado_01` já dizia sobre
 transcrever número para dentro de texto — **e vale para este documento tanto quanto para o da
 [0.1]**.
+
+### ⚠️ O que a revisão pegou, e que nenhuma guarda pegaria
+
+Seis correções, e **nenhuma delas move um número** — a saída depois de todas é idêntica linha a
+linha à de antes. Ficam registradas porque três são de conteúdo, não de forma:
+
+| o que | por que importava |
+|---|---|
+| **a Champions não é zerada pelo teto** — são 56 jogos sem preço mais 8 depois do corte | a explicação publicada não cobria as 56, e ela vinha da #51; a conclusão não muda, o mecanismo sim |
+| **"as 7 não mudam" virou "não mudam no piso 0"** | cinco das sete mudam no piso 5, e o texto do veredito dizia o contrário do que a própria tabela mostra |
+| **o cabeçalho da análise citava números errados** sobre o corte do `bq query` | é a falha que a regra de abertura deste documento existe para evitar: número dentro de comentário envelhece sozinho |
+| **`campos_piso0` era uma segunda cópia** da lista que define "mexeu" | duas definições fariam esta análise e a `taskf_delta_celulas` discordarem sobre a mesma linha; extraída para `taskf_campos_do_piso0()`, com o SQL compilado das duas conferido idêntico |
+| **o universo não era fail-closed** | a célula era validada e o universo não; agora passa por `taskf_universo_valido()` e o predicado sai do mesmo nome |
+| **a ordenação omitia `benchmark`** | é parte do grão: sem ele, duas execuções podem sair em ordem diferente e a comparação linha a linha acusaria diferença onde não há |
+
+E uma sexta quebra, esta de autoria: o comentário que documenta a ordenação **fechava com o traço**
+e comeu a quebra de linha, colando o `ORDER BY` no `CROSS JOIN` acima — exatamente o que o
+comentário da #37 fez com o `task01_base()` (commit `b535130`). O `bq query` recusou com erro de
+sintaxe, alto. E ao documentar isso dentro do próprio comentário, a sequência de fechamento
+escrita no texto **encerrou o comentário no meio** e despejou o resto como SQL. As duas quebraram
+antes de qualquer número sair.
 
 ### Reprodução
 

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -2684,5 +2684,9 @@ O `taskf_entregavel` sai com **60 linhas** — 39 no bloco `principal` e 21 no `
 `taskf_familia_e_mecanismo` com **16** (13 de competição, 2 de família e 1 de total). O
 `fora_do_universo` do `taskf_exclusao` sai com **seis linhas de `copa_mundo`**, somando 10.
 
+Rodado duas vezes seguidas, o `taskf_entregavel` devolve CSV **idêntico linha a linha** — que é o
+que "o lote está congelado" quer dizer em fato verificável, e não em promessa. Ele lê tabela
+gravada e não reconstrói nada; a deriva de odds que a #51 documentou não o alcança.
+
 ⚠️ **Sem `--max_rows` o `bq query` corta em 100 linhas sem avisar**, e são 60 mais o cabeçalho de
 progresso; com o anexo junto a margem é pequena. É o mesmo corte silencioso da #57.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -2067,10 +2067,17 @@ declarado é o universo de placebo — remover 79 jogos sorteados por hash e com
 contra a distribuição do placebo. Ele continua não tendo sido rodado, e continua sendo a única
 coisa que mudaria a leitura desta linha.
 
-**De passagem, a mesma tabela mostra que a Copa do Mundo jogou 88 e não 79.** Nove partidas
-encerradas dela ficam fora do universo: oito por status (5 PEN e 3 AET — mata-mata decidido fora
-do tempo normal, o caso da issue #71) e **uma** por não ter preço coletado, na primeira rodada de
-grupos. O deserto de histórico dela, portanto, é medido sobre 79 dos 88 jogos que aconteceram.
+**De passagem, a mesma tabela mostra que a Copa do Mundo jogou 89 e não 79.** Dez partidas
+encerradas dela ficam fora do universo: **nove por status** (5 AET e 4 PEN — mata-mata decidido
+fora do tempo normal, o caso da issue #71) e **uma** por não ter preço coletado, na primeira rodada
+de grupos. O deserto de histórico dela, portanto, é medido sobre 79 dos 89 jogos que aconteceram.
+
+⚠️ *Corrigido na #59.* Este parágrafo dizia "88 … oito por status (5 PEN e 3 AET)". O bloco
+`fora_do_universo`, que não mudou, sempre devolveu **seis linhas somando 10** — AET 1+2+2 = 5 e
+PEN 1+3 = 4, mais a sem preço —, e a contagem direta no `fact_fixtures` confirma 80 FT + 5 AET +
+4 PEN = **89** na janela. Era erro de transcrição da prosa, não da medição: os rótulos de AET e PEN
+saíram trocados e uma partida se perdeu na soma. É o mesmo modo de falha que a
+`macros/taskf_publicado_01.sql` documenta sobre transcrever número para dentro do texto.
 
 ⚠️ **E a exclusão não é aleatória no tempo.** Tirar a Copa do Mundo não tira 47% dos jogos
 espalhados pela janela: tira **os primeiros 24 dias dela**. O universo `sem_copa_mundo` começa em
@@ -2620,6 +2627,24 @@ saiu com `WHERE celula = ''`, devolveu zero linha, e as 39 premissas apareceram 
 `taskf_nomes_de_celula().values()` e levanta erro de compilação. É o mesmo modo de falha que o
 fail-closed do `taskf_eixos()` existe para fechar, numa porta que ninguém tinha fechado.
 
+### ⚠️ O que apareceu no caminho: a #58 publicou 88 onde a query diz 89
+
+Contar as partidas encerradas da janela para responder ao critério de aceite deste ticket colidiu
+com um número já publicado: a seção da #58 dizia que a Copa do Mundo "jogou 88", com nove partidas
+fora do universo, "oito por status (5 PEN e 3 AET)".
+
+O `fact_fixtures` diz **80 FT + 5 AET + 4 PEN = 89**, nos dois datasets (produção e medição), e o
+bloco `fora_do_universo` do próprio `taskf_exclusao` — re-executado sem nenhuma alteração — devolve
+**seis linhas somando 10**: AET 1 + 2 + 2 = 5, PEN 1 + 3 = 4, mais a partida sem preço coletado.
+79 + 10 = 89.
+
+**A medição estava certa e a prosa errada**: os rótulos de AET e PEN saíram trocados e uma partida
+se perdeu na soma. A seção da #58 foi corrigida no lugar, com a marca de que a correção é da #59;
+nada mais depende do número (a recomendação de manter a Copa do Mundo se apoia nos 2 jogos acima do
+piso 5 dentro dos 79, que não mudam). O aprendizado é o que a `taskf_publicado_01` já dizia sobre
+transcrever número para dentro de texto — **e vale para este documento tanto quanto para o da
+[0.1]**.
+
 ### Reprodução
 
 ```bash
@@ -2648,10 +2673,16 @@ SELECT competition,
        COUNTIF(status_short IN ('FT', 'AET', 'PEN')) AS encerrados
 FROM janela GROUP BY competition ORDER BY encerrados DESC
 SQL
+
+# a correção do 88 → 89: o bloco `fora_do_universo` da #58, re-executado sem alteração nenhuma
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_exclusao
+bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=500 \
+  < target/compiled/dbt_futebol/analyses/taskf_exclusao.sql
 ```
 
 O `taskf_entregavel` sai com **60 linhas** — 39 no bloco `principal` e 21 no `anexo` — e o
-`taskf_familia_e_mecanismo` com **16** (13 de competição, 2 de família e 1 de total).
+`taskf_familia_e_mecanismo` com **16** (13 de competição, 2 de família e 1 de total). O
+`fora_do_universo` do `taskf_exclusao` sai com **seis linhas de `copa_mundo`**, somando 10.
 
 ⚠️ **Sem `--max_rows` o `bq query` corta em 100 linhas sem avisar**, e são 60 mais o cabeçalho de
 progresso; com o anexo junto a margem é pequena. É o mesmo corte silencioso da #57.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -6,6 +6,88 @@ acrescenta a sua seção aqui. O SQL que produz cada número está em `dbt_futeb
 Os resultados moram neste arquivo, e não no cabeçalho das análises, para que o SQL mude quando a
 lógica muda e não quando os números mudam. Mesmo padrão do `TASK01_RESULTADOS.md`.
 
+**As 39 linhas que o ticket de origem pediu estão na [seção do #59](#ticket-59--o-entregável-as-39-linhas-e-o-que-o-merge-não-conserta).**
+
+---
+
+# Veredito
+
+## A pergunta do ticket
+
+> **O histórico de cada premissa está contado dentro da competição do jogo — e juntar os
+> campeonatos muda os números o bastante para valer.**
+
+**As duas metades são verdadeiras, e a segunda entrega amostra, não sinal novo.**
+
+O escopo por competição existe, e é mais amplo do que o ticket supunha: não é a
+`fact_standings_snapshot` (substituída pela correção da Task 0), e não é um lugar só. São **nove
+predicados** em seis modelos — o `int_futebol_team_form_pit` e as fontes de histórico próprias de
+cada mercado (os `last5` de Gols, BTTS e Dupla Chance, o `margin_stats` do Handicap, os spines de
+xG e de ritmo). **32 das 39 premissas** mudam de número quando ele é solto; as outras 7 não mudam,
+e cada uma tem motivo declarado.
+
+O que o merge entrega é **amostra**: o universo que satisfaz `min_jogos >= 5` sobe de **69 para 92
+jogos** sem jogar nada fora, a amostra curta média cai de **45,5% para 34,5%** e os jogos médios
+por premissa vão de **10,5 para 12,9**. Nas linhas de aposta do piso 5, de 3.746 para 4.931
+(+31,6%). O ganho não vem só das competições resgatadas: **os jogos já medidos também mudam** —
+num jogo de Brasileirão cada time ganha em média **5,75** partidas de histórico, e num de Copa do
+Brasil, **24,25** (média sobre todos os pares (jogo, time), inclusive os que não ganham nada).
+
+E ele **não** infla o catálogo: o número de premissas com peso positivo no piso 5 **cai de 15 para
+11**. Duas das quatro premissas que a spec apontou como "muito sinal, pouca amostra" sobrevivem
+quando o histórico é real (`clean_sheets_altos` e `defesa_forte`); as outras duas continuam sem
+evidência (`superioridade_xg` e `tende_golear`).
+
+## O que o merge não conserta
+
+**Copa do Mundo e Champions somam 53,7% das partidas encerradas da janela — 145 de 270 — e seguem
+sem conserto.** Na Copa do Mundo o deserto é real e não artefato: **0% dos pares (jogo, time)
+ganham uma única partida** ao soltar a competição, porque seleção não joga mais nada na nossa base;
+dos 79 jogos dela no universo, 2 passam o piso 5, antes e depois. A Champions não tem **um** jogo
+no universo congelado — os 8 do período caem depois do teto —, e no universo estendido, onde ela
+existe, nenhum dos 18 passa o piso.
+
+⚠️ **E a quebra por família não tem o que dizer nesta janela.** O universo congelado é **100%
+ano-calendário**: as ligas split-year não tinham começado em 16/06–04/08. Célula vazia é *sem
+amostra*, nunca *efeito nulo* — não se pode concluir daqui nada sobre as europeias.
+
+## Recomendações
+
+**1. Juntar o escopo — sim, e é uma mudança de pipeline, não de peso.** A medição sustenta soltar
+`competition_id` nas nove fontes de histórico. O que ela entrega é amostra e a evidência que a [B]
+vai ler; o que ela **não** entrega é peso novo, e reescrever peso a partir destes números repetiria
+o erro que a [0.1] mediu (+10,0% in-sample virando −6,2% out-of-sample).
+
+**2. As quatro de tabela ficam fora do merge, e a alternativa é decisão da [B].** `rank`, `ppg` e
+`n_teams` não existem num histórico juntado (ADR 0008). Eleger uma "competição principal" por time
+é a alternativa séria — ela muda a definição da premissa, e por isso ficou adiada, não descartada.
+
+**3. Não excluir Copa do Mundo nem a fase classificatória da Champions.** Nenhuma das duas
+exclusões se sustenta na medição (#58): o piso de amostra já faz o trabalho que elas fariam, e o
+eixo de escopo move a ordenação muito mais (ρ = 0,648) do que a maior das exclusões (0,964).
+
+**4. O merge cobra, e o preço está medido (#57):** 1,46 titular a mais de rodízio entre liga e copa
+(6,88 de 11 repetidos, contra 8,34 entre dois jogos de liga) e **40,7% das partidas emprestadas
+contra adversário que a coleta não alcança**. Nenhum dos dois inverte a recomendação; os dois
+entram na [B] como ressalva com número.
+
+**5. "Escopo sozinho não ajuda a Europa" NÃO é regra geral.** Vale para esta janela, que cai
+inteira na virada de temporada — em janeiro, liga nacional e Champions estão sob o mesmo rótulo de
+`season` e o escopo junta os dois normalmente. Quem implementar precisa decidir o eixo de recorte
+com o calendário na mão, e não a partir deste número.
+
+---
+
+## Carimbo de execução
+
+**Toda tabela deste documento sai de um lote único de medição, e o #59 não o moveu.** As quatro
+células foram medidas na mesma execução da #58; este ticket compila e consulta, sem reconstruir
+nada — um rebuild produziria outro lote e o 2×2 deixaria de ser comparável.
+
+| Execução | Corte do universo | Origem dos números |
+|---|---|---|
+| células em 2026-08-13 17:49–17:56 UTC, commit `7fdd1a3` | `kickoff` em [16/06, 04/08 12:00 UTC) — **169 jogos** | `futebol_taskF.taskf_teste2` · `odds_loaded_at` 12/08 13:24:15 · 16 grupos célula × universo, todos com o mesmo sha |
+
 ---
 
 ## Ticket #51 — Célula `base` ponta a ponta
@@ -2276,3 +2358,300 @@ três), com `ERROR=0` e `SKIP=0` — iguais aos da #54 e da #55.
 
 ⚠️ **Sem `--max_rows` o `bq query` corta em 100 linhas sem avisar**, e o `taskf_exclusao` emite
 mais do que isso. É o mesmo corte silencioso que a #57 documentou.
+
+---
+
+## Ticket #59 — O entregável: as 39 linhas, e o que o merge não conserta
+
+`analyses/taskf_entregavel.sql` + `macros/taskf_fontes_de_historico.sql` · leitura do lote medido
+na #58 (células de 2026-08-13 17:49–17:56 UTC, commit `7fdd1a3`, `odds_loaded_at` 12/08 13:24:15)
+· dataset `futebol_taskF`
+
+**Este ticket não mede — ele junta.** Todas as células já existem na tabela acumulativa desde a
+#58, e reconstruir qualquer uma delas hoje produziria um lote novo, quebrando a mesma-execução que
+torna o 2×2 comparável. O que este ticket acrescenta é a metade do entregável que **não** sai de
+query nenhuma: de qual modelo cada premissa puxa o histórico, se aquilo é limitado à competição do
+jogo, e se dá para juntar. `dbt compile` + `bq query`, e nada de `dbt build`.
+
+### Veredito
+
+**As 39 linhas fecham, e a metade declarada delas está conferida contra a medição, não afirmada.**
+Das 39 premissas do catálogo, **32 se mexem** quando o histórico deixa de ser limitado à competição
+do jogo, **3** não se mexem por definição (as de tabela, ADR 0008), **1** já cruza campeonatos hoje
+(`h2h_favoravel`) e **3** não leem histórico nenhum (`desfalque_adversario` e as duas de movimento
+de linha). As 39 linhas da declaração batem uma a uma com o que a medição fez: **zero `DIVERGE`**.
+
+O ganho de amostra é o que a spec previu e maior do que ela estimou no piso: o universo que
+satisfaz `min_jogos >= 5` sobe de **69 para 92 jogos** sem jogar nada fora, e a soma dos `n` do
+piso 5 nas 39 vai de **3.746 para 4.931 linhas de aposta** (+31,6%).
+
+E o que ele **não** conserta continua sendo mais da metade da janela: Copa do Mundo e Champions
+somam **53,7% das partidas encerradas** no período (145 de 270) e seguem sem histórico para
+emprestar — a Copa do Mundo porque os times dela não jogam mais nada na nossa base (**0% dos pares
+ganham uma única partida** ao soltar a competição), a Champions porque não tem um jogo sequer no
+universo congelado.
+
+### As quatro colunas do ticket, e de onde cada uma sai
+
+| coluna do ticket | onde mora | como não apodrece |
+|---|---|---|
+| de onde puxa o histórico | `macros/taskf_fontes_de_historico.sql` (`fonte`, `predicado`) | erro de compilação se o conjunto declarado divergir de `futebol_insumos_premissa()` |
+| se a janela é limitada à competição | idem (`escopo_hoje`) | idem |
+| se dá para juntar, e o que impede | idem (`juntavel`, `impedimento`) | idem, **mais** a conferência contra a medição: quem é declarado imóvel tem de sair imóvel |
+| o que o número vira | `futebol_taskF.taskf_teste2`, células `base` → `escopo` | é medição, não declaração |
+
+A quarta coluna é o par que responde à pergunta literal do ticket: "juntar os campeonatos" é o eixo
+de **escopo**. O eixo de recorte e o 2×2 completo estão nas seções das #53 e #54, e não se repetem
+aqui.
+
+⚠️ **A declaração é confrontada com a medição, e é isso que a separa de uma opinião bem
+formatada.** Uma premissa declarada "não dá para juntar" cujo número muda entre `base` e `escopo`
+sai marcada `DIVERGE` na coluna `confere` da análise. Hoje são **60 de 60 `CONFERE`** — as 39 do
+benchmark preferido e as 21 do anexo.
+
+### As 39 linhas
+
+Uma por premissa, no benchmark preferido de cada mercado (sharp para 1X2, Handicap e Gols;
+derivada para Dupla Chance; consenso para BTTS). `piso 0` e `piso 5` são a **diferença** do Teste 2
+— quanto o resultado real superou o que a odd dava —, e o `n` do piso 5 é quantas linhas de aposta
+sobraram nele.
+
+| mercado | premissa | de onde puxa o histórico | limitada à competição? | dá para juntar? | piso 0: diferença | piso 5: diferença (n) | família |
+|---|---|---|---|---|---|---|---|
+| 1X2 | `desfalque_adversario` | desfalques · boletim do próprio jogo | não lê histórico | não se aplica — lê o boletim de desfalques do próprio jogo | **−24,9 → −24,9** ⁽ⁱ⁾ | −24,9 → −24,9 (7 → 7) | ano-calendário |
+| 1X2 | `forca_mismatch` | team_form_pit · gols pró/contra por venue | sim — competição + temporada | sim | −3,1 → +1,4 | −12,6 → −5,5 (18 → 24) | ano-calendário |
+| 1X2 | `forma` | team_form_pit · vitórias nos 5 jogos anteriores | sim — competição + temporada | sim | −1,4 → −0,8 | −5,9 → −5,3 (45 → 69) | ano-calendário |
+| 1X2 | `h2h_favoravel` | fact_h2h · confronto direto | não — já cruza tudo | já junto — o `fact_h2h` já cruza campeonatos hoje | **−10,7 → −10,7** ⁽ⁱ⁾ | −12,9 → −10,7 (41 → 52) | ano-calendário |
+| 1X2 | `mando` | team_form_pit · aproveitamento em casa e fora | sim — competição + temporada | sim | +2,4 → +3,9 | −6,4 → −2,6 (48 → 75) | ano-calendário |
+| 1X2 | `superioridade_tabela` | team_form_pit · CTE `tabela` (rank e ppg) | sim — competição + temporada | não — rank/ppg só existem dentro da competição (ADR 0008) | **+0,8 → +0,8** ⁽ⁱ⁾ | −8,2 → −6,1 (35 → 47) | ano-calendário |
+| 1X2 | `superioridade_xg` | premissas_1x2 · spine de xG sobre fact_fixture_stats | sim — competição + temporada | sim | +5,2 → +4,3 | −8,9 → −4,1 (31 → 44) | ano-calendário |
+| BTTS | `ambos_marcam` | team_form_pit · failed-to-score% dos dois times | sim — competição + temporada | sim | −2,5 → −1,8 | +1,7 → −1,9 (25 → 36) | ano-calendário |
+| BTTS | `ataque_dos_dois` | team_form_pit · gols feitos por venue | sim — competição + temporada | sim | +11,9 → +0,3 | +4,0 → −11,0 (20 → 26) | ano-calendário |
+| BTTS | `ataque_trava` | team_form_pit · failed-to-score% dos dois times | sim — competição + temporada | sim | −2,2 → −3,3 | −8,4 → −3,4 (36 → 36) | ano-calendário |
+| BTTS | `defesa_forte` | team_form_pit · clean sheet% dos dois times | sim — competição + temporada | sim | +2,8 → +1,9 | −3,3 → +10,3 (12 → 28) | ano-calendário |
+| BTTS | `defesas_vazaveis` | team_form_pit · clean sheet% dos dois times | sim — competição + temporada | sim | +2,2 → −2,3 | +8,7 → +1,6 (31 → 36) | ano-calendário |
+| BTTS | `historico_btts` | premissas_btts · últimos 5 jogos com os dois marcando | sim — competição + temporada | sim | +0,0 → −15,5 | +0,0 → −15,5 (16 → 15) | ano-calendário |
+| BTTS | `historico_seco` | premissas_btts · últimos 5 jogos sem os dois marcarem | sim — competição + temporada | sim | −0,9 → −1,8 | −8,6 → −3,1 (53 → 77) | ano-calendário |
+| Dupla Chance | `adversario_limitado` | team_form_pit · aproveitamento do adversário OU h2h reusado do 1X2 | misto — ver ressalva | sim | +0,7 → +1,2 | +0,6 → +1,8 (80 → 101) | ano-calendário |
+| Dupla Chance | `equilibrio_defensivo` | team_form_pit · gols sofridos + `team_hist` do DC (goleadas) | sim — competição + temporada | sim | +2,0 → −1,6 | +6,4 → +1,9 (66 → 86) | ano-calendário |
+| Dupla Chance | `invicto_recente` | premissas_dc · `team_hist` (derrotas nos últimos 5) | sim — competição + temporada | sim | −10,7 → −4,5 | −16,5 → −4,5 (17 → 23) | ano-calendário |
+| Dupla Chance | `lado_coberto_forte` | premissas_1x2 · reuso de forca_mismatch OU superioridade_tabela | misto — ver ressalva | sim | +2,8 → +1,0 | +0,9 → +0,0 (47 → 63) | ano-calendário |
+| Gols | `ambos_vazam` | team_form_pit · clean sheet% dos dois times | sim — competição + temporada | sim | −3,7 → −3,2 | −11,7 → −8,0 (156 → 176) | ano-calendário |
+| Gols | `ataque_combinado` | team_form_pit · gols feitos por venue dos dois times | sim — competição + temporada | sim | −3,6 → −2,9 | −6,0 → −7,3 (117 → 155) | ano-calendário |
+| Gols | `ataques_fracos` | team_form_pit · failed-to-score% dos dois times | sim — competição + temporada | sim | +2,1 → −0,4 | −1,1 → −2,5 (178 → 178) | ano-calendário |
+| Gols | `clean_sheets_altos` | team_form_pit · clean sheet% dos dois times | sim — competição + temporada | sim | +17,1 → +14,9 | −1,7 → +6,3 (24 → 35) | ano-calendário |
+| Gols | `defesas_firmes` | team_form_pit · gols sofridos por venue dos dois times | sim — competição + temporada | sim | +3,7 → +1,9 | +0,7 → +1,5 (146 → 212) | ano-calendário |
+| Gols | `defesas_vazaveis` | team_form_pit · gols sofridos por venue dos dois times | sim — competição + temporada | sim | −5,0 → −4,6 | −5,8 → −5,8 (158 → 201) | ano-calendário |
+| Gols | `historico_over` | premissas_ou · total de gols dos últimos 5 jogos | sim — competição + temporada | sim | −0,5 → −1,8 | −6,0 → −6,7 (104 → 122) | ano-calendário |
+| Gols | `historico_under` | premissas_ou · total de gols dos últimos 5 jogos | sim — competição + temporada | sim | +1,5 → +6,8 | +1,2 → +6,7 (139 → 183) | ano-calendário |
+| Gols | `linha_descendo` | fact_odds_snapshot · consenso das casas de t24h para t15m | não lê histórico | não se aplica — lê preço (consenso t24h→t15m) | **+3,2 → +3,2** ⁽ⁱ⁾ | +5,5 → +3,8 (213 → 296) | ano-calendário |
+| Gols | `linha_subindo` | fact_odds_snapshot · consenso das casas de t24h para t15m | não lê histórico | não se aplica — lê preço (consenso t24h→t15m) | **−1,5 → −1,5** ⁽ⁱ⁾ | +0,8 → −6,6 (96 → 116) | ano-calendário |
+| Gols | `ritmo_alto` | premissas_ou · ritmo dos dois times contra a mediana da liga | sim — competição + temporada | sim | −5,3 → −6,2 | −6,9 → −11,2 (162 → 288) | ano-calendário |
+| Gols | `xg_baixo_combinado` | premissas_ou · spine de xG sobre fact_fixture_stats | sim — competição + temporada | sim | +1,5 → +1,0 | +3,6 → +2,1 (133 → 178) | ano-calendário |
+| Gols | `xg_combinado_alto` | premissas_ou · spine de xG sobre fact_fixture_stats | sim — competição + temporada | sim | −2,6 → −1,9 | −3,4 → −4,9 (129 → 158) | ano-calendário |
+| Handicap | `adversario_fragil_fora` | team_form_pit · gols sofridos do adversário por venue | sim — competição + temporada | sim | −2,8 → −1,5 | −11,0 → −5,8 (113 → 138) | ano-calendário |
+| Handicap | `defesa_fora_solida` | team_form_pit · gols sofridos por venue | sim — competição + temporada | sim | +3,9 → +0,5 | +2,6 → −1,3 (134 → 190) | ano-calendário |
+| Handicap | `favorito_irregular` | premissas_ah · `margin_stats` sobre resultados anteriores | sim — só competição (já cruza temporada) | sim | +5,9 → +6,4 | +7,1 → +6,4 (374 → 493) | ano-calendário |
+| Handicap | `mando_forte` | team_form_pit · aproveitamento em casa | sim — competição + temporada | sim | −3,1 → −3,0 | −10,2 → −7,7 (89 → 168) | ano-calendário |
+| Handicap | `raramente_perde_por_2` | premissas_ah · `margin_stats` sobre resultados anteriores | sim — só competição (já cruza temporada) | sim | +6,3 → +7,8 | +7,4 → +8,0 (352 → 469) | ano-calendário |
+| Handicap | `sem_rodizio` | team_form_pit · CTE `tabela` (rank) e tamanho da liga | sim — competição + temporada | não — rank **e** `n_teams` não existem juntando (ADR 0008) | **−2,7 → −2,7** ⁽ⁱ⁾ | −2,7 → −2,7 (188 → 188) | ano-calendário |
+| Handicap | `supremacia` | team_form_pit · CTE `tabela` (rank e ppg) | sim — competição + temporada | não — rank/ppg só existem dentro da competição (ADR 0008) | **−1,9 → −1,9** ⁽ⁱ⁾ | −6,0 → −6,4 (95 → 121) | ano-calendário |
+| Handicap | `tende_golear` | team_form_pit · gols pró/contra por venue | sim — competição + temporada | sim | +3,9 → +5,7 | −18,5 → −22,7 (18 → 21) | ano-calendário |
+
+⁽ⁱ⁾ **imóvel no piso 0**: a premissa acende exatamente nas mesmas linhas nas duas células. Ela
+ainda muda nos pisos maiores, porque o `min_jogos` segue a célula — é a seção *Consequences* da
+ADR 0008, e não uma inconsistência.
+
+No agregado das 39: amostra curta média **45,5% → 34,5%**, jogos médios **10,5 → 12,9**, e o número
+de premissas com peso positivo no piso 5 cai de **15 para 11**. O merge não infla o catálogo: ele
+recompõe quem tem evidência.
+
+### As sete que não mudam, e por quê
+
+O critério de aceite pede que elas apareçam com o motivo. São **sete**, e o motivo é de três tipos
+diferentes:
+
+| premissa | mercado | por que não muda |
+|---|---|---|
+| `superioridade_tabela` | 1X2 | premissa de tabela: rank e ppg saem do agregado competição-scoped do PIT em qualquer célula (ADR 0008) |
+| `supremacia` | Handicap | idem |
+| `sem_rodizio` | Handicap | idem, e ainda compara o rank contra o `n_teams` da liga — número que não existe num histórico juntado |
+| `h2h_favoravel` | 1X2 | o `fact_h2h` já cruza campeonatos e temporadas hoje; restringi-lo seria mudar premissa |
+| `desfalque_adversario` | 1X2 | lê o boletim de desfalques do próprio jogo — não lê passado |
+| `linha_subindo` | Gols | lê preço: consenso das casas de t24h para t15m |
+| `linha_descendo` | Gols | idem |
+
+⚠️ **O ticket diz "as quatro de tabela"; no catálogo medido são três.** A quarta que a ADR 0008
+nomeia, `x_superioridade_tabela`, **não é premissa**: é coluna interna do
+`int_futebol_premissas_1x2` que a Dupla Chance reusa dentro do `lado_coberto_forte` — e este também
+lê `forca_mismatch`, que segue o eixo, então ele se mexe. A leitura corrigida já é a que a Costura
+B (#55) implementa; o enunciado da spec não foi editado porque ele é o registro do que se sabia
+antes de medir.
+
+⚠️ **Reusar fonte imune não dá imunidade.** `adversario_limitado` (DC) consome o `fact_h2h` de
+segunda mão e **se mexe** (`n_p0` 160 → 165), porque a outra metade da definição —
+`o_aproveitamento < 45` — sai do PIT. A regra, para a [B]: uma premissa só herda imunidade se
+**todos** os seus insumos forem imunes.
+
+### A quebra por família é degenerada — e é isso que ela tem a dizer
+
+`analyses/taskf_familia_e_mecanismo.sql`, re-executada neste ticket e idêntica à da #53:
+
+| família | jogos no universo | % | pares com ganho | ganho médio por par | piso 5: base → escopo |
+|---|---|---|---|---|---|
+| ano-calendário | **169** | 100,0% | 44,7% | 3,43 | 69 → 92 |
+| split-year | **0** | 0,0% | — | — | 0 → 0 |
+
+A coluna "família" das 39 linhas vale `ano-calendário` nas 39 porque **o universo congelado inteiro
+é ano-calendário**. A janela (16/06 a 04/08) cai na virada de temporada europeia: as cinco ligas
+split-year ainda não tinham começado, e os únicos jogos de Champions do período são os 8 de 04/08 à
+noite, que o teto do universo remove.
+
+⚠️ **Célula vazia é SEM AMOSTRA, nunca efeito nulo.** Não se pode concluir daqui que juntar
+campeonato não ajuda as europeias. O que se sabe sobre elas é mecânico, não medido: nesta janela o
+rótulo de `season` do time europeu vira no meio do ano, e como o eixo de escopo não toca o filtro
+de season, só a célula `ambos` alcançaria esse caso. Em janeiro, o mesmo time tem liga nacional e
+Champions sob o mesmo rótulo e `escopo` junta os dois normalmente.
+
+Por competição, o mecanismo é muito desigual — e é ele que explica de onde vêm os 23 jogos que
+cruzam o piso:
+
+| competição | jogos | pares com ganho | ganho médio | piso 5: base → escopo |
+|---|---|---|---|---|
+| copa_mundo | 79 | **0,0%** | 0,00 | 2 → 2 |
+| serie_b | 39 | 70,5% | 2,23 | 39 → 39 |
+| brasileirao | 28 | 100,0% | 5,75 | 28 → 28 |
+| sudamericana | 15 | 80,0% | 9,17 | **0 → 15** |
+| copa_do_brasil | 8 | 100,0% | 24,25 | **0 → 8** |
+
+### O que o merge NÃO conserta
+
+O critério de aceite pede que isto fique declarado, e a spec #49 o enuncia como "Copa do Mundo e
+Champions somam 139 encerrados — 53% da janela". **O percentual confere; a contagem não, e os dois
+números respondem a denominadores diferentes** — o mesmo cuidado que a #56 teve com as duas colunas
+do ticket original.
+
+| denominador | Copa do Mundo | Champions | soma | % |
+|---|---|---|---|---|
+| partidas **encerradas** na janela (`FT`+`AET`+`PEN`), 270 | 89 | 56 | **145** | **53,7%** |
+| o mesmo, só `FT`, 255 | 80 | 51 | 131 | 51,4% |
+| o **universo congelado** medido (169 jogos com linha de aposta) | 79 | **0** | 79 | 46,7% |
+
+A afirmação da spec é verdadeira sobre a **janela de jogos encerrados**, não sobre o universo em
+que as 39 linhas foram medidas — ali a Champions vale zero, porque o teto das 12:00 UTC de 04/08
+remove os 8 jogos dela e não sobra nenhum.
+
+E "seguem de amostra curta" é literal nas duas:
+
+- **Copa do Mundo** — 79 dos 169 jogos do universo, e **2** deles passam o piso 5. O merge não move
+  isso: **0% dos pares (jogo, time) ganham uma única partida** ao soltar a competição, porque
+  seleção não joga outra competição na nossa base. É deserto real, não artefato de escopo.
+- **Champions** — zero jogo no universo congelado. No estendido, onde ela existe (18 jogos), a #58
+  mediu que **nenhum** passa o piso 5, nem em `base` nem em `escopo`.
+
+Junte-se a isso o que a #58 já fechou: **nenhuma das duas exclusões se sustenta**, porque o piso de
+amostra já faz o trabalho que a exclusão faria. Não há o que remover — há o que **não** esperar do
+merge.
+
+### O anexo: as 21 linhas de benchmark não-preferido
+
+Marcadas `usado_para_peso = false` na medição e **não usadas para peso**. Elas existem porque a
+diferença de ROI entre benchmarks é informação sobre **quais jogos a Pinnacle escolhe precificar**,
+não sobre o benchmark — o achado da [0.1] que sobreviveu a tudo. São as linhas de consenso do
+Handicap e do Gols.
+
+| mercado | premissa | benchmark | de onde puxa o histórico | limitada à competição? | dá para juntar? | piso 0: diferença | piso 5: diferença (n) | família |
+|---|---|---|---|---|---|---|---|---|
+| Gols | `ambos_vazam` | consenso | team_form_pit · clean sheet% dos dois times | sim — competição + temporada | sim | −2,3 → −2,7 | −7,7 → −6,6 (173 → 206) | ano-calendário |
+| Gols | `ataque_combinado` | consenso | team_form_pit · gols feitos por venue dos dois times | sim — competição + temporada | sim | −5,9 → −5,6 | −4,4 → −7,7 (111 → 152) | ano-calendário |
+| Gols | `ataques_fracos` | consenso | team_form_pit · failed-to-score% dos dois times | sim — competição + temporada | sim | +1,9 → −0,4 | +0,0 → −0,5 (194 → 195) | ano-calendário |
+| Gols | `clean_sheets_altos` | consenso | team_form_pit · clean sheet% dos dois times | sim — competição + temporada | sim | +10,3 → +8,2 | +4,2 → +9,7 (26 → 33) | ano-calendário |
+| Gols | `defesas_firmes` | consenso | team_form_pit · gols sofridos por venue dos dois times | sim — competição + temporada | sim | +3,2 → +3,0 | +1,7 → +2,6 (258 → 355) | ano-calendário |
+| Gols | `defesas_vazaveis` | consenso | team_form_pit · gols sofridos por venue dos dois times | sim — competição + temporada | sim | −4,7 → −5,2 | −4,7 → −7,8 (117 → 157) | ano-calendário |
+| Gols | `historico_over` | consenso | premissas_ou · total de gols dos últimos 5 jogos | sim — competição + temporada | sim | −2,7 → −5,5 | −5,4 → −7,9 (98 → 131) | ano-calendário |
+| Gols | `historico_under` | consenso | premissas_ou · total de gols dos últimos 5 jogos | sim — competição + temporada | sim | +1,5 → +2,3 | +2,0 → +2,7 (257 → 349) | ano-calendário |
+| Gols | `linha_descendo` | consenso | fact_odds_snapshot · consenso das casas de t24h para t15m | não lê histórico | não se aplica — lê preço (consenso t24h→t15m) | **+1,9 → +1,9** ⁽ⁱ⁾ | +3,7 → +2,8 (193 → 261) | ano-calendário |
+| Gols | `linha_subindo` | consenso | fact_odds_snapshot · consenso das casas de t24h para t15m | não lê histórico | não se aplica — lê preço (consenso t24h→t15m) | **−3,7 → −3,7** ⁽ⁱ⁾ | −2,7 → −6,0 (104 → 138) | ano-calendário |
+| Gols | `ritmo_alto` | consenso | premissas_ou · ritmo dos dois times contra a mediana da liga | sim — competição + temporada | sim | −1,9 → −2,9 | −2,3 → −6,6 (194 → 337) | ano-calendário |
+| Gols | `xg_baixo_combinado` | consenso | premissas_ou · spine de xG sobre fact_fixture_stats | sim — competição + temporada | sim | +1,8 → +1,8 | +2,4 → +2,8 (266 → 358) | ano-calendário |
+| Gols | `xg_combinado_alto` | consenso | premissas_ou · spine de xG sobre fact_fixture_stats | sim — competição + temporada | sim | −3,7 → −4,1 | −3,6 → −6,9 (114 → 157) | ano-calendário |
+| Handicap | `adversario_fragil_fora` | consenso | team_form_pit · gols sofridos do adversário por venue | sim — competição + temporada | sim | −4,9 → −2,9 | −4,5 → −2,1 (91 → 101) | ano-calendário |
+| Handicap | `defesa_fora_solida` | consenso | team_form_pit · gols sofridos por venue | sim — competição + temporada | sim | +5,1 → +4,3 | +5,1 → +4,0 (136 → 207) | ano-calendário |
+| Handicap | `favorito_irregular` | consenso | premissas_ah · `margin_stats` sobre resultados anteriores | sim — só competição (já cruza temporada) | sim | +5,6 → +5,4 | +6,6 → +5,4 (346 → 464) | ano-calendário |
+| Handicap | `mando_forte` | consenso | team_form_pit · aproveitamento em casa | sim — competição + temporada | sim | −9,7 → −10,5 | −12,7 → −9,7 (63 → 119) | ano-calendário |
+| Handicap | `raramente_perde_por_2` | consenso | premissas_ah · `margin_stats` sobre resultados anteriores | sim — só competição (já cruza temporada) | sim | +6,4 → +6,1 | +7,1 → +6,0 (332 → 448) | ano-calendário |
+| Handicap | `sem_rodizio` | consenso | team_form_pit · CTE `tabela` (rank) e tamanho da liga | sim — competição + temporada | não — rank **e** `n_teams` não existem juntando (ADR 0008) | **−6,0 → −6,0** ⁽ⁱ⁾ | −6,0 → −6,0 (177 → 177) | ano-calendário |
+| Handicap | `supremacia` | consenso | team_form_pit · CTE `tabela` (rank e ppg) | sim — competição + temporada | não — rank/ppg só existem dentro da competição (ADR 0008) | **−1,3 → −1,3** ⁽ⁱ⁾ | −1,5 → −0,3 (68 → 98) | ano-calendário |
+| Handicap | `tende_golear` | consenso | team_form_pit · gols pró/contra por venue | sim — competição + temporada | sim | −7,6 → −7,0 | +2,1 → −1,0 (14 → 17) | ano-calendário |
+
+### As conferências que a tabela carrega
+
+Nenhuma delas é afirmação no texto: as quatro saem como coluna da própria análise.
+
+| conferência | o que cobra | resultado |
+|---|---|---|
+| `cobertura` | declaração e medição cobrem o mesmo conjunto | 60/60 `CONFERE` |
+| `confere` | declarado imóvel ⟺ medido imóvel no piso 0 | 60/60 `CONFERE`, zero `DIVERGE` |
+| `lote` | as 16 combinações célula × universo têm um `git_sha` e um `odds_loaded_at` só | `HOMOGENEO (16 grupos)` |
+| `confere_universo` | a camada materializada agora é a que produziu a medição | 169 = 169 |
+
+A quarta existe porque a quebra por família é a única parte desta análise que lê a camada
+**materializada** (para saber quais jogos entram no universo), enquanto o resto lê a tabela de
+medição. Se alguém rematerializar uma célula com outro recorte, os dois números se separam e a
+tabela denuncia em vez de misturar.
+
+### A falsificação: quatro quebras, quatro vermelhos
+
+A validação da declaração foi quebrada de propósito antes de ser publicada, para não ser guarda de
+enfeite:
+
+| quebra | o que aconteceu |
+|---|---|
+| premissa removida da declaração (`1X2 · mando`) | erro de compilação: `Sem declaração: [1X2 · mando]` |
+| `defesas_vazaveis` do BTTS declarada como Gols | erro de compilação — é o caso que uma chave por nome esconderia |
+| `1X2 · forma` declarada duas vezes | erro de compilação: `(mercado, premissa) repetido` |
+| `juntavel = 'nao'` com `impedimento` vazio | erro de compilação: meia resposta à terceira coluna do ticket |
+
+⚠️ **E uma quinta quebra apareceu sozinha, na primeira execução.** A análise lia o nome da célula
+com `taskf_nomes_de_celula()['da_competicao_temporada']` — chave com `_` onde a macro usa `|`. O
+Jinja resolve chave inexistente como `Undefined`, que é renderizado como **string vazia**: o SQL
+saiu com `WHERE celula = ''`, devolveu zero linha, e as 39 premissas apareceram como
+`SEM_MEDICAO` — que se parece com um achado. A análise passou a validar os dois nomes contra
+`taskf_nomes_de_celula().values()` e levanta erro de compilação. É o mesmo modo de falha que o
+fail-closed do `taskf_eixos()` existe para fechar, numa porta que ninguém tinha fechado.
+
+### Reprodução
+
+```bash
+cd dbt_futebol
+
+# NADA de `dbt build` aqui: as quatro células são as da #58 e um rebuild produziria outro lote.
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+  --select taskf_entregavel taskf_familia_e_mecanismo
+
+bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=200 \
+  < target/compiled/dbt_futebol/analyses/taskf_entregavel.sql
+bq query --use_legacy_sql=false --project_id=smartbetting-dados --max_rows=100 \
+  < target/compiled/dbt_futebol/analyses/taskf_familia_e_mecanismo.sql
+
+# o número da seção "o que o merge não conserta", que não sai de análise nenhuma
+bq query --use_legacy_sql=false --project_id=smartbetting-dados <<'SQL'
+WITH janela AS (
+    SELECT fixture_id, competition, status_short
+    FROM `smartbetting-dados.futebol.fact_fixtures`
+    WHERE kickoff_utc >= TIMESTAMP('2026-06-16')
+      AND kickoff_utc <  TIMESTAMP('2026-08-04 12:00:00')
+)
+SELECT competition,
+       COUNT(*)                                      AS agendados,
+       COUNTIF(status_short = 'FT')                  AS ft,
+       COUNTIF(status_short IN ('FT', 'AET', 'PEN')) AS encerrados
+FROM janela GROUP BY competition ORDER BY encerrados DESC
+SQL
+```
+
+O `taskf_entregavel` sai com **60 linhas** — 39 no bloco `principal` e 21 no `anexo` — e o
+`taskf_familia_e_mecanismo` com **16** (13 de competição, 2 de família e 1 de total).
+
+⚠️ **Sem `--max_rows` o `bq query` corta em 100 linhas sem avisar**, e são 60 mais o cabeçalho de
+progresso; com o anexo junto a margem é pequena. É o mesmo corte silencioso da #57.


### PR DESCRIPTION
O entregável que o ticket de origem pediu, publicado onde a pergunta foi feita: as 39 linhas, uma
por premissa, com as quatro colunas dele mais a quebra por família — e o doc de resultados no padrão
do da [0.1].

**Este ticket não mede — ele junta.** As quatro células são as da #58 e nenhuma foi reconstruída:
um rebuild produziria outro lote e o 2×2 deixaria de ser comparável. `dbt compile` + `bq query`, e
nada de `dbt build`.

## O entregável

| | |
|---|---|
| **as 39 linhas** | benchmark preferido de cada mercado, com as 4 colunas do ticket + família |
| **o anexo** | 21 linhas de benchmark não-preferido, marcadas `usado_para_peso = false` |
| **quantas se mexem** | **32 das 39**; 3 não por definição (ADR 0008), 1 já cruza (`h2h_favoravel`), 3 não leem histórico |
| **o ganho** | piso 5 de **69 → 92 jogos** sem jogar nada fora; amostra curta média 45,5% → 34,5% |
| **o catálogo não infla** | premissas com peso positivo no piso 5 **caem de 15 para 11** |

## A metade do entregável que não sai de query

Três das quatro colunas do ticket são leitura de código, não medição. Elas viram declaração em
`macros/taskf_fontes_de_historico.sql`, chaveada por **(mercado, premissa)** — nunca por premissa
sozinha, porque `defesas_vazaveis` existe no BTTS e no Gols com vereditos opostos, e uma chave por
nome faria as 39 virarem 38 ou 40 em silêncio.

Declaração que ninguém confere apodrece. Duas defesas:

```
compilacao  o conjunto declarado tem de ser exatamente o que futebol_insumos_premissa()
            lista como premissa, traduzido por task01_markets()  -> fail-closed
leitura     quem e declarado nao-juntavel tem de sair IMOVEL no piso 0, e quem e declarado
            juntavel tem de se mexer  -> coluna `confere` da analise, hoje 60 de 60
```

A segunda é a que importa: nenhuma checagem de nome pegaria uma linha que diz "não dá para juntar"
sobre uma premissa cujo número muda. **Quatro quebras de propósito, quatro vermelhos** — premissa
removida, premissa no mercado errado, linha duplicada e `juntavel='nao'` sem `impedimento`.

## O que o merge NÃO conserta

O critério de aceite pede que isto fique declarado. A spec #49 o enuncia como "139 encerrados — 53%
da janela"; **o percentual confere e a contagem não**, e os dois números respondem a denominadores
diferentes:

```
partidas encerradas na janela (FT+AET+PEN), 270   CdM 89 + UCL 56 = 145   53,7%
o mesmo, so FT, 255                               CdM 80 + UCL 51 = 131   51,4%
o universo congelado medido, 169                  CdM 79 + UCL  0 =  79   46,7%
```

Na Copa do Mundo o deserto é real e não artefato de escopo: **0% dos pares (jogo, time) ganham uma
única partida** ao soltar a competição — seleção não joga mais nada na nossa base. A Champions não
tem um jogo sequer no universo congelado, e por dois mecanismos somados (56 sem preço + 8 depois do
teto), não pelo teto sozinho — ver os achados abaixo.

## Achados de percurso

- **a #58 publicou 88 onde a própria query dela diz 89.** A prosa trocou os rótulos de AET e PEN e
  perdeu uma partida na soma; o bloco `fora_do_universo`, re-executado sem alteração, devolve seis
  linhas somando 10, e o `fact_fixtures` diz 80 FT + 5 AET + 4 PEN. Corrigido no lugar, com a marca
  de que a correção é da #59. Nada mais depende do número;
- **chave de dicionário inexistente no Jinja vira string vazia, não erro.** A análise lia
  `taskf_nomes_de_celula()['da_competicao_temporada']` (com `_` onde a macro usa `|`), o SQL saiu
  com `WHERE celula = ''` e as 39 premissas apareceram como `SEM_MEDICAO` — que se parece com um
  achado. Agora os dois nomes são validados contra os valores da macro, fail-closed;
- **a Champions não é zerada pelo teto do universo, e a explicação publicada só cobria metade.**
  Ela jogou **56 partidas dentro da janela**, todas encerradas e todas antes do corte, e nenhuma
  tem linha em `fact_odds_snapshot` — a coleta da UCL entrou em 31/07. O teto explica os *outros*
  8, de 04/08. Entra no doc a decomposição que reconstrói os 169 competição a competição
  (`FT` + preço = 79/39/0/28/15/8): **o universo é aposta, não partida**;
- **a quebra por família é degenerada nesta janela, e isso é conteúdo.** O universo congelado é
  100% ano-calendário: as split-year não tinham começado. Célula vazia é *sem amostra*, nunca
  *efeito nulo*.

## O que a revisão mudou

Revisão em dois eixos (standards e spec) sobre o diff. **Seis correções, nenhuma move um número** —
a saída depois delas é idêntica linha a linha. Três de conteúdo (a Champions acima, "as 7 não
mudam" → "não mudam **no piso 0**" porque cinco delas mudam no piso 5, e números errados no
cabeçalho sobre o corte do `bq query`) e três de forma, as três a mesma doença: `campos_piso0` era
uma segunda cópia da lista que define "mexeu" (extraída para `taskf_campos_do_piso0()`, com o SQL
compilado da `taskf_delta_celulas` conferido idêntico antes e depois), o universo não era
fail-closed, e a ordenação omitia `benchmark`.

## Validação

`dbt parse` e `dbt compile` do projeto inteiro limpos; `dbt test` verde nas cinco guardas que
cobrem exatamente a tabela de onde este entregável lê — `assert_taskf_base_reproduz_01`,
`assert_taskf_celulas_mesmo_universo`, `assert_taskf_contagens_por_recorte`,
`assert_taskf_premissas_de_tabela_identicas` e `assert_premissas_insumo_declarado` (PASS=5,
ERROR=0). Nenhum modelo foi tocado.

Closes #59
Closes #49
