### PR TITLE
feat(futebol): o contador de desfalques deixa de afirmar zero (#42)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -116,6 +116,16 @@ answered "nothing". The two are indistinguishable downstream unless the asking i
 recorded, and the Motor then reports the second while in fact holding the first.
 _Avoid_: dado faltante (silent about which of the two it is)
 
+**Registro de coleta** (vazio registrado):
+The record that we *asked* the source about a fixture, kept even when the answer was
+empty. It is what lets a counter be zero on purpose: a desfalque count of zero is earned
+either by a real list for that team or by a pre-kickoff record for that fixture — the
+poll returns the whole match in one call. Without a record and without a list, the count
+is NULL, and NULL neither fires the opponent-desfalque premissa nor certifies our side as
+complete. The record is per (fixture, day) and lives apart from the injury rows, since an
+empty answer is a fact about the asking, not about a player.
+_Avoid_: linha vazia (it is not a row of the injury list; it is the receipt of the call)
+
 ### Odds and value
 
 **Edge**:
@@ -208,6 +218,12 @@ A player missing a fixture. Only a desfalque of a titular importante fires premi
 roughly two to three days out and not before — so on the earlier part of the board the
 premissa has **no input**, which is not the same as a negative one.
 _Avoid_: injury (a desfalque may be suspension or other absence)
+
+Catalogue decision (#42, for whoever runs the Limpeza): **desfalque_adversario stays**.
+The hypothesis that its −24,9 in Teste 2 was this bug is **falsified** — that number was
+measured on the nine best-informed lines in the base, every one of them with a real list
+for the backed side, not on the blind ones. What survives is that its n is too small to
+measure anything, which is a reason to keep it and re-measure, not a reason to cut it.
 
 **Escalação confirmada**:
 The starting eleven as announced before kickoff, roughly forty minutes out — distinct

--- a/dbt_futebol/macros/premissas_insumos.sql
+++ b/dbt_futebol/macros/premissas_insumos.sql
@@ -50,9 +50,12 @@
     registradas aqui porque quem acrescentar premissa nova vai recriá-las sem perceber:
 
       (a) COALESCE para ZERO na própria `metrics`. Era o caso de n_wins_last5 e h2h_total
-          (removidos na #41) e ainda é o de s_missing/o_missing, que só a #42 alcança —
-          ela depende do vazio registrado (data-engineering#33) para ter de onde tirar o NULL.
-          Enquanto isso, `desfalque_adversario` é a ÚNICA das 39 que o contador não enxerga.
+          (removidos na #41) e de s_missing/o_missing (removido na #42, que dependia do vazio
+          registrado de data-engineering#33 para ter de onde tirar o NULL). Nenhuma das 39
+          está fora do alcance do contador hoje. ⚠️ O zero de desfalque agora é MERECIDO —
+          contagem real do time OU registro de coleta pré-apito (stg_futebol_injuries_coleta).
+          Repor um COALESCE ali não deixa nada vermelho por si: devolve a cegueira ao estado
+          de "premissa avaliada", que é o disfarce que esta classe descreve.
       (b) CONTAGEM sobre array vazio ou NULL — os `(SELECT COUNT(*) FROM UNNEST(last5_*))` de
           Gols, BTTS e Dupla Chance, e o n_wins_last5 que vem do team_form_pit. Devolvem 0 sem
           nenhum NULL para detectar, e o zero é indistinguível de "cinco jogos, nenhum deles

--- a/dbt_futebol/macros/premissas_sem_dado.sql
+++ b/dbt_futebol/macros/premissas_sem_dado.sql
@@ -33,11 +33,11 @@
     sabemos. Marcador também não — ele nem soma nem subtrai.
 
     ⚠️ SÓ ENXERGA A AUSÊNCIA QUE CHEGA COMO NULL. Insumo COALESCEado antes daqui é
-    indistinguível de valor real e o contador o dá por presente. Depois da #41 isso vale para
-    UMA premissa: `desfalque_adversario`, cujos s_missing/o_missing seguem COALESCEados para
-    zero até a #42 (que espera o vazio registrado de data-engineering#33). As outras 38 têm
-    insumo capaz de expressar ausência. As três classes de disfarce estão no cabeçalho do
-    macros/premissas_insumos.sql. -#}
+    indistinguível de valor real e o contador o dá por presente. Depois da #42 as 39 premissas
+    têm insumo capaz de expressar ausência — `desfalque_adversario` era a última, e o NULL dela
+    só existe porque a coleta passou a registrar o vazio (data-engineering#33). As três classes
+    de disfarce estão no cabeçalho do macros/premissas_insumos.sql, e nenhuma delas fica
+    vermelha sozinha: quem repuser um COALESCE cala o contador em silêncio. -#}
 {% macro futebol_premissas_cegas(modelo) %}
     {%- set premissas = [] -%}
     {%- for p in futebol_insumos_premissa() if p.modelo == modelo and p.tipo == 'premissa' -%}

--- a/dbt_futebol/models/intermediate/_int_futebol__unit_tests.yml
+++ b/dbt_futebol/models/intermediate/_int_futebol__unit_tests.yml
@@ -21,11 +21,11 @@ version: 2
 #      colidem exatamente aqui, e a decisão — "meio insumo não é meia premissa",
 #      registrada no gerador — só vira fato asserido nesta linha.
 #
-# A fixture 2 conta 6, e não 7, DE PROPÓSITO: `desfalque_adversario` lê s_missing
-# e o_missing, que seguem COALESCEados para zero até a #42 (que depende do vazio
-# registrado de data-engineering#33). O 6 é o contorno exato do que a #41 entrega
-# — se ele virar 7 sem a #42 ter sido feita, alguém removeu um COALESCE cuja
-# ausência ainda não tem de onde vir.
+# A fixture 2 conta 7 — as SETE premissas do 1X2 — desde a #42, que tirou o último
+# COALESCE (s_missing/o_missing) e ligou `desfalque_adversario` ao contador. Enquanto
+# a #41 era a entrega mais nova, este número era 6 de propósito: sem o vazio registrado
+# (data-engineering#33) não havia de onde tirar o NULL do desfalque. Se ele voltar a 6,
+# alguém repôs o COALESCE ou o registro de coleta parou de chegar.
 # ==============================================================================
 unit_tests:
   - name: premissas_1x2_contador_separa_cegueira_de_evidencia_contraria
@@ -65,6 +65,12 @@ unit_tests:
           - {fixture_id: 1, team_id: 10, injury_type: 'Questionable', is_important: false}
           - {fixture_id: 1, team_id: 20, injury_type: 'Questionable', is_important: false}
 
+      - input: ref('stg_futebol_injuries_coleta')
+        rows:
+          # Só a fixture 1 foi perguntada antes do apito — é o que torna o zero dela
+          # legítimo. As fixtures 2 e 3 nunca foram, e por isso o desfalque delas é cego.
+          - {fixture_id: 1, snapshot_date: '2026-08-01', coletado_em: '2026-08-01 08:00:00'}
+
       - input: ref('fact_h2h')
         rows:
           # Um confronto direto anterior, vencido pelo time 20 (mandante lá).
@@ -81,19 +87,20 @@ unit_tests:
         - {fixture_id: 1, outcome: 'Draw', pts_premissas: 0, forma: false, h2h_favoravel: false, premissas_sem_dado: 0}
 
         # ---- fixture 2: insumo ausente -----------------------------------------
-        # 6 das 7 cegas; desfalque_adversario fica de fora até a #42 (ver cabeçalho).
-        - {fixture_id: 2, outcome: 'Home', pts_premissas: 0, forma: false, h2h_favoravel: false, premissas_sem_dado: 6}
-        - {fixture_id: 2, outcome: 'Away', pts_premissas: 0, forma: false, h2h_favoravel: false, premissas_sem_dado: 6}
+        # As 7 cegas — nunca perguntamos por este jogo, então o desfalque entra junto.
+        - {fixture_id: 2, outcome: 'Home', pts_premissas: 0, forma: false, h2h_favoravel: false, premissas_sem_dado: 7}
+        - {fixture_id: 2, outcome: 'Away', pts_premissas: 0, forma: false, h2h_favoravel: false, premissas_sem_dado: 7}
         - {fixture_id: 2, outcome: 'Draw', pts_premissas: 0, forma: false, h2h_favoravel: false, premissas_sem_dado: 0}
 
         # ---- fixture 3: insumo pela metade ---------------------------------------
         # Home (S=50, o lado que TEM dados): forca_mismatch tem s_gf_venue presente e
         # desfavorável (0,5) e o_ga_venue ausente -> CEGA, não "avaliada e não acendeu".
-        # Cegas: forca_mismatch, superioridade_xg, superioridade_tabela, h2h_favoravel = 4.
-        # mando e forma NÃO contam: o insumo que importa do lado mandante existe.
-        - {fixture_id: 3, outcome: 'Home', pts_premissas: 0, forma: false, mando: false, premissas_sem_dado: 4}
-        # Away (S=60, o lado sem nada): as mesmas 6 da fixture 2.
-        - {fixture_id: 3, outcome: 'Away', pts_premissas: 0, forma: false, mando: false, premissas_sem_dado: 6}
+        # Cegas: forca_mismatch, superioridade_xg, superioridade_tabela, h2h_favoravel e
+        # desfalque_adversario (sem registro de coleta dos dois lados) = 5. mando e forma
+        # NÃO contam: o insumo que importa do lado mandante existe.
+        - {fixture_id: 3, outcome: 'Home', pts_premissas: 0, forma: false, mando: false, premissas_sem_dado: 5}
+        # Away (S=60, o lado sem nada): as mesmas 7 da fixture 2.
+        - {fixture_id: 3, outcome: 'Away', pts_premissas: 0, forma: false, mando: false, premissas_sem_dado: 7}
         - {fixture_id: 3, outcome: 'Draw', pts_premissas: 0, forma: false, mando: false, premissas_sem_dado: 0}
 
   # ============================================================================
@@ -150,3 +157,95 @@ unit_tests:
         # Sobram as duas de histórico. Contador 2, e o score é o mesmo 0 do jogo cego.
         - {fixture_id: 2, outcome: '1X', pts_premissas: 0, lado_coberto_forte: false, adversario_limitado: false, premissas_sem_dado: 2}
         - {fixture_id: 2, outcome: 'X2', pts_premissas: 0, lado_coberto_forte: false, adversario_limitado: false, premissas_sem_dado: 2}
+
+  # ============================================================================
+  # A CEGUEIRA DE DESFALQUE (#42, ADR 0003). O contador do lado apostado era forçado a
+  # zero, e zero é o que `desfalque_adversario` EXIGE do nosso lado — a nossa cegueira
+  # era condição para a premissa acender. É a única das três ausências que a ADR 0003
+  # chama de número FABRICADO, e não só suprimido.
+  #
+  # Por que unit test: das 8.355 fixtures do Motor, as que têm lista pré-apito são
+  # dezenas. O caso assimétrico — a fonte devolveu um lado só — existe em 1 fixture de
+  # 8.661, e nenhum data test sobre produção distingue "não acendeu porque medimos e não
+  # havia" de "não acendeu porque o modelo nunca soube". Linha construída distingue.
+  #
+  # As quatro asserções:
+  #   1. lado apostado CEGO não acende a premissa, mesmo com o adversário desfalcado
+  #      (fixture 10 Home) — o caso assimétrico, e a razão de a guarda existir;
+  #   2. lado apostado cego não EXIME a penalidade: `desfalque_proprio` chega NULL, não
+  #      FALSE (fixture 10 Home). FALSE afirmaria "o time está completo", que é
+  #      exatamente o que não sabemos. O score não muda — a aritmética COALESCEa o NULL
+  #      —, mas a coluna deixa de mentir;
+  #   3. registro de coleta PÓS-APITO não vale como registro (fixture 10): a âncora é a
+  #      mesma do int_futebol_desfalques, e sem ela o poll do dia seguinte "explicaria"
+  #      um jogo que já aconteceu;
+  #   4. zero LEGÍTIMO — perguntamos e não havia titular importante fora — acende como
+  #      sempre acendeu (fixture 11) e não conta como cegueira (fixture 12).
+  #
+  # O contador vale 7 nas linhas cegas e 6 nas demais porque só desfalques e coleta
+  # entram como insumo aqui: as outras seis premissas ficam cegas nas três fixtures, de
+  # propósito, para que a única coisa que se move entre as linhas seja o desfalque.
+  # ============================================================================
+  - name: premissas_1x2_desfalque_cego_nao_acende_nem_exime
+    model: int_futebol_premissas_1x2
+    description: >
+      Sem registro de coleta pré-apito o contador de desfalques é NULL: a premissa do
+      adversário não acende, a penalidade própria deixa de ser eximida por omissão, e o
+      contador de premissas sem dado passa a enxergar a cegueira. Com registro, o zero é
+      real e tudo se comporta como antes.
+    given:
+      - input: ref('fact_fixtures')
+        rows:
+          # 10: NUNCA perguntamos antes do apito. 11 e 12: perguntamos.
+          - {fixture_id: 10, competition: 'brasileirao', competition_id: 71, season: 2026, home_team_id: 100, away_team_id: 200, kickoff_utc: '2026-08-01 20:00:00'}
+          - {fixture_id: 11, competition: 'brasileirao', competition_id: 71, season: 2026, home_team_id: 110, away_team_id: 210, kickoff_utc: '2026-08-01 20:00:00'}
+          - {fixture_id: 12, competition: 'brasileirao', competition_id: 71, season: 2026, home_team_id: 120, away_team_id: 220, kickoff_utc: '2026-08-01 20:00:00'}
+
+      - input: ref('int_futebol_desfalques')
+        rows:
+          # O ADVERSÁRIO do mandante tem titular importante fora nas fixtures 10 e 11. A
+          # diferença entre as duas não está aqui — está no registro de coleta.
+          - {fixture_id: 10, team_id: 200, injury_type: 'Missing Fixture', is_important: true}
+          - {fixture_id: 11, team_id: 210, injury_type: 'Missing Fixture', is_important: true}
+
+      - input: ref('stg_futebol_injuries_coleta')
+        rows:
+          # Fixture 10: perguntamos DEPOIS do apito — não conta (asserção 3).
+          - {fixture_id: 10, snapshot_date: '2026-08-01', coletado_em: '2026-08-01 22:00:00'}
+          - {fixture_id: 11, snapshot_date: '2026-08-01', coletado_em: '2026-08-01 08:00:00'}
+          - {fixture_id: 12, snapshot_date: '2026-08-01', coletado_em: '2026-08-01 08:00:00'}
+
+      # As outras fontes ficam vazias de propósito: o que se mede aqui é só o desfalque.
+      - input: ref('int_futebol_team_form_pit')
+        rows: []
+      - input: ref('fact_fixture_stats')
+        rows: []
+      - input: ref('fact_h2h')
+        rows: []
+
+    expect:
+      rows:
+        # ---- fixture 10: cega dos dois lados (o caso assimétrico) ----------------
+        # Home (S=100 sem lista e sem registro -> NULL; O=200 com 1 titular fora):
+        # a premissa NÃO acende, e a penalidade própria chega NULL em vez de FALSE.
+        - {fixture_id: 10, outcome: 'Home', desfalque_adversario: false, desfalque_proprio: , pts_premissas: 0, penalidades_1x2_pts: 0, premissas_sem_dado: 7}
+        # Away (S=200 tem lista real -> 1): a penalidade própria é REAL e continua valendo
+        # −15; o adversário (100) é que está cego, então a premissa não acende.
+        - {fixture_id: 10, outcome: 'Away', desfalque_adversario: false, desfalque_proprio: true, pts_premissas: 0, penalidades_1x2_pts: 15, premissas_sem_dado: 7}
+        # Draw: sem lado apostado, nenhuma das 7 se aplica. A penalidade de empate segue
+        # inteira — é a linha que prova que o NULL do desfalque não zera as penalidades.
+        - {fixture_id: 10, outcome: 'Draw', desfalque_adversario: false, desfalque_proprio: , pts_premissas: 0, penalidades_1x2_pts: 10, premissas_sem_dado: 0}
+
+        # ---- fixture 11: zero legítimo do lado apostado --------------------------
+        # Perguntamos antes do apito e o mandante não tinha ninguém fora: a premissa
+        # acende (+8) exatamente como acendia antes da #42, e não conta como cegueira.
+        - {fixture_id: 11, outcome: 'Home', desfalque_adversario: true, desfalque_proprio: false, pts_premissas: 8, penalidades_1x2_pts: 0, premissas_sem_dado: 6}
+        - {fixture_id: 11, outcome: 'Away', desfalque_adversario: false, desfalque_proprio: true, pts_premissas: 0, penalidades_1x2_pts: 15, premissas_sem_dado: 6}
+        - {fixture_id: 11, outcome: 'Draw', desfalque_adversario: false, desfalque_proprio: false, pts_premissas: 0, penalidades_1x2_pts: 10, premissas_sem_dado: 0}
+
+        # ---- fixture 12: perguntamos e não havia ninguém fora --------------------
+        # Os dois contadores valem zero de verdade: nada acende, nada penaliza, e o
+        # desfalque NÃO entra no contador de cegueira.
+        - {fixture_id: 12, outcome: 'Home', desfalque_adversario: false, desfalque_proprio: false, pts_premissas: 0, penalidades_1x2_pts: 0, premissas_sem_dado: 6}
+        - {fixture_id: 12, outcome: 'Away', desfalque_adversario: false, desfalque_proprio: false, pts_premissas: 0, penalidades_1x2_pts: 0, premissas_sem_dado: 6}
+        - {fixture_id: 12, outcome: 'Draw', desfalque_adversario: false, desfalque_proprio: false, pts_premissas: 0, penalidades_1x2_pts: 10, premissas_sem_dado: 0}

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='S1 do Motor de Score — premissas de contexto do mercado RESULTADO (1X2). 3 linhas por fixture (outcome Home/Draw/Away). S = lado apostado, O = adversário. ⚠️ Task 0 (look-ahead): forca_mismatch/mando/superioridade_tabela/forma leem int_futebol_team_form_pit (point-in-time por fixture), NÃO mais fact_team_season_stats + standings_latest — que em 24/25 entregavam a temporada fechada e a tabela final a jogos da rodada 1. Cada premissa é um booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.1 do épico MOTOR_SCORE_CONFIABILIDADE.md). Penalidades específicas: pick_empate (-10), desfalque_proprio (-15). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/injuries). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities. ⚠️ MEDIÇÃO (task [F], ADR 0007): o spine de xG aceita as DUAS vars da medição — pit_escopo (da_competicao|todas) e pit_recorte (temporada|ultimos_10, que troca o filtro de season por um teto de 10 partidas) —, cujos DEFAULTS reproduzem exatamente o comportamento descrito acima; no default o SQL compilado é idêntico ao de antes de as vars existirem. Produção nunca a passa; ela serve às células de medição, materializadas no dataset futebol_taskF. superioridade_tabela NÃO segue o eixo (rank/ppg vêm do team_form_pit, que os mantém competição-scoped em todas as células, ADR 0008), e o h2h_favoravel também não, por motivo oposto: o fact_h2h já cruza campeonatos hoje, e restringi-lo seria mudar premissa. Contador de cegueira (#41, ADR 0003): premissas_cegas[] e premissas_sem_dado dizem quais premissas APLICÁVEIS a cada linha não puderam ser avaliadas por falta de insumo — geradas do mapa futebol_insumos_premissa(), nunca escritas à mão. O score NÃO muda: a premissa cega já não acendia e continua não acendendo; o que muda é o board passar a dizer o que não levou em conta. Para isso, n_wins_last5 e h2h_total/s_wins perderam o COALESCE de entrada (a ausência chega NULL), e n_wins_last5 vira NULL sem histórico nenhum. s_missing/o_missing seguem COALESCEados para zero até a #42 — desfalque_adversario é a única das 39 que o contador ainda não enxerga.'
+    description='S1 do Motor de Score — premissas de contexto do mercado RESULTADO (1X2). 3 linhas por fixture (outcome Home/Draw/Away). S = lado apostado, O = adversário. ⚠️ Task 0 (look-ahead): forca_mismatch/mando/superioridade_tabela/forma leem int_futebol_team_form_pit (point-in-time por fixture), NÃO mais fact_team_season_stats + standings_latest — que em 24/25 entregavam a temporada fechada e a tabela final a jogos da rodada 1. Cada premissa é um booleano que soma seu peso ao PTS_PREMISSAS (espelha §12.1 do épico MOTOR_SCORE_CONFIABILIDADE.md). Penalidades específicas: pick_empate (-10), desfalque_proprio (-15). Degradação graciosa: dado ausente -> premissa FALSE (Copa sem xG/injuries). evidencias[]/avisos[] = bullets legíveis pro front. O gate/edge/Score são aplicados no mart fact_value_opportunities. ⚠️ MEDIÇÃO (task [F], ADR 0007): o spine de xG aceita as DUAS vars da medição — pit_escopo (da_competicao|todas) e pit_recorte (temporada|ultimos_10, que troca o filtro de season por um teto de 10 partidas) —, cujos DEFAULTS reproduzem exatamente o comportamento descrito acima; no default o SQL compilado é idêntico ao de antes de as vars existirem. Produção nunca a passa; ela serve às células de medição, materializadas no dataset futebol_taskF. superioridade_tabela NÃO segue o eixo (rank/ppg vêm do team_form_pit, que os mantém competição-scoped em todas as células, ADR 0008), e o h2h_favoravel também não, por motivo oposto: o fact_h2h já cruza campeonatos hoje, e restringi-lo seria mudar premissa. Contador de cegueira (#41, ADR 0003): premissas_cegas[] e premissas_sem_dado dizem quais premissas APLICÁVEIS a cada linha não puderam ser avaliadas por falta de insumo — geradas do mapa futebol_insumos_premissa(), nunca escritas à mão. O score NÃO muda: a premissa cega já não acendia e continua não acendendo; o que muda é o board passar a dizer o que não levou em conta. Para isso, n_wins_last5 e h2h_total/s_wins perderam o COALESCE de entrada (a ausência chega NULL), e n_wins_last5 vira NULL sem histórico nenhum. Desfalque (#42): s_missing/o_missing perderam o COALESCE para zero e passam a ser NULL onde não perguntamos pelo jogo antes do apito (o registro vem de stg_futebol_injuries_coleta, o vazio registrado de data-engineering#33). O zero agora é merecido — contagem real do time OU registro de coleta pré-apito —, e com isso a cegueira deixa de ser CONDIÇÃO para desfalque_adversario acender e deixa de eximir a penalidade desfalque_proprio, que também chega NULL onde não se sabe (a aritmética das penalidades COALESCEa; a coluna não). Nenhuma linha da base muda: as 13 em que a premissa acende e as 73 em que a penalidade pesa têm todas registro de coleta pré-apito (medido 2026-08-14). Com isso o contador enxerga as 39 premissas.'
 ) }}
 {#- EIXOS DE ESCOPO E RECORTE DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — produção nunca passa estas vars.
 
@@ -144,6 +144,20 @@ desf AS (
     GROUP BY fixture_id, team_id
 ),
 
+-- #42 (ADR 0003): o REGISTRO DE QUE PERGUNTAMOS pelo jogo antes do apito. Sem ele, "a fonte
+-- respondeu e não havia desfalque" e "nunca perguntamos por este jogo" chegavam aqui como o
+-- mesmo zero — e o zero do nosso lado é CONDIÇÃO para desfalque_adversario acender, de modo
+-- que a cegueira habilitava a premissa em vez de impedi-la.
+-- Mesma âncora do int_futebol_desfalques (coleta ANTES do apito, e não no dia do apito): o
+-- poll roda de hora em hora, então no dia do jogo há coleta dos dois lados do apito, e a de
+-- depois explicaria um jogo que já aconteceu.
+coleta AS (
+    SELECT DISTINCT c.fixture_id
+    FROM {{ ref('stg_futebol_injuries_coleta') }} c
+    JOIN fixtures f USING (fixture_id)
+    WHERE c.coletado_em < f.kickoff_utc
+),
+
 -- H2H: confrontos diretos ANTERIORES ao jogo; conta vitórias de S (só Home/Away).
 h2h AS (
     SELECT
@@ -181,9 +195,19 @@ metrics AS (
         sx.xg_for_avg      AS s_xg_for,
         ox.xg_against_avg  AS o_xg_against,
 
-        -- desfalques pesados por importância (S7): só titular importante fora conta
-        COALESCE(si.missing_important_count, 0) AS s_missing,
-        COALESCE(oi.missing_important_count, 0) AS o_missing,
+        -- Desfalques pesados por importância (S7): só titular importante fora conta.
+        -- SEM COALESCE PARA ZERO (#42): o zero passa a ter de ser MERECIDO, e são dois os
+        -- jeitos de merecê-lo. (1) O time tem linha de desfalque, e aí a contagem é real —
+        -- pode ser zero porque só há 'Questionable' ou reserva na lista. (2) Não tem linha,
+        -- mas perguntamos pelo jogo antes do apito: o poll devolve a partida inteira, então
+        -- "perguntamos e não veio nada deste time" é zero de verdade.
+        -- Fora desses dois, o contador é NULL — e o NULL é o que impede a nossa cegueira de
+        -- habilitar `desfalque_adversario` e de eximir a penalidade de desfalque próprio.
+        -- A ordem dos dois braços importa e protege o CASO ASSIMÉTRICO: quando a fonte
+        -- devolveu um lado só, o lado com linha mantém a contagem real e o outro fica NULL,
+        -- em vez de o fixture inteiro virar zero (antes) ou NULL (se o registro mandasse).
+        COALESCE(si.missing_important_count, IF(cl.fixture_id IS NULL, NULL, 0)) AS s_missing,
+        COALESCE(oi.missing_important_count, IF(cl.fixture_id IS NULL, NULL, 0)) AS o_missing,
 
         -- tabela do campeonato NO INSTANTE DO JOGO (superioridade_tabela)
         s.rank    AS s_rank,
@@ -215,6 +239,7 @@ metrics AS (
     LEFT JOIN xg ox   ON ox.fixture_id = o.fixture_id AND ox.team_id = o.o_team_id
     LEFT JOIN desf si  ON si.fixture_id = o.fixture_id AND si.team_id = o.s_team_id
     LEFT JOIN desf oi  ON oi.fixture_id = o.fixture_id AND oi.team_id = o.o_team_id
+    LEFT JOIN coleta cl ON cl.fixture_id = o.fixture_id
     LEFT JOIN h2h hh  ON hh.fixture_id = o.fixture_id AND hh.outcome = o.outcome
 ),
 
@@ -236,6 +261,12 @@ flags AS (
         COALESCE(m.h2h_total >= 1 AND m.s_wins * 2 >= m.h2h_total, FALSE)  AS h2h_favoravel,
         -- penalidades específicas 1X2
         (m.outcome = 'Draw')                                              AS pick_empate,
+        -- SEM COALESCE (#42), e este é o ponto da mudança: com o zero forjado, a penalidade
+        -- nunca punia um time do qual não sabíamos nada — a coluna afirmava "está completo".
+        -- Agora ela chega NULL onde não sabemos. Não vira −15 (não sabemos que há desfalque,
+        -- e inventá-lo puniria 99% do board): deixa de AFIRMAR a isenção. Quem consome sabe
+        -- separar as duas coisas — a aritmética logo abaixo COALESCEa, e o contador de
+        -- cegueira já marca a linha pela premissa que lê o mesmo insumo.
         (m.s_missing >= 1)                                                AS desfalque_proprio
     FROM metrics m
 ),
@@ -255,7 +286,11 @@ scored AS (
         ) AS pts_premissas,
         (
             10 * CAST(f.pick_empate       AS INT64)
-          + 15 * CAST(f.desfalque_proprio AS INT64)
+          -- COALESCE aqui, e não na origem (#42): o NULL de desfalque_proprio é informação
+          -- na coluna e ruído na soma. Sem ele, TODA linha de empate zeraria as penalidades
+          -- inteiras — no 'Draw' não há lado apostado, logo não há s_missing, logo o NULL é
+          -- permanente e contaminaria os −10 do pick_empate.
+          + 15 * CAST(COALESCE(f.desfalque_proprio, FALSE) AS INT64)
         ) AS penalidades_1x2_pts
     FROM flags f
 ),

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
@@ -151,6 +151,14 @@ desf AS (
 -- Mesma âncora do int_futebol_desfalques (coleta ANTES do apito, e não no dia do apito): o
 -- poll roda de hora em hora, então no dia do jogo há coleta dos dois lados do apito, e a de
 -- depois explicaria um jogo que já aconteceu.
+-- ⚠️ QUALQUER registro pré-apito conta, inclusive o das 96h — que é o horizonte do poll,
+-- enquanto a fonte só publica a lista a ~53–70h. Ou seja, um jogo distante pode ter registro
+-- de uma resposta vazia que só significa "ainda não publicaram". Estreitar isto para uma
+-- janela de publicação é a HEURÍSTICA DE JANELA que a ADR 0003 rejeitou explicitamente — é o
+-- mesmo conhecimento fabricado com outro nome, derivado de 28 fixtures observados. O erro que
+-- sobra é conservador e se cura sozinho: nessa faixa os dois lados valem zero, então a
+-- premissa do adversário não acende por falta do adversário desfalcado, e o poll do dia
+-- seguinte substitui o registro assim que a fonte publica.
 coleta AS (
     SELECT DISTINCT c.fixture_id
     FROM {{ ref('stg_futebol_injuries_coleta') }} c

--- a/dbt_futebol/models/staging/models.yml
+++ b/dbt_futebol/models/staging/models.yml
@@ -251,6 +251,38 @@ models:
       - name: loaded_at
         description: "Timestamp ISO UTC do extractor"
 
+  - name: stg_futebol_injuries_coleta
+    description: >
+      O registro de que PERGUNTAMOS por um jogo (#42, ADR 0003). 1 linha por (fixture, dia)
+      do poll pré-jogo de /injuries?fixture, inclusive quando a resposta veio sem desfalque
+      nenhum — o vazio registrado de data-engineering#33. É o irmão do stg_futebol_injuries,
+      que descarta essa linha por desenho (`player.id IS NOT NULL`, com not_null em cima):
+      vazio não é desfalque, mas é resposta. Sem este modelo, "perguntamos e a fonte não
+      tinha" e "nunca perguntamos" são o mesmo estado, e o contador de desfalques do
+      int_futebol_premissas_1x2 não teria de onde tirar o NULL.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - fixture_id
+              - snapshot_date
+    columns:
+      - name: fixture_id
+        description: "ID do jogo pelo qual perguntamos (FK p/ fact_fixtures)"
+        tests:
+          - not_null
+      - name: snapshot_date
+        description: "Data (UTC) da coleta"
+        tests:
+          - not_null
+      - name: coletado_em
+        description: >
+          Instante (UTC) da PRIMEIRA coleta do dia para aquele jogo. É ele, e não o
+          snapshot_date, que decide se a resposta é pré-apito — o poll roda de hora em hora e
+          no dia do jogo há coleta antes e depois do apito.
+        tests:
+          - not_null
+
   - name: stg_futebol_predictions
     description: "Flatten do raw_futebol_predictions. 1 linha por fixture (1 previsão/jogo, sem UNNEST). predictions/comparison achatados; percentuais ('45%') e linhas de gol ('-1.5') STRING → FLOAT64 (REPLACE('%','') + SAFE_CAST). `def` escapado com crases. fact_predictions_api deriva competition/collection_date e dedup."
     columns:

--- a/dbt_futebol/models/staging/models.yml
+++ b/dbt_futebol/models/staging/models.yml
@@ -266,6 +266,18 @@ models:
             combination_of_columns:
               - fixture_id
               - snapshot_date
+      # Este modelo é TABLE por custo (ver o cabeçalho do .sql), e tabela que deixa de ser
+      # reconstruída envelhece calada: o jogo de amanhã passa a parecer nunca perguntado, o
+      # contador de desfalque vira NULL e as premissas legítimas somem do board sem erro.
+      # warn, e não error, porque o poll só cobre ligas com coverage.injuries e jogos NS
+      # dentro de 96h — numa pausa de calendário o silêncio é legítimo.
+      - dbt_utils.recency:
+          arguments:
+            datepart: day
+            field: coletado_em
+            interval: 2
+          config:
+            severity: warn
     columns:
       - name: fixture_id
         description: "ID do jogo pelo qual perguntamos (FK p/ fact_fixtures)"

--- a/dbt_futebol/models/staging/models.yml
+++ b/dbt_futebol/models/staging/models.yml
@@ -271,6 +271,11 @@ models:
       # contador de desfalque vira NULL e as premissas legítimas somem do board sem erro.
       # warn, e não error, porque o poll só cobre ligas com coverage.injuries e jogos NS
       # dentro de 96h — numa pausa de calendário o silêncio é legítimo.
+      # tag 'guarda' porque o agendado roda `dbt test --select tag:guarda` e nada mais
+      # (data-engineering#19): teste sem a tag existe só no laptop de quem lembrar de rodá-lo.
+      # ⚠️ Mesmo tagueado, `warn` não dispara o alarme da C4, que lê ERROR — este teste é
+      # diagnóstico no resumo diário, não sentinela. Quem protege de verdade contra o
+      # envelhecimento é o modelo estar nos `--select` dos workflows.
       - dbt_utils.recency:
           arguments:
             datepart: day
@@ -278,6 +283,7 @@ models:
             interval: 2
           config:
             severity: warn
+            tags: ['guarda']
     columns:
       - name: fixture_id
         description: "ID do jogo pelo qual perguntamos (FK p/ fact_fixtures)"

--- a/dbt_futebol/models/staging/stg_futebol_injuries_coleta.sql
+++ b/dbt_futebol/models/staging/stg_futebol_injuries_coleta.sql
@@ -1,0 +1,26 @@
+{{ config(
+    description='O REGISTRO DE QUE PERGUNTAMOS (#42, ADR 0003) — 1 linha por (fixture, dia de coleta) do poll pré-jogo de /injuries?fixture, INCLUSIVE quando a fonte não devolveu desfalque nenhum. É o único lugar onde o VAZIO REGISTRADO (data-engineering#33) sobrevive: o stg_futebol_injuries o descarta por desenho (player.id IS NOT NULL, com not_null em cima), porque vazio não é desfalque — mas é resposta, e sem ela "perguntamos e a fonte não tinha" e "nunca perguntamos" são o mesmo estado. Consumido por int_futebol_premissas_1x2, que só pode deixar s_missing/o_missing valerem ZERO onde existe registro; sem registro o contador é NULL. ⚠️ O discriminador é o NOME DO ARQUIVO: o poll por fixture grava raw_futebol_injuries_{fixture}_{janela}_{dia}.json e o season-log grava raw_futebol_injuries_{current|backfill}_{dia}.json — o segmento após o endpoint é numérico só no primeiro. Casar o número, e não a janela, porque a janela é configuração (FUTEBOL_INJURIES_WINDOWS, hoje só `daily`) e renomeá-la não deve apagar o registro em silêncio.'
+) }}
+
+WITH src AS (
+    SELECT
+        _FILE_NAME AS arquivo,
+        fixture.id AS fixture_id,
+        snapshot_date,
+        loaded_at
+    FROM {{ source('futebol', 'raw_futebol_injuries') }}
+)
+
+SELECT
+    fixture_id,
+    snapshot_date,
+    -- Instante da coleta. É ele — e não o snapshot_date — que decide se a resposta é
+    -- pré-apito: o poll roda de hora em hora e no dia do jogo há coleta antes E depois do
+    -- apito (mesma razão pela qual int_futebol_desfalques usa extracted_at).
+    MIN(loaded_at) AS coletado_em
+FROM src
+WHERE fixture_id IS NOT NULL
+  -- Só o poll POR FIXTURE registra o vazio; o season-log é por (liga, season) e a ausência
+  -- de um jogo nele não é resposta sobre aquele jogo.
+  AND REGEXP_CONTAINS(arquivo, r'/raw_futebol_injuries_[0-9]+_')
+GROUP BY fixture_id, snapshot_date

--- a/dbt_futebol/models/staging/stg_futebol_injuries_coleta.sql
+++ b/dbt_futebol/models/staging/stg_futebol_injuries_coleta.sql
@@ -1,4 +1,21 @@
+{#- ⚠️ TABLE, e não a view padrão do staging — é decisão de CUSTO, não de estilo.
+
+    A fonte é NDJSON externo, sem predicate pushdown: qualquer leitura varre o prefixo inteiro
+    (236 MiB em 2026-08-14, e ele acumula 1 arquivo por fixture por dia). Como view, cada
+    rebuild do int_futebol_premissas_1x2 pagaria essa varredura — e quem o reconstrói é o
+    `futebol-odds-pregame`, de 15 em 15 minutos, 96× por dia. São ~22 GB/dia de varredura para
+    responder a uma pergunta que só muda de hora em hora, porque o poll de /injuries roda de
+    hora em hora: a tabela não pode ser mais fresca que a fonte dela.
+
+    Então ela é construída onde a varredura JÁ acontece — junto do fact_injuries_snapshot, nos
+    workflows diário e de injuries (horário) — e o caminho de 15 minutos lê tabela nativa. O
+    `dbt_utils.recency` no yml é o que pega o modo de falha desta escolha: tabela que parou de
+    ser reconstruída envelhece em silêncio, e jogo recente passa a parecer nunca perguntado.
+
+    ⚠️ Isto exige que o modelo esteja nos `--select` dos dois workflows (data-engineering):
+    sem isso ele nunca é reconstruído em produção, e editar este arquivo não muda nada lá. -#}
 {{ config(
+    materialized='table',
     description='O REGISTRO DE QUE PERGUNTAMOS (#42, ADR 0003) — 1 linha por (fixture, dia de coleta) do poll pré-jogo de /injuries?fixture, INCLUSIVE quando a fonte não devolveu desfalque nenhum. É o único lugar onde o VAZIO REGISTRADO (data-engineering#33) sobrevive: o stg_futebol_injuries o descarta por desenho (player.id IS NOT NULL, com not_null em cima), porque vazio não é desfalque — mas é resposta, e sem ela "perguntamos e a fonte não tinha" e "nunca perguntamos" são o mesmo estado. Consumido por int_futebol_premissas_1x2, que só pode deixar s_missing/o_missing valerem ZERO onde existe registro; sem registro o contador é NULL. ⚠️ O discriminador é o NOME DO ARQUIVO: o poll por fixture grava raw_futebol_injuries_{fixture}_{janela}_{dia}.json e o season-log grava raw_futebol_injuries_{current|backfill}_{dia}.json — o segmento após o endpoint é numérico só no primeiro. Casar o número, e não a janela, porque a janela é configuração (FUTEBOL_INJURIES_WINDOWS, hoje só `daily`) e renomeá-la não deve apagar o registro em silêncio.'
 ) }}
 

--- a/dbt_futebol/tests/assert_cegueira_desfalque_visivel.sql
+++ b/dbt_futebol/tests/assert_cegueira_desfalque_visivel.sql
@@ -1,0 +1,50 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DA CEGUEIRA DE DESFALQUE (#42, ADR 0003) — duas direções, e nenhuma delas é a
+-- asserção "premissa cega nunca acende": essa é garantida por CONSTRUÇÃO no
+-- futebol_premissas_cegas() (a condição `NOT <premissa>` faz parte da expressão gerada) e
+-- cobrá-la aqui seria guarda vacuosa, no sentido exato do cabeçalho da
+-- assert_contador_sem_dado_vivo.
+--
+-- O que os dados podem responder, e as duas maneiras de esta entrega morrer em silêncio:
+--
+--   (1) O CONTADOR PARA DE VER O DESFALQUE. Basta alguém repor um COALESCE em s_missing/
+--       o_missing e `desfalque_adversario` volta a chegar aqui como "avaliada e não acendeu"
+--       em toda linha. Nada fica vermelho por si: o board segue igual, o contador segue
+--       verde, só que menor que a verdade — que é o modo de falha que a ADR 0003 nomeia.
+--
+--   (2) O REGISTRO DE COLETA PARA DE CHEGAR. O `stg_futebol_injuries_coleta` reconhece o poll
+--       por fixture pelo NOME DO ARQUIVO; se a ingestão renomear o arquivo, o modelo devolve
+--       zero linha, TODO desfalque vira cego e as linhas em que a premissa legitimamente
+--       acende somem do board sem nenhum erro. É o oposto da direção (1) e o mesmo silêncio.
+--
+-- Nenhuma das duas nasce vermelha: em 2026-08-14 são ~21 mil linhas com desfalque cego (a
+-- coleta pré-jogo é forward-only desde 14/07 e cobre dezenas de jogos, não milhares) e 72
+-- fixtures com registro pré-apito. Se um dia a direção (1) ficar verde por vacuidade — todo
+-- jogo do portfólio com lista pré-apito —, é porque a cegueira acabou, e aí esta guarda vira
+-- o aviso de que ela pode ser aposentada.
+
+WITH cegueira AS (
+    SELECT
+        COUNT(*)                                                        AS n_linhas,
+        COUNTIF('desfalque_adversario' IN UNNEST(premissas_cegas))      AS n_cegas
+    FROM {{ ref('int_futebol_premissas_1x2') }}
+),
+
+registro AS (
+    SELECT COUNT(*) AS n_registros
+    FROM {{ ref('stg_futebol_injuries_coleta') }}
+)
+
+SELECT
+    c.n_linhas,
+    c.n_cegas,
+    r.n_registros,
+    CASE
+        WHEN c.n_cegas = 0
+            THEN 'nenhuma linha com desfalque cego: s_missing/o_missing voltaram a chegar preenchidos (COALESCE reposto?) e o contador deixou de enxergar desfalque_adversario'
+        ELSE 'o registro de coleta do /injuries por fixture está vazio: o nome do arquivo mudou na ingestão e TODO desfalque virou cego — as premissas de desfalque legítimas sumiram do board'
+    END AS diagnostico
+FROM cegueira c
+CROSS JOIN registro r
+WHERE c.n_linhas > 0
+  AND (c.n_cegas = 0 OR r.n_registros = 0)


### PR DESCRIPTION
## O que muda

O terceiro `COALESCE` da ADR 0003 não suprimia, **fabricava**: `desfalque_adversario` é
`o_missing >= 1 AND s_missing = 0`, e o zero forçado do nosso lado fazia da **nossa cegueira a
condição para a premissa acender**. Pelo mesmo mecanismo, a penalidade de desfalque próprio
nunca punia um time do qual não sabíamos nada.

O zero passa a ser **merecido**, por um de dois caminhos:

1. o time tem lista de desfalque — a contagem é real, e pode ser zero legitimamente (só
   `Questionable`, ou só reserva na lista);
2. não tem lista, mas **perguntamos pelo jogo antes do apito** — o poll por fixture devolve a
   partida inteira numa chamada, então "perguntamos e não veio nada deste time" é zero de verdade.

Fora desses dois, o contador é `NULL`. A **ordem dos dois braços** é o que protege o caso
assimétrico (a fonte devolveu um lado só): o lado com lista mantém a contagem real e o outro
fica `NULL`, em vez de o fixture inteiro virar zero (antes) ou `NULL` (se o registro mandasse).

O `NULL` só existe porque a coleta passou a registrar o vazio (`tech-lamjav/data-engineering#33`).
O `stg_futebol_injuries` descarta essa linha por desenho — vazio não é desfalque —, então o
registro entra por um modelo irmão, `stg_futebol_injuries_coleta`, que reconhece o poll por
fixture pelo **nome do arquivo** (o segmento após o endpoint é numérico só no poll por fixture).

`desfalque_proprio` passa a chegar `NULL` onde não se sabe, em vez de `FALSE`. Não vira −15 — não
sabemos que há desfalque, e inventá-lo puniria 99% do board —, mas **deixa de afirmar a isenção**.
A aritmética das penalidades COALESCEa: sem isso, toda linha de empate zeraria os −10 do
`pick_empate`, porque no `Draw` não há lado apostado e o `NULL` é permanente.

## Nenhuma linha muda — medido, não esperado

Antes e depois do rebuild, no dataset real:

| | antes | depois |
|---|---|---|
| `desfalque_adversario` aceso | 13 | **13** |
| `desfalque_proprio` aceso | 73 | **73** |
| soma de `pts_premissas` | 184.376 | **184.376** |
| soma de `penalidades_1x2_pts` | 106.365 | **106.365** |
| `premissas_sem_dado` | 37.207 | **58.117** |
| `s_missing` nulo | 0 | 31.365 |

As outras sete contagens de premissa bateram exatamente. O que sobe é só o contador de cegueira:
as 20.910 linhas não-`Draw` sem registro de coleta pré-apito. Com isso o contador passa a enxergar
as **39** premissas — `desfalque_adversario` era a última fora do alcance dele.

## Deploy: independente da C8

Nenhuma coluna nova ou removida — só **nulidade**, e o Postgres já declara as duas colunas
`nullable`. Conferido no PRD vivo, pela regra do `docs/contrato-serving-rpcs.md`: `s_missing` não
é lido por RPC nenhuma, e `desfalque_proprio` só por `get_futebol_fixture_value`, num `CASE`
positivo (a RPC ainda usa `array_remove(..., null)`, então `NULL` degrada como `FALSE`). É a
diferença entre esta e as #38/#40.

## ⚠️ Exige uma mudança em data-engineering ANTES da imagem

Nenhum dos workflows seleciona o modelo novo: o diário usa `+fact_injuries_snapshot` (que **não**
é ancestral dele) e `int_futebol_premissas_1x2` sem `+`. Sem a mudança, editar o arquivo não muda
nada em produção e a tabela envelhece calada — jogo novo passa a parecer nunca perguntado e as
premissas de desfalque legítimas somem do board.

São 4 linhas (`"--select", "stg_futebol_injuries_coleta",`) em `workflow_futebol.yml:602,644` e
`workflow_futebol_injuries.yml:142,182`, mais o `deploy_workflows.sh` dos dois.

**Ordem: workflows primeiro, imagem depois.** Seletor desconhecido na imagem velha é no-op
inofensivo; imagem primeiro abre a janela de envelhecimento.

## Testes

- **Unit test da #41 atualizado** (6 → 7, e 4 → 5 na fixture de meio insumo) e **um novo** com as
  quatro asserções: lado apostado cego não acende; cego não exime (chega `NULL`, não `FALSE`);
  registro **pós-apito** não vale como registro; zero legítimo acende como sempre acendeu.
  Os dois foram **falsificados** — repondo o `COALESCE`, ambos vão a vermelho nas quatro linhas exatas.
- **Guarda nova** (`assert_cegueira_desfalque_visivel`) nas duas direções em que a entrega morre
  calada: contador que para de ver o desfalque (alguém repõe o `COALESCE`) e registro de coleta
  que para de chegar (a ingestão renomeia o arquivo e **todo** desfalque vira cego).
  Falsificada com o predicado invertido, e depois **pela realidade**: às 18:16 o
  `futebol-odds-pregame` reconstruiu o mart com a imagem de produção por cima do build local e ela
  foi a vermelho na direção 1.
- **Suíte completa: PASS=292, WARN=10, ERROR=0.** Os 10 warns são os órfãos de `relationships` já
  conhecidos, todos em modelos que este PR não toca.

## Decisões de revisão que ficaram registradas em vez de corrigidas

**A janela de publicação.** Qualquer registro pré-apito conta, inclusive o das 96h do horizonte do
poll, enquanto a fonte só publica a ~53–70h. Estreitar isso é exatamente a **heurística de janela
que a ADR 0003 rejeitou** — mesmo conhecimento fabricado com outro nome. O erro que sobra é
conservador (nessa faixa os dois lados valem zero, então a premissa não acende por falta de
adversário desfalcado) e se cura no poll seguinte. Está escrito no modelo para ninguém "consertar".

**A materialização.** O registro é `table`, não a view padrão do staging, por custo: a fonte é
NDJSON externo sem predicate pushdown, e o consumidor é reconstruído 96× por dia pelo
`futebol-odds-pregame`. Ressalva honesta: o BigQuery sub-reporta bytes de tabela externa
(dry-run devolve 0/`LOWER_BOUND`), então a economia é **estrutural, não medida**. O modo de falha
que ela cria — tabela que para de ser reconstruída — entra como `dbt_utils.recency` em `warn` e
com a tag `guarda`, porque o agendado só roda `tag:guarda` (`data-engineering#19`).

## Decisão de catálogo, para quem executar a Limpeza

`desfalque_adversario` **fica**. A hipótese de que os −24,9 do Teste 2 eram este bug está
**falsificada**: o número foi medido nas nove linhas mais bem informadas da base, todas com lista
real para o lado apostado, não nas mais cegas. O que sobrevive é `n = 9` ser incapaz de medir
qualquer coisa — razão para manter e re-medir, não para cortar. Registrado no `CONTEXT.md`.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
