### PR TITLE
fix(futebol): premissa não muda de contagem entre builds do mesmo código (#78)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -304,6 +304,28 @@ A fixture whose teams have played too few matches for a season aggregate to mean
 anything — structural in knockout competitions, and an established cause of fabricated
 signal.
 
+**Prova de identidade de mart**:
+The evidence that a change moved no rows. It is the **count per premissa**, never
+`SUM(pts_premissas)` — an aggregate sum hides offsetting moves, and #42 had to retract
+evidence stated that way. Since #78 the rule carries a second half: a count from **one
+build** proves identity only for premissas whose inputs are reproducible. Where they are
+not, the count is a sample and not a measurement, and the comparison has to compute both
+sides in the same query.
+
+**Média reproduzível**:
+`SAFE_DIVIDE(SUM(x), COUNT(x))` with an exact sum — integer, or fixed point via NUMERIC
+when the input is fractional. **Never `AVG(x)`**: BigQuery parallelises the aggregation
+and merges the shards' *partial averages* in floating point, so the last bit follows the
+merge order and changes between runs. This is not a property of fractional data — over
+15,556 integers `AVG` returned five distinct values in six runs while
+`SAFE_DIVIDE(SUM, COUNT)` returned one. `APPROX_QUANTILES` is unreproducible for the
+sibling reason (it is a sketch); the exact form is `taskf_mediana`. A premissa comparing
+such a mean against a threshold changes its own row count between builds of identical
+code over frozen input — measured at ±1 row for `superioridade_xg`, ±15 for `ritmo_alto`,
+and as 71 outright false positives for `linha_subindo`/`linha_descendo`, which were
+reading tied windows as movement. Guarded by `assert_premissas_sem_agregado_instavel`.
+_Avoid_: "a média" unqualified, when the question is whether two builds can be compared
+
 **Escopo do PIT**:
 Which competitions a PIT aggregate counts. Today it is *da competição*: only fixtures of the
 same competition as the one being rated. It is **not one join** — `int_futebol_team_form_pit`

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_1x2.sql
@@ -71,6 +71,36 @@ fixture_team_spine AS (
 -- DATE(kickoff)) — time-bounded igual ao h2h/last5, sem look-ahead em fixtures já jogadas. P/ jogos
 -- FUTUROS == média da season (todos os jogos com stats são anteriores). Brasileirão preenchido;
 -- Copa ~vazio -> NULL -> premissa de xG não dispara.
+-- ⚠️ NÃO USE `AVG()` AQUI — É `SAFE_DIVIDE(SUM(...), COUNT(...))`, E EM NUMERIC (#78).
+--
+-- `AVG()` no BigQuery NÃO é bit-reproduzível entre execuções. A agregação é paralelizada e as
+-- médias PARCIAIS de cada shard são fundidas em ponto flutuante; a ordem da fusão muda de
+-- execução para execução e leva o último bit junto. Medido com o insumo CONGELADO, sem join
+-- nenhum, 9 linhas: `AVG` devolveu 1.4766666666666667 em três execuções e 1.4766666666666665 em
+-- outras três, enquanto a mesma média em BIGNUMERIC saiu byte-idêntica nas seis.
+--
+-- ⚠️ E ISSO NÃO É PRIVILÉGIO DE COLUNA FRACIONÁRIA — foi a primeira explicação e ela é FALSA.
+-- Sobre 15.556 linhas de `total_shots + corner_kicks`, que são INTEIROS, `AVG` deu cinco valores
+-- distintos em seis execuções (17.530213422473619 a …661) enquanto
+-- `SAFE_DIVIDE(SUM(...), COUNT(...))` sobre os MESMOS inteiros saiu idêntico nas seis. O
+-- discriminante é a CONSTRUÇÃO, não o tipo: `SUM` é exato (inteiro, ou ponto fixo em NUMERIC) e
+-- independe da ordem, e depois há UMA divisão só. É, aliás, por isso que as outras oito premissas
+-- do 1X2 ficam cravadas build após build — o `int_futebol_team_form_pit` já as calcula com
+-- `SAFE_DIVIDE(SUM(...), COUNTIF(...))`. Elas não são estáveis por serem de inteiro; são estáveis
+-- por não passarem por `AVG`.
+--
+-- Sozinho o ruído seria inofensivo. O estrago vem do limiar fixo da premissa logo abaixo, contra
+-- o qual 16 linhas estão a UM ULP: o delta delas vale 0,30 em decimal, e o `0.3` binário é
+-- 0,29999999999999998889…, de modo que nenhuma margem real separa os dois lados. Elas trocavam de
+-- lado sozinhas a cada build — `superioridade_xg` acendeu em 4019/4020/4021/4022 linhas em seis
+-- execuções do MESMO SQL sobre o MESMO insumo.
+--
+-- O NUMERIC resolve a segunda metade: é ponto FIXO, então `1,4 − 1,1 >= 0,3` é TRUE, que é o que
+-- a premissa quis dizer. As alternativas medidas e recusadas: `ROUND(delta, 2) >= 0.3` NÃO
+-- corrige (só muda a borda de faca de 0,300 para 0,295, região mais densa, e segue flapando em
+-- 4061/4062/4063); tolerância (`>= 0.3 - 1e-9`) chega ao mesmo número mas exige épsilon com o
+-- sinal certo em cada call-site, para sempre. `expected_goals` tem 2 casas na fonte, e NUMERIC
+-- (escala 9) as representa exatamente.
 {#- O FROM/JOIN existe UMA vez e é renderizado nas duas formas do CTE `xg` (média direta no
     default, pares ranqueados sob recorte de contagem). É aqui que os DOIS eixos entram, e é por
     isso que ele não pode ser escrito duas vezes: duas cópias de um predicado de eixo não ficam
@@ -112,8 +142,8 @@ xg_pares AS (
 xg AS (
     SELECT
         fixture_id, team_id,
-        AVG(xg_for)     AS xg_for_avg,
-        AVG(xg_against) AS xg_against_avg
+        SAFE_DIVIDE(SUM(CAST(xg_for     AS NUMERIC)), COUNT(xg_for))     AS xg_for_avg,
+        SAFE_DIVIDE(SUM(CAST(xg_against AS NUMERIC)), COUNT(xg_against)) AS xg_against_avg
     FROM xg_pares
     GROUP BY fixture_id, team_id
 ),
@@ -121,8 +151,8 @@ xg AS (
 xg AS (
     SELECT
         sp.fixture_id, sp.team_id,
-        AVG(st.expected_goals)  AS xg_for_avg,
-        AVG(opp.expected_goals) AS xg_against_avg
+        SAFE_DIVIDE(SUM(CAST(st.expected_goals  AS NUMERIC)), COUNT(st.expected_goals))  AS xg_for_avg,
+        SAFE_DIVIDE(SUM(CAST(opp.expected_goals AS NUMERIC)), COUNT(opp.expected_goals)) AS xg_against_avg
 {{- xg_from }}
     GROUP BY sp.fixture_id, sp.team_id
 ),
@@ -256,7 +286,10 @@ flags AS (
     SELECT
         m.*,
         COALESCE(m.s_gf_venue >= 1.4 AND m.o_ga_venue >= 1.3, FALSE)        AS forca_mismatch,
-        COALESCE(m.s_xg_for - m.o_xg_against >= 0.3, FALSE)                 AS superioridade_xg,
+        -- O limiar é NUMERIC casado com a média NUMERIC (#78): se um dos lados fosse FLOAT64, o
+        -- supertipo da comparação viraria FLOAT64 e o NUMERIC da CTE seria convertido de volta,
+        -- reintroduzindo exatamente o ruído que ele existe para tirar.
+        COALESCE(m.s_xg_for - m.o_xg_against >= NUMERIC '0.3', FALSE)       AS superioridade_xg,
         CASE
             WHEN m.s_is_home       AND m.pct_pts_home >= 55 THEN 8
             WHEN m.s_is_home = FALSE AND m.aprov_fora  >= 45 THEN 4

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ou.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ou.sql
@@ -100,6 +100,28 @@ fixture_team_spine AS (
         {%- endif %}
         AND st.date_utc       < DATE(sp.kickoff_utc)
 {%- endset %}
+{#- ⚠️ NENHUMA MÉDIA DESTE MODELO USA `AVG()` — todas são `SAFE_DIVIDE(SUM(...), COUNT(...))` (#78).
+
+    A causa está explicada por extenso no int_futebol_premissas_1x2, junto do `superioridade_xg`.
+    Resumo: `AVG()` no BigQuery não é bit-reproduzível entre execuções, porque funde as médias
+    parciais dos shards em ponto flutuante e a ordem da fusão muda. Vale para insumo fracionário
+    E para inteiro — foram as duas medidas.
+
+    Aqui o defeito aparecia em TRÊS premissas, por dois caminhos:
+
+      xg_combinado_alto /    o xG entra num limiar fixo (`line_value ± 0.3`). Acendeu em 11411
+      xg_baixo_combinado     linhas em 11 execuções e 11410 na décima segunda, com 16 linhas Over
+                             e 9 Under a menos de 1e-12 do limiar. Consertadas com SUM/COUNT em
+                             NUMERIC, exatamente como no 1X2 — o limiar também virou NUMERIC, ou o
+                             supertipo da comparação puxaria tudo de volta para FLOAT64.
+
+      ritmo_alto             o pior dos três, e o último a cair: 16684–16702 linhas, ±15 por build.
+                             `total_shots + corner_kicks` são INTEIROS, e a primeira suspeita
+                             (`APPROX_QUANTILES` na mediana da liga, ver o CTE league_pace_median)
+                             explicava só parte — trocada a mediana pela exata, ainda flapava.
+                             Era o `AVG` do próprio `pace_avg`. Fica em FLOAT64 mesmo: aqui não há
+                             literal decimal na comparação (`pace_both >= pace_median`, os dois
+                             calculados), então o que faltava era só a construção determinística. -#}
 {%- if pit_recorte == 'ultimos_10' %}
 -- MEDIÇÃO — recorte de contagem. O filtro de season sai e no lugar dele os pares (jogo-alvo,
 -- time) × partida anterior são ranqueados, sobrevivendo só os N mais recentes — contagem móvel,
@@ -121,7 +143,7 @@ spine_pares AS (
     ) <= {{ tamanho_do_recorte }}
 ),
 xg AS (
-    SELECT fixture_id, team_id, AVG(expected_goals) AS xg_for_avg
+    SELECT fixture_id, team_id, SAFE_DIVIDE(SUM(CAST(expected_goals AS NUMERIC)), COUNT(expected_goals)) AS xg_for_avg
     FROM spine_pares
     GROUP BY fixture_id, team_id
 ),
@@ -129,13 +151,13 @@ xg AS (
 -- Ritmo: finalizações+escanteios por time-jogo -> média do time ATÉ o jogo.
 pace_team AS (
     SELECT fixture_id, team_id, competition_id, season,
-           AVG(total_shots + corner_kicks) AS pace_avg
+           SAFE_DIVIDE(SUM(total_shots + corner_kicks), COUNT(total_shots + corner_kicks)) AS pace_avg
     FROM spine_pares
     GROUP BY fixture_id, team_id, competition_id, season
 ),
 {%- else %}
 xg AS (
-    SELECT sp.fixture_id, sp.team_id, AVG(st.expected_goals) AS xg_for_avg
+    SELECT sp.fixture_id, sp.team_id, SAFE_DIVIDE(SUM(CAST(st.expected_goals AS NUMERIC)), COUNT(st.expected_goals)) AS xg_for_avg
 {{- spine_from }}
     GROUP BY sp.fixture_id, sp.team_id
 ),
@@ -143,7 +165,7 @@ xg AS (
 -- Ritmo: finalizações+escanteios por time-jogo -> média do time ATÉ o jogo.
 pace_team AS (
     SELECT sp.fixture_id, sp.team_id, sp.competition_id, sp.season,
-           AVG(st.total_shots + st.corner_kicks) AS pace_avg
+           SAFE_DIVIDE(SUM(st.total_shots + st.corner_kicks), COUNT(st.total_shots + st.corner_kicks)) AS pace_avg
 {{- spine_from }}
     GROUP BY sp.fixture_id, sp.team_id, sp.competition_id, sp.season
 ),
@@ -172,15 +194,28 @@ pace_team AS (
             {%- endif %}
             AND st.date_utc       < DATE(sp.kickoff_utc)
 {%- endset %}
+-- ⚠️ A MEDIANA É `taskf_mediana`, E NÃO `APPROX_QUANTILES` (#78). Achado ao fechar a correção de
+-- reprodutibilidade do xG: `ritmo_alto` acendeu em 16687/16690/16696/16699/16702 linhas em oito
+-- execuções do MESMO SQL sobre o MESMO insumo — oscilação de ±15 linhas, ~5× a do xG, e por
+-- MECANISMO DIFERENTE. Não é ponto flutuante: `APPROX_QUANTILES` é um SKETCH, e o resultado
+-- depende de como a execução foi paralelizada. Este repositório já tinha medido isso na #57 (a
+-- mediana de ppg do Brasileirão saiu 1,313 e depois 1,294 em execuções seguidas) e já tinha
+-- escrito a cura — `macros/taskf_mediana.sql`, mediana exata por ordenação. O que faltava era
+-- aplicá-la aqui: a cura ficou nas análises da task [F] e a produção seguiu com o sketch.
+-- O `pace_avg` que entra aqui é determinístico (soma de INTEIROS em FLOAT64 é exata em qualquer
+-- ordem); a instabilidade era toda da mediana. Custo da troca: ordena o pool por fixture em vez
+-- de esboçá-lo, irrelevante no tamanho deste pool. Contrapartida declarada: para contagem par a
+-- mediana passa a ser a INFERIOR dos dois centrais, e o valor é arredondado (o macro arredonda em
+-- 3 casas por padrão) — as duas coisas declaradas, não descobertas.
 league_pace_median AS (
     SELECT fixture_id,
-           APPROX_QUANTILES(pace_avg, 2)[OFFSET(1)] AS pace_median
+           {{ taskf_mediana('pace_avg') }} AS pace_median
     FROM (
     {%- if pit_recorte == 'ultimos_10' %}
         -- MEDIÇÃO — o corte desce um nível: o histórico de CADA time do pool é recortado nas N
         -- partidas mais recentes antes de virar média, exatamente como o do time avaliado no
         -- `spine_pares`. Os dois lados da comparação medidos igual é o que a mediana exige.
-        SELECT fixture_id, team_id, AVG(total_shots + corner_kicks) AS pace_avg
+        SELECT fixture_id, team_id, SAFE_DIVIDE(SUM(total_shots + corner_kicks), COUNT(total_shots + corner_kicks)) AS pace_avg
         FROM (
             SELECT sp.fixture_id, lt.team_id, st.total_shots, st.corner_kicks
     {{- pool_from }}
@@ -192,7 +227,7 @@ league_pace_median AS (
         GROUP BY fixture_id, team_id
     {%- else %}
         SELECT sp.fixture_id, lt.team_id,
-               AVG(st.total_shots + st.corner_kicks) AS pace_avg
+               SAFE_DIVIDE(SUM(st.total_shots + st.corner_kicks), COUNT(st.total_shots + st.corner_kicks)) AS pace_avg
     {{- pool_from }}
         GROUP BY sp.fixture_id, lt.team_id
     {%- endif %}
@@ -248,8 +283,18 @@ last5 AS (
 line_move AS (
     SELECT
         fixture_id, line_value, outcome_side AS outcome,
-        AVG(IF(collection_window = 't24h', 1.0 / odd_decimal, NULL)) AS prob_t24h,
-        AVG(IF(collection_window = 't15m', 1.0 / odd_decimal, NULL)) AS prob_t15m
+        -- Mesma regra do resto do modelo (#78): sem `AVG`, e a soma em NUMERIC. Aqui a soma
+        -- PRECISA ser em ponto fixo — `1.0 / odd_decimal` é fracionário, então somá-lo em FLOAT64
+        -- voltaria a depender da ordem mesmo com SUM/COUNT no lugar de AVG (é por isso que o
+        -- `pace_avg` pôde ficar em FLOAT64 e este não: lá a soma é de INTEIROS, e essa é exata).
+        -- O CAST arredonda cada probabilidade implícita em 9 casas, folga de sobra p/ um número
+        -- que vive perto de 0,5 e é comparado contra outro igual.
+        SAFE_DIVIDE(
+            SUM(  IF(collection_window = 't24h', CAST(1.0 / odd_decimal AS NUMERIC), NULL)),
+            COUNT(IF(collection_window = 't24h', odd_decimal, NULL))) AS prob_t24h,
+        SAFE_DIVIDE(
+            SUM(  IF(collection_window = 't15m', CAST(1.0 / odd_decimal AS NUMERIC), NULL)),
+            COUNT(IF(collection_window = 't15m', odd_decimal, NULL))) AS prob_t15m
     FROM {{ ref('fact_odds_snapshot') }}
     WHERE market_id = 5 AND outcome_side IN ('Over', 'Under') AND odd_decimal > 0
     GROUP BY fixture_id, line_value, outcome_side
@@ -318,7 +363,7 @@ flags AS (
         -- Over (Σ56)
         (m.outcome = 'Over') AND COALESCE(m.gf_comb  >= m.line_value + 0.5, FALSE) AS ataque_combinado,
         (m.outcome = 'Over') AND COALESCE(m.ga_comb  >= m.line_value,       FALSE) AS defesas_vazaveis,
-        (m.outcome = 'Over') AND COALESCE(m.xg_comb  >= m.line_value + 0.3, FALSE) AS xg_combinado_alto,
+        (m.outcome = 'Over') AND COALESCE(m.xg_comb  >= CAST(m.line_value AS NUMERIC) + NUMERIC '0.3', FALSE) AS xg_combinado_alto,
         (m.outcome = 'Over') AND COALESCE(m.pace_both >= m.pace_median,     FALSE) AS ritmo_alto,
         (m.outcome = 'Over') AND COALESCE(m.home_cs_pct < 35 AND m.away_cs_pct < 35, FALSE) AS ambos_vazam,
         (m.outcome = 'Over') AND COALESCE(m.home_over_cnt >= 3 AND m.away_over_cnt >= 3, FALSE) AS historico_over,
@@ -326,7 +371,7 @@ flags AS (
         -- Under (Σ52)
         (m.outcome = 'Under') AND COALESCE(m.ga_comb <= m.line_value - 0.3, FALSE) AS defesas_firmes,
         (m.outcome = 'Under') AND COALESCE(m.home_cs_pct >= 40 AND m.away_cs_pct >= 40, FALSE) AS clean_sheets_altos,
-        (m.outcome = 'Under') AND COALESCE(m.xg_comb <= m.line_value - 0.3, FALSE) AS xg_baixo_combinado,
+        (m.outcome = 'Under') AND COALESCE(m.xg_comb <= CAST(m.line_value AS NUMERIC) - NUMERIC '0.3', FALSE) AS xg_baixo_combinado,
         (m.outcome = 'Under') AND COALESCE(m.home_fts_pct >= 35 OR m.away_fts_pct >= 35, FALSE) AS ataques_fracos,
         (m.outcome = 'Under') AND COALESCE(m.home_under_cnt >= 3 AND m.away_under_cnt >= 3, FALSE) AS historico_under,
         (m.outcome = 'Under') AND COALESCE(m.linha_caiu, FALSE)                    AS linha_descendo,

--- a/dbt_futebol/tests/assert_premissas_sem_agregado_instavel.sql
+++ b/dbt_futebol/tests/assert_premissas_sem_agregado_instavel.sql
@@ -1,0 +1,62 @@
+{{ config(tags=['guarda']) }}
+-- GUARDA DE REPRODUTIBILIDADE DAS PREMISSAS (#78) — nenhum modelo de premissa pode usar `AVG()`
+-- nem `APPROX_QUANTILES()`.
+--
+-- POR QUE UMA GUARDA DE TEXTO, E NÃO DE DADO. O defeito que ela impede não aparece em UMA
+-- execução: `AVG()` no BigQuery não é bit-reproduzível entre execuções, porque a agregação é
+-- paralelizada e as médias PARCIAIS de cada shard são fundidas em ponto flutuante. Qualquer
+-- guarda que compare números de um build só vê a média certa; o erro só existe ENTRE builds. E
+-- uma guarda que comparasse dois builds seria ela própria instável — daria vermelho de vez em
+-- quando, que é o pior tipo de guarda. Sobra checar a CONSTRUÇÃO, que é onde o defeito mora e
+-- onde ele é determinístico.
+--
+-- O QUE ELA IMPEDE, MEDIDO. Com o insumo CONGELADO e o MESMO SQL, seis execuções davam
+-- `superioridade_xg` em 4019/4020/4021/4022 linhas e `ritmo_alto` em 16684 a 16702 (±15 por
+-- build). As linhas que viravam estavam a UM ULP do limiar da premissa. O estrago não é no board
+-- (±8 pontos numa soma de ~184 mil): é em MEDIÇÃO — quem comparasse dois builds na [A] ou na [F]
+-- veria ±1 linha e não teria como saber, olhando o número, que aquilo é ruído do instrumento e
+-- não efeito da mudança sob teste.
+--
+-- A FORMA CERTA é `SAFE_DIVIDE(SUM(x), COUNT(x))`, com a soma EXATA — inteiro, ou ponto fixo em
+-- NUMERIC quando o insumo é fracionário. `SUM` independe da ordem e depois há uma divisão só.
+-- Medido sobre 15.556 inteiros: `AVG` deu cinco valores distintos em seis execuções,
+-- `SAFE_DIVIDE(SUM, COUNT)` deu um só. Não é privilégio de coluna fracionária — a primeira
+-- explicação foi essa e ela é falsa.
+--
+-- `APPROX_QUANTILES` entra na mesma lista por motivo irmão: é um SKETCH, e o resultado depende de
+-- como a execução foi paralelizada. Já estava medido na #57 e já tinha cura escrita
+-- (`macros/taskf_mediana.sql`); o que faltava era ela valer na produção, e não só nas análises da
+-- task [F]. Foi assim que o `ritmo_alto` passou meses instável sem ninguém reparar.
+--
+-- ⚠️ A varredura é sobre o código com os comentários REMOVIDOS — os dois tipos. Sem isso esta
+-- guarda acusaria a si mesma e aos comentários que explicam a correção, que citam `AVG()` pelo
+-- nome dezenas de vezes. `{#- ... -#}` sai primeiro (pode conter `--` dentro), depois `--` até o
+-- fim da linha.
+
+{%- set proibidos = ['AVG(', 'APPROX_QUANTILES('] -%}
+{%- set achados = [] -%}
+
+{%- if execute -%}
+  {%- for node in graph.nodes.values() -%}
+    {%- if node.resource_type == 'model' and node.name.startswith('int_futebol_premissas_') -%}
+      {%- set sem_jinja = modules.re.sub('(?s)\{#.*?#\}', ' ', node.raw_code) -%}
+      {%- set codigo    = modules.re.sub('--[^\n]*', ' ', sem_jinja) -%}
+      {%- for termo in proibidos -%}
+        {%- if termo in codigo -%}
+          {%- do achados.append(node.name ~ ' usa ' ~ termo ~ ')') -%}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif -%}
+
+-- Uma linha por violação; zero linhas = verde. O array vazio precisa de tipo explícito, senão o
+-- BigQuery não sabe montar o UNNEST de um literal `[]`.
+SELECT ocorrencia
+FROM UNNEST(
+{%- if achados %}
+    {{ achados | tojson }}
+{%- else %}
+    CAST([] AS ARRAY<STRING>)
+{%- endif %}
+) AS ocorrencia

--- a/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+++ b/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
@@ -71,6 +71,32 @@
 -- se cair, é empate. `analyses/taskf_remedicao.sql` faz essa comparação entre duas medições e é
 -- onde o caso se confirma.
 --
+-- ⚠️ CORREÇÃO DE DUAS COISAS DITAS ACIMA, MEDIDAS NA #78 — leia antes de usar este parágrafo.
+--
+--   1. "a ordem depende do layout físico da tabela, que muda quando os modelos são reconstruídos"
+--      é MAIS BENIGNO do que a realidade. A ordem muda entre EXECUÇÕES, sobre a MESMA tabela, sem
+--      reconstrução nenhuma: o `AVG` funde as médias PARCIAIS dos shards em ponto flutuante e o
+--      particionamento varia sozinho. Seis execuções da mesma SQL sobre insumo congelado deram
+--      quatro valores distintos de `superioridade_xg`. Não é preciso reconstruir nada para a
+--      guarda virar.
+--   2. A régua acima diz que as 37 premissas fora de `linha_subindo`/`linha_descendo` leem
+--      "insumos determinísticos sobre um universo congelado". Isso era FALSO para quatro delas —
+--      `superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado` e `ritmo_alto` —, e uma das
+--      16 linhas de borda do 1X2 cai dentro da janela publicada da [0.1]. A guarda tinha uma linha
+--      capaz de virar sozinha a cada remedição.
+--
+-- A #78 tornou a afirmação VERDADEIRA na produção (nenhum modelo de premissa usa mais `AVG` nem
+-- `APPROX_QUANTILES` — ver tests/assert_premissas_sem_agregado_instavel.sql). A contrapartida é
+-- que os números de `macros/taskf_publicado_01.sql` foram medidos sob a regra antiga:
+--
+--   ⚠️ NA PRÓXIMA RECONSTRUÇÃO DAS CÉLULAS DA [F] ESTA GUARDA FICA VERMELHA DE PROPÓSITO,
+--      em `superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado` e `ritmo_alto`.
+--
+-- Não é bug e não é o empate de arredondamento descrito acima: é a correção chegando à medição.
+-- O rebaseline dos quatro exige remedir as células (um `dbt run --target taskF`) e ficou FORA da
+-- #78 por isso — está no ticket de follow-up. Enquanto ele não roda, a guarda segue verde, porque
+-- as células materializadas hoje são as da regra antiga.
+--
 -- ────────────────────────────────────────────────────────────────────────────────
 -- O QUE É COMPARÁVEL. O doc da [0.1] publica três recortes diferentes (ver
 -- macros/taskf_publicado_01.sql), então nem toda linha tem todo campo — NULL ali significa NÃO


### PR DESCRIPTION
Diagnóstico completo e medições em #78. Este PR é a correção.

## O que estava errado

`AVG()` no BigQuery **não é bit-reproduzível entre execuções** — funde as médias *parciais* dos
shards em ponto flutuante, e o particionamento varia sozinho, sobre a **mesma** tabela, sem
reconstrução. Seis builds do mesmo SQL sobre insumo congelado davam `superioridade_xg` em
4019/4020/4021/4022 linhas.

A hipótese da issue ("só onde o insumo é fracionário") foi **falsificada com medição**. Sobre
15.556 **inteiros**:

```
avg_int               sum_div_count         n
17.530213422473648    17.530213422473643    15556
17.530213422473661    17.530213422473643    15556
17.530213422473643    17.530213422473643    15556
17.530213422473619    17.530213422473643    15556
17.530213422473648    17.530213422473643    15556
17.530213422473637    17.530213422473643    15556
```

`AVG` dá cinco valores distintos em seis execuções; `SAFE_DIVIDE(SUM, COUNT)` sobre os mesmos
inteiros dá um só. **O discriminante é a construção, não o tipo do dado** — e é isso que explica o
que a issue observou e não conseguiu explicar: as outras oito premissas do 1X2 ficavam cravadas
porque o `int_futebol_team_form_pit` já usa `SAFE_DIVIDE(SUM(...), COUNTIF(...))`. A forma certa já
estava escrita no repositório; só não estava em todo lugar.

## Eram 6 premissas, não 1

| premissa | antes (mesma SQL, insumo congelado) | depois |
|---|---|---|
| `superioridade_xg` | 4019 / 4020 / 4021 / 4022 | **4027** ×8 |
| `xg_combinado_alto` | 11411 / 11410 | **11412** ×8 |
| `xg_baixo_combinado` | 9 linhas na borda | **10468** ×8 |
| `ritmo_alto` | 16684 … 16702 (**±15/build**) | **16693** ×8 |
| `linha_subindo` / `linha_descendo` | `AVG(1.0/odd)` | **1967 / 2579** ×8 |

Dupla Chance herda do 1X2 via `ref()`. Handicap e BTTS já eram estáveis.

### Dois achados fora do enunciado

**`ritmo_alto` era o pior dos seis.** A mediana da liga era `APPROX_QUANTILES` (um sketch), e este
repositório **já tinha medido isso na #57 e já tinha escrito a cura** — `macros/taskf_mediana.sql`,
que ficou nas análises da [F] e nunca chegou à produção. Troquei pela mediana exata e **`ritmo_alto`
continuou flapando**: era o `AVG` do próprio `pace_avg`. As duas correções ficaram, mas vale
registrar: a causa provável, documentada e já corrigida noutro canto **não era a causa**.

**`linha_subindo`/`linha_descendo` não eram só ruído — eram falso positivo.** Quando t24h e t15m têm
as mesmas odds, as duas médias são o mesmo número real, mas o `AVG` as calculava em shards
diferentes e o `>` virava cara-ou-coroa em cima de um empate:

```
sobe_numeric=4546  sobe_float=4579  empates_exatos=1137
dos 1137 empates, o float diz que 33 subiram e 38 desceram
```

`4579 − 4546 = 33`, exatamente os empates que o float chamou de alta. **71 pares de janela idêntica
eram lidos como movimento de linha.**

## A regra adotada

`SAFE_DIVIDE(SUM(...), COUNT(...))` com soma exata — inteiro, ou NUMERIC onde o insumo é fracionário
—, com o limiar em NUMERIC junto (senão o supertipo da comparação puxa tudo de volta para FLOAT64 e
desfaz a correção).

Recusadas **com medição**, não por preferência:

| regra | 6 execuções | estável? |
|---|---|---|
| hoje: `delta >= 0.3` | 4019, 4020, 4021, 4022, 4022, 4022 | **não** |
| `ROUND(delta, 2) >= 0.3` | 4061, 4062, 4062, 4062, 4063, 4063 | **não** |
| `delta >= 0.3 - 1e-9` | 4027 ×6 | sim |
| soma em NUMERIC vs `NUMERIC '0.3'` | 4027 ×6 | sim |

⚠️ **O arredondamento do delta — a primeira opção do escopo sugerido na issue — não corrige.** Não
remove a borda de faca; muda-a de 0,300 para 0,295, região *mais densa* da distribuição. Continua
flapando e ainda move 41 linhas de brinde. A tolerância funciona, mas exige épsilon com o sinal
certo em cada call-site (`xg_baixo_combinado` é `<=`) e não alcança `ritmo_alto`, cuja comparação
não tem literal.

## Verificação

Os dois modelos compilados e rodados **como SELECT** — sem `dbt run`, sem escrever no dataset
compartilhado (CLAUDE.md: só uma sessão roda `dbt run` por vez). 8 execuções cada, as 18 premissas
idênticas nas 8.

Contra a tabela viva de 19:31, que leu o mesmo insumo congelado, **só as premissas previstas se
moveram**. Batem exatamente: `forca_mismatch` 3043, `mando` 6560, `desfalque_adversario` 14,
`superioridade_tabela` 5622, `forma` 3935, `h2h_favoravel` 5791, `pick_empate` 10527,
`ataque_combinado` 10883, `historico_over` 7401, `defesas_firmes` 11351, `clean_sheets_altos` 2965,
`ambos_vazam` 13420, e as 31.581 / 76.028 linhas.

`dbt test --select tag:guarda` → 20 PASS. Unit tests do 1X2 → 2 PASS (o `_ou` não tem unit test).

**Board de hoje: zero linhas mudam** — nenhuma das 16 de borda está no `fact_value_opportunities`
(83 fixtures, 122 linhas). Mas 10 das 20 linhas de `match_winner` estão a ±7 pontos do gate de 40 e
a premissa vale 8: o efeito nulo é da composição do board de hoje, não de folga na regra.

## A guarda

`assert_premissas_sem_agregado_instavel` falha se `AVG(` ou `APPROX_QUANTILES(` voltarem a um modelo
de premissa. Falsificada nos dois sentidos: vermelha com `AVG` de volta, verde ao restaurar.

É guarda de **texto** por necessidade, e o cabeçalho explica: o defeito não existe dentro de um
build — só aparece ENTRE builds —, e uma guarda que comparasse dois builds seria ela própria
instável, dando vermelho de vez em quando. Sobra checar a construção, que é onde o defeito mora e
onde ele é determinístico.

## ⚠️ O que este PR deixa vermelho de propósito, depois

Os números de `macros/taskf_publicado_01.sql` foram medidos sob a regra antiga, então
`assert_taskf_base_reproduz_01` **fica vermelha na próxima reconstrução das células da [F]** em
`superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado` e `ritmo_alto`. Ela segue verde hoje,
porque as células materializadas são as da regra antiga. Rebaseline em **#82**.

Esse PR também corrige duas afirmações no cabeçalho dessa guarda: ela dizia que a ordem do `AVG`
"depende do layout físico da tabela, que muda quando os modelos são reconstruídos" (a ordem muda
entre execuções, sem reconstrução), e que as 37 premissas leem "insumos determinísticos sobre um
universo congelado" (era falso para quatro delas — e este PR torna verdadeiro).

## Depois do merge

```bash
./build-and-push.sh dbt_futebol   # mergear não é deployar
./scripts/checa_deriva.sh
```

Closes #78
