### PR TITLE
fix(deploy): um job por alvo no detector de deriva

### DIFF
--- a/.github/workflows/deriva-imagem.yml
+++ b/.github/workflows/deriva-imagem.yml
@@ -14,11 +14,39 @@
 # POR QUE DE HORA EM HORA, e não uma vez por dia:
 # o job `dbt-futebol` roda ~96×/dia (workflow-futebol-odds é */15 e chama o job três vezes
 # por ciclo). Imagem velha não causa um dano diário, causa dano contínuo. Cadência horária
-# limita a ~4 execuções ruins. Não gera spam: o GitHub notifica na primeira falha de um
-# workflow agendado e na recuperação, não a cada execução. Repo público = Actions ilimitado.
+# limita a ~4 execuções ruins. Repo público = Actions ilimitado.
+#
+# POR QUE UM JOB POR ALVO (matrix), e não um job que checa os dois:
+# entre 12/08 e 17/08/2026 este workflow ficou vermelho em 104 execuções seguidas. A causa
+# era o `dbt_nba`: o commit 80d9c61 acrescentou 14 linhas ao `profiles.yml`, que é path
+# COMPARTILHADA no carimbo dos dois projetos, então o hash do NBA mudou sem uma única linha
+# de código NBA ter mudado — e ninguém rebuildou, porque a NBA está dormente (último
+# `dbt-nba` executado em 25/05). O `dbt_futebol` estava verde o tempo todo.
+# O problema não era o falso alarme; era que, com os dois alvos num job só, uma deriva NOVA
+# no futebol não teria produzido MUDANÇA de estado — já estava vermelho. Um alvo dormente
+# permanentemente vermelho anestesia o alvo que importa. Um job por alvo separa os estados.
+#
+# ⚠️ `fail-fast: false` é LOAD-BEARING. Com o default (`true`), a falha de um alvo cancela o
+# outro no meio da execução — o que reintroduz exatamente o mascaramento que a matrix existe
+# para eliminar, e de forma pior, porque o alvo cancelado nem aparece como checado.
+#
+# ⚠️ LIMITE CONHECIDO: o GitHub notifica por EXECUÇÃO do workflow, não por job. A matrix
+# separa o diagnóstico (você vê QUAL alvo derivou, e o histórico de cada um é independente na
+# aba Actions), mas a execução inteira continua contando como falha se qualquer alvo falhar.
+# Enquanto um alvo estiver vermelho de forma permanente, uma deriva nova no outro continua
+# não gerando notificação nova. A correção completa disso é um workflow POR alvo (arquivos
+# separados), não uma matrix. Decisão consciente: a matrix resolve o diagnóstico agora; a
+# separação em arquivos fica para quando um alvo voltar a ficar vermelho por muitos dias.
+#
+# ⚠️ NÃO é verdade que o GitHub notifica só na primeira falha e na recuperação — este
+# arquivo afirmava isso e foi FALSIFICADO em 17/08/2026: as 104 falhas consecutivas geraram
+# "cem e poucos" e-mails, um por execução. Cadência horária com alvo vermelho = ~24 e-mails
+# por dia. Some-se a isso que a notificação de workflow agendado vai APENAS para quem criou
+# o workflow (ou alterou a linha do `cron:` por último) — o time não recebe nada.
 #
 # ⚠️ Em repositório público, workflow agendado é desativado após 60 dias sem atividade no
-# repo. Se este detector parar de rodar sem explicação, é a primeira coisa a conferir.
+# repo. Só COMMIT reseta o contador — issue, release, tag e merge de PR não contam. Se este
+# detector parar de rodar sem explicação, é a primeira coisa a conferir.
 
 name: Deriva de imagem dbt
 
@@ -30,10 +58,21 @@ on:
 
 jobs:
   checa-deriva:
+    # Aparece na aba Actions como "deriva dbt_futebol" e "deriva dbt_nba", com estado
+    # verde/vermelho próprio para cada um.
+    name: deriva ${{ matrix.alvo }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+
+    strategy:
+      # Ver o bloco LOAD-BEARING no cabeçalho antes de mexer nisto.
+      fail-fast: false
+      matrix:
+        # Acrescentar um alvo aqui exige que `scripts/procedencia.sh` conheça as paths dele
+        # — é a mesma porta de entrada da tabela ALVOS do checa_deriva.sh.
+        alvo: [dbt_futebol, dbt_nba]
 
     steps:
       - name: Checkout
@@ -53,4 +92,6 @@ jobs:
           project_id: smartbetting-dados
 
       - name: Checar deriva
-        run: ./scripts/checa_deriva.sh
+        # O script já aceita alvo por argumento; sem argumento ele checa a tabela inteira,
+        # que é justamente o que esta matrix substitui.
+        run: ./scripts/checa_deriva.sh ${{ matrix.alvo }}


### PR DESCRIPTION
## O que aconteceu

Entre **12/08 12:02** e **17/08** o `deriva-imagem.yml` ficou vermelho em **104 execuções seguidas**.

Não era falso alarme — o detector estava certo. O `dbt_nba` estava genuinamente em deriva:

- **12/08 09:37**, o commit `80d9c61` (andaime da medição da task [F]) acrescentou 14 linhas ao `profiles.yml`;
- `profiles.yml` é **path compartilhada** no carimbo de procedência dos dois projetos;
- logo o hash esperado do NBA mudou **sem uma única linha de código NBA ter mudado**;
- o `dbt_futebol` foi rebuildado e absorveu a mudança; o `dbt_nba` não, porque a NBA está dormente (último `dbt-nba` executado em **25/05**, 84 dias).

`git diff bbe524e..master` nas paths do carimbo do NBA devolve exatamente um arquivo: `profiles.yml`.

## Qual era o defeito

Não o falso alarme — o dano do NBA dormente é zero. O defeito é que, **com os dois alvos num job só, uma deriva nova no `dbt_futebol` não produziria mudança de estado**: o workflow já estava vermelho. O alvo que roda ~96×/dia ficou sem sinal por 5 dias, encoberto por um alvo que não executa há três meses.

É o padrão do ADR 0001 um nível acima: lá a guarda era cega por rodar de dentro da imagem; aqui o detector ficou cego porque o alarme já estava tocando.

## A mudança

- `strategy.matrix` com um job por alvo — estado verde/vermelho independente para cada um na aba Actions;
- **`fail-fast: false` é load-bearing**: no default (`true`), a falha de um alvo cancela o outro no meio da execução, o que reintroduz o mascaramento de forma pior — o alvo cancelado nem aparece como checado;
- `checa_deriva.sh` **não muda**: já aceitava alvo por argumento.

## Correção de um comentário falso no cabeçalho

O arquivo afirmava que *"o GitHub notifica na primeira falha de um workflow agendado e na recuperação, não a cada execução"*. **Falsificado em 17/08**: as 104 falhas geraram cem e poucos e-mails, um por execução. Corrigido no cabeçalho, junto com o fato de que a notificação de workflow agendado vai **apenas** para quem criou o workflow (ou alterou a linha do `cron:` por último) — o time não recebe nada.

## Limite conhecido (documentado no cabeçalho, não resolvido aqui)

O GitHub notifica por **execução**, não por job. A matrix separa o diagnóstico, mas um alvo permanentemente vermelho continua suprimindo a novidade da notificação do outro. A correção completa é um workflow **por alvo**, em arquivos separados — decisão adiada conscientemente.

## Verificação

- `dbt_nba` rebuildado e recarimbado (`c72c7ce…`); detector **verde** em 17/08 17:14, primeira execução verde desde 12/08.
- `./scripts/checa_deriva.sh dbt_futebol` → `exit=0`; `./scripts/checa_deriva.sh dbt_nba` → `exit=0`.
- YAML validado.
- ⚠️ Aceitação pós-merge: um `workflow_dispatch` deve mostrar **dois jobs** (`deriva dbt_futebol` e `deriva dbt_nba`) em vez de um. Workflow agendado roda sempre a versão do branch default — até o merge, o cron das :20 segue rodando a versão de job único.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
