### PR TITLE
feat(futebol): a janela de detecção no board — há quanto tempo a oportunidade está lá (#40)

### DIFF
--- a/dbt_futebol/docs/contrato-serving-rpcs.md
+++ b/dbt_futebol/docs/contrato-serving-rpcs.md
@@ -89,7 +89,7 @@ Antes de mudar **grão** ou **colunas** de qualquer tabela da allowlist:
 |---|---|---|
 | **#37** (C5) | Janela no grão do de-vig | Precisa de desempate por `janela_usada` em `get_futebol_fixture_value` |
 | **#38** (C1) | Duas fases da escalação coexistem | `get_futebol_fixture_extras` duplicaria cada time e cada jogador; a projeção nem expõe `lineup_phase`. `lineup_phase` **já é coluna** nos dois fatos, então não há drift de esquema — só de grão |
-| **#40** (C5b) | Coluna `janela_deteccao` no mart | Coluna nova → migration antes do deploy |
+| **#40** (C5b) | Coluna `janela_deteccao` no mart | Coluna nova → migration antes do deploy, em **DUAS** tabelas: `futebol.fact_value_opportunities` e `futebol.fact_value_opportunities_hist` (o snapshot copia a linha inteira, então a coluna chega lá no primeiro `dbt snapshot` e o parity acusa as duas). `ALTER TABLE ... ADD COLUMN janela_deteccao text;` nos dois bancos (dev e prd). Nenhuma RPC muda: `get_futebol_value_board` declara o `RETURNS TABLE` coluna a coluna e não lista a nova — o board só passa a exibi-la quando o front pedir |
 | **#41** (C3b) | Contador de premissas sem dado | Coluna nova → migration antes do deploy |
 | **A1** | Remove `pts_valor`/`pts_corroboracao`/`penalidades` do mart | Colunas removidas **e** declaradas no `RETURNS TABLE` das duas RPCs → `DROP FUNCTION` + recriar |
 | **A7** | Tabela nova de funil | Livre — fora da allowlist |

--- a/dbt_futebol/macros/devig_janela.sql
+++ b/dbt_futebol/macros/devig_janela.sql
@@ -37,6 +37,42 @@
 
 
 {#-
+  O DE-VIG COM AS QUATRO JANELAS ABERTAS, cada uma carimbada com a sua prioridade e
+  com a resposta para "esta é a janela corrente desta linha?" (issue #40).
+
+  Existe porque o consumidor que precisa avaliar TODAS as janelas — hoje só o
+  `fact_value_opportunities`, para achar a janela de detecção — precisa saber qual
+  delas é a corrente ANTES de qualquer filtro seu. O flag é calculado aqui, sobre as
+  linhas cruas do de-vig, e não depois dos filtros do consumidor.
+
+  ⚠️ A diferença não é estética. Os ramos do mart filtram por completude do conjunto
+  (`pin_n_outcomes >= 3` no 1X2, `>= 2` no O/U e no AH). Se o `MAX(prioridade)` fosse
+  tirado DEPOIS desse filtro, uma linha cuja janela mais recente tem conjunto
+  incompleto veria a t24h virar "a corrente" e continuaria no board com o preço de
+  ontem — que é o oposto do que a ADR 0004 decidiu (preço que não dá para pegar sai
+  do board). Tirado aqui, a linha simplesmente não tem janela corrente publicável.
+
+  A partição é (fixture, mercado, LINHA) e deliberadamente NÃO inclui a saída — pela
+  mesma razão explicada em `futebol_devig_janela_corrente()` logo abaixo.
+-#}
+{% macro futebol_devig_todas_janelas() -%}
+    SELECT
+        d.* EXCEPT (_janela_prioridade, _line_key),
+        d._janela_prioridade AS janela_prioridade,
+        d._janela_prioridade = MAX(d._janela_prioridade) OVER (
+            PARTITION BY d.fixture_id, d.market_id, d._line_key
+        ) AS janela_e_corrente
+    FROM (
+        SELECT
+            *,
+            {{ futebol_janela_prioridade('janela_usada') }} AS _janela_prioridade,
+            COALESCE(CAST(line_value AS STRING), 'NONE')    AS _line_key
+        FROM {{ ref('int_futebol_odds_devig') }}
+    ) d
+{%- endmacro %}
+
+
+{#-
   O DE-VIG REDUZIDO À JANELA CORRENTE — a forma como todo consumidor lê o de-vig.
 
   O de-vig emite N linhas por (fixture, mercado, saída, linha), uma por janela
@@ -50,17 +86,13 @@
   conjunto de saídas: se o Home viesse da t15m e o Away da t1h, o Σ(1/odd) somaria
   preços de momentos diferentes. É a mesma partição que o `eval_odds` usava antes
   da #37, e é o que faz a saída do mart sair idêntica à de antes da mudança de grão.
+
+  Desde a #40 esta redução é um FILTRO sobre `futebol_devig_todas_janelas()`, e não
+  uma segunda cópia do `MAX(prioridade)`: as duas leituras do de-vig não têm como
+  divergir na definição de "janela corrente" porque só existe uma.
 -#}
 {% macro futebol_devig_janela_corrente() -%}
-    SELECT d.* EXCEPT (_janela_prioridade, _line_key)
-    FROM (
-        SELECT
-            *,
-            {{ futebol_janela_prioridade('janela_usada') }} AS _janela_prioridade,
-            COALESCE(CAST(line_value AS STRING), 'NONE')    AS _line_key
-        FROM {{ ref('int_futebol_odds_devig') }}
-    ) d
-    QUALIFY d._janela_prioridade = MAX(d._janela_prioridade) OVER (
-        PARTITION BY d.fixture_id, d.market_id, d._line_key
-    )
+    SELECT * EXCEPT (janela_prioridade, janela_e_corrente)
+    FROM ({{ futebol_devig_todas_janelas() }})
+    WHERE janela_e_corrente
 {%- endmacro %}

--- a/dbt_futebol/models/marts/_fact_value_opportunities.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities.yml
@@ -12,6 +12,9 @@ models:
       `market` — v5: 1X2 (match_winner) + Gols O/U (goals_over_under) + Handicap asiático
       (asian_handicap) + Ambos Marcam/BTTS (btts, via de-vig de consenso) + Dupla Chance
       (double_chance, saídas 1X/X2, prob derivada do 1X2 da Pinnacle, gate próprio). valor_fonte distingue.
+      ⚠️ Desde a #40 o gate é avaliado em TODAS as janelas coletadas e só depois reduzido a uma
+      linha: é o que permite dizer, em `janela_deteccao`, há quanto tempo a oportunidade está no
+      board. O grão não muda; o custo por build sim (os joins abrem ~4x antes do filtro final).
     columns:
       - name: fixture_id
         tests: [not_null]
@@ -71,9 +74,53 @@ models:
               arguments:
                 min_value: 0
                 inclusive: true
+      - name: janela_usada
+        description: >
+          Janela de coleta da avaliação PUBLICADA — a mais recente disponível para a linha
+          (daily < t24h < t1h < t15m). É a janela de onde saem best_odd, edge e as penalidades
+          de preço: o que o board mostra é o preço que ainda dá para pegar.
+        tests: [not_null]
+      - name: janela_deteccao
+        description: >
+          Janela mais cedo em que ESTA linha passou no gate (#40, ADR 0004) — o "há quanto tempo
+          está no board", para o apostador julgar se o mercado já teve chance de corrigir a
+          oportunidade. Igual a `janela_usada` quando a linha nasceu na janela corrente; mais
+          cedo quando ela já vinha passando. NUNCA posterior a `janela_usada` — guarda
+          assert_janela_deteccao_nao_posterior. ⚠️ Não é "quando o alerta saiu": linha que passou
+          em t24h e não passa mais na janela corrente sai do board inteira (preço que não dá mais
+          para pegar não é oportunidade); o registro do que já foi anunciado vive no snapshot
+          fact_value_opportunities_hist.
+        tests:
+          # Sem tag de propósito, e sem buraco no agendado: o caso NULL desta coluna é a
+          # primeira das duas condições de assert_janela_deteccao_nao_posterior, que é
+          # `tag:guarda`. Aqui o not_null serve o `dbt build` local e o CI.
+          - not_null
+          # Mesma lista, mesmo motivo e MESMA TAG do accepted_values de
+          # int_futebol_odds_devig.janela_usada: a ordem das janelas vive no macro
+          # futebol_janela_prioridade e janela fora da lista cai no ELSE 0 dele. Aqui a guarda
+          # também REPORTA em vez de prevenir — no agendado o `dbt run` é a fase 2 e o
+          # `dbt test --select tag:guarda` a 4, sem gate. Sem a tag ela não rodaria em lugar
+          # nenhum (o agendado só executa `tag:guarda`) e o comentário acima descreveria um
+          # caminho que o teste não teria como percorrer.
+          - accepted_values:
+              arguments:
+                values: ['daily', 't24h', 't1h', 't15m']
+              config:
+                severity: error
+                tags: ['guarda']
       - name: edge
         description: "EV/edge = best_odd * prob_justa − 1. Gate garante > 0 nas linhas materializadas. É a MEDIDA DE VALOR/EV — ranqueie por `edge` p/ tamanho de vantagem; `score`/`faixa` são índice de CONFIABILIDADE (não monotônicos no edge)."
     tests:
+      # O GRÃO NÃO MUDOU com a #40 — a janela NÃO entra nele. Depois que o gate passou a ser
+      # avaliado por (linha × janela), esta guarda é o que prova que a redução final continua
+      # devolvendo uma linha só: sem ela, a mesma oportunidade sairia no board uma vez por
+      # janela e o front não teria como saber qual mostrar.
+      #
+      # `tag:guarda` acrescentada na #40, e não é enfeite: até aqui a unicidade era garantida
+      # pelo QUALIFY do macro, ANTES dos joins, e este teste era confirmação de algo que a
+      # forma da consulta já impunha. Agora ela depende do `WHERE janela_e_corrente` do próprio
+      # mart — passou a ser a única coisa que separa o board de uma linha por janela, e uma
+      # guarda dessas que não roda no agendado é uma guarda que ninguém lê.
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -81,3 +128,5 @@ models:
               - market
               - outcome
               - line_value
+          config:
+            tags: ['guarda']

--- a/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
@@ -1,0 +1,99 @@
+version: 2
+
+# ==============================================================================
+# Unit test da JANELA DE DETECÇÃO (#40, ADR 0004).
+#
+# Por que unit test e não data test: as três situações que a coluna existe para
+# distinguir — detectada cedo e ainda viva, detectada cedo e já morta, nascida na
+# janela corrente — são indistinguíveis numa contagem sobre produção. Um board em
+# que toda `janela_deteccao` é igual a `janela_usada` é compatível tanto com "a
+# coluna está certa e nenhuma oportunidade sobreviveu duas janelas" quanto com "a
+# coluna está copiando janela_usada". Só linha construída separa as duas.
+#
+# Cada fixture isola um caso e muda UMA COISA SÓ em relação ao caso base:
+#
+#   1  passou em t24h e segue passando em t15m -> publica com deteccao=t24h
+#   2  passou em t24h e NÃO passa em t15m (o edge virou negativo) -> fora do board
+#   3  falhou em t24h (poucas casas) e só passou em t15m -> deteccao=t15m
+#   4  passou em t24h e a t15m veio com o conjunto da Pinnacle INCOMPLETO
+#      (pin_n_outcomes=2) -> fora do board
+#
+# A fixture 4 é a que não é óbvia, e é a razão de `janela_e_corrente` ser carimbado
+# no macro sobre o de-vig CRU em vez de calculado dentro do mart. A t15m dela é
+# descartada pelo filtro de completude do ramo 1X2; se o "qual é a janela corrente"
+# fosse tirado DEPOIS desse filtro, a t24h passaria a ser a corrente e a linha
+# continuaria no board exibindo o preço de ontem. Com o flag vindo de cima, ela
+# simplesmente não tem janela corrente publicável — que é o que a ADR 0004 decidiu.
+#
+# As linhas do de-vig são deliberadamente idênticas fora do que cada caso move:
+# pts_valor 30 + pts_premissas 15 = score 45 (faixa Média), a folga mínima confortável
+# sobre o gate de 40. Se alguém mexer nesses pesos e o teste ficar vermelho por score,
+# é o número daqui que se ajusta — não é o caso de teste que está errado.
+# ==============================================================================
+unit_tests:
+  - name: value_opportunities_janela_deteccao_e_a_mais_cedo_que_passou
+    model: fact_value_opportunities
+    description: >
+      A janela de detecção é a janela mais cedo em que a linha passou no gate, e nunca
+      é posterior à janela avaliada. Linha que passou cedo e não passa na janela
+      corrente — por preço ou por conjunto incompleto — não aparece no board.
+    given:
+      # format: sql porque evidencias/avisos são ARRAY<STRING>, e o formato de
+      # dicionário entrega todo valor como escalar (o cast de STRING p/ ARRAY falha).
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 1 AS fixture_id, 'Home' AS outcome, 'brasileirao' AS competition,
+                 2026 AS season, 15 AS pts_premissas, 0 AS premissas_sem_dado,
+                 0 AS penalidades_1x2_pts,
+                 CAST([] AS ARRAY<STRING>) AS evidencias,
+                 CAST([] AS ARRAY<STRING>) AS avisos
+          UNION ALL SELECT 2, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 3, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 4, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # -- fixture 1: passou nas duas. A t15m é a corrente; a t24h é a detecção. ---
+          - {fixture_id: 1, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't24h', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 1, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.08, pts_valor: 30, best_odd: 2.15, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- fixture 2: o mercado corrigiu até o fechamento — edge virou negativo. ---
+          - {fixture_id: 2, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't24h', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 2, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: -0.05, pts_valor: 30, best_odd: 1.90, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- fixture 3: em t24h o mercado ainda não estava líquido (2 casas). --------
+          - {fixture_id: 3, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't24h', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 2, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 3, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- fixture 4: a t15m existe, mas com o conjunto 1X2 da Pinnacle incompleto.
+          # O ramo 1X2 a descarta (pin_n_outcomes >= 3). A t24h NÃO herda o posto de
+          # janela corrente por isso — é a asserção que protege o carimbo no macro.
+          - {fixture_id: 4, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't24h', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 4, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      # Os outros quatro mercados e a corroboração ficam vazios de propósito: o que se
+      # mede aqui é só a janela, e o 1X2 é o ramo com o gate de completude mais estrito.
+      - input: ref('int_futebol_premissas_ou')
+        rows: []
+      - input: ref('int_futebol_premissas_ah')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+
+    expect:
+      rows:
+        # fixture 1: publica a t15m (o preço que dá para pegar) e conta que a
+        # oportunidade está no board desde a t24h.
+        - {fixture_id: 1, market: 'match_winner', outcome: 'Home', janela_usada: 't15m', janela_deteccao: 't24h', score: 45}
+        # fixture 3: nasceu na janela corrente — detecção e avaliação coincidem.
+        - {fixture_id: 3, market: 'match_winner', outcome: 'Home', janela_usada: 't15m', janela_deteccao: 't15m', score: 45}
+        # As fixtures 2 e 4 não aparecem. São as duas formas de morrer na janela
+        # corrente: a 2 por preço, a 4 por conjunto incompleto.

--- a/dbt_futebol/models/marts/fact_value_opportunities.sql
+++ b/dbt_futebol/models/marts/fact_value_opportunities.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='table',
     cluster_by=['competition', 'fixture_id'],
-    description='Mart de saída do Motor de Score de Confiabilidade (value bet futebol). 1 linha por (fixture_id, market, outcome, line_value) que PASSA no gate (edge>0 E n_casas>=3 E de-vig válido E conjunto da Pinnacle completo pro mercado E score>=40 E — p/ Handicap asiático/Gols O/U — linha meia .5, sem push). Score 0-100 = clamp(PTS_VALOR + PTS_PREMISSAS + PTS_CORROBORACAO − PENALIDADES). faixa Alta(>=60)/Média(40-59); abaixo de 40 não vira oportunidade. evidencias[] = o "por quê" (premissas + corroboração); avisos[] = red flags. Long por `market` — v5 liga 1X2 (market_id=1) + Gols O/U (market_id=5) + Handicap asiático (market_id=4) + Ambos Marcam/BTTS (market_id=8) + Dupla Chance (market_id=12, saídas 1X/X2). Junta int_futebol_premissas_1x2/_ou/_ah/_btts/_dc + int_futebol_odds_devig + int_futebol_corroboracao. line_value é NULL no 1X2/BTTS/DC, a linha L no O/U e o handicap (ótica do mandante, mesmo p/ Home e Away) no AH. valor_fonte = pinnacle (de-vig da Pinnacle, mercados 1/4/5; e DC, derivada do 1X2 da Pinnacle) ou consenso (de-vig da mediana das casas — BTTS, pois a Pinnacle não precifica; rotular como estimativa no front). A DC tem GATE PRÓPRIO (melhor_odd >=1,25, sem odd_juice) — aplicado no ramo joined_dc; o gate >=1,25 já garante o retorno mínimo (sem penalidade específica de odd baixa). Contador de cegueira (#41, ADR 0003): premissas_sem_dado diz QUANTAS premissas aplicáveis àquela linha não puderam ser avaliadas por falta de insumo — gerado do mapa futebol_insumos_premissa(), nunca escrito à mão. QUAIS foram fica nos modelos de premissas (premissas_cegas[]), de onde este número vem: o mart carrega a contagem, que é o que o board exibe. O score NÃO muda: a premissa cega já não acendia e continua não acendendo; o que muda é o board passar a dizer o que não levou em conta. premissas_sem_dado é propagado dos cinco modelos de premissas e sai também como aviso em avisos[], SEM pontos entre parênteses: ele não desconta nada, diz que a nota está incompleta e não contrária (#41, ADR 0003).'
+    description='Mart de saída do Motor de Score de Confiabilidade (value bet futebol). 1 linha por (fixture_id, market, outcome, line_value) que PASSA no gate (edge>0 E n_casas>=3 E de-vig válido E conjunto da Pinnacle completo pro mercado E score>=40 E — p/ Handicap asiático/Gols O/U — linha meia .5, sem push). Score 0-100 = clamp(PTS_VALOR + PTS_PREMISSAS + PTS_CORROBORACAO − PENALIDADES). faixa Alta(>=60)/Média(40-59); abaixo de 40 não vira oportunidade. evidencias[] = o "por quê" (premissas + corroboração); avisos[] = red flags. Long por `market` — v5 liga 1X2 (market_id=1) + Gols O/U (market_id=5) + Handicap asiático (market_id=4) + Ambos Marcam/BTTS (market_id=8) + Dupla Chance (market_id=12, saídas 1X/X2). Junta int_futebol_premissas_1x2/_ou/_ah/_btts/_dc + int_futebol_odds_devig + int_futebol_corroboracao. line_value é NULL no 1X2/BTTS/DC, a linha L no O/U e o handicap (ótica do mandante, mesmo p/ Home e Away) no AH. valor_fonte = pinnacle (de-vig da Pinnacle, mercados 1/4/5; e DC, derivada do 1X2 da Pinnacle) ou consenso (de-vig da mediana das casas — BTTS, pois a Pinnacle não precifica; rotular como estimativa no front). A DC tem GATE PRÓPRIO (melhor_odd >=1,25, sem odd_juice) — aplicado no ramo joined_dc; o gate >=1,25 já garante o retorno mínimo (sem penalidade específica de odd baixa). Contador de cegueira (#41, ADR 0003): premissas_sem_dado diz QUANTAS premissas aplicáveis àquela linha não puderam ser avaliadas por falta de insumo — gerado do mapa futebol_insumos_premissa(), nunca escrito à mão. QUAIS foram fica nos modelos de premissas (premissas_cegas[]), de onde este número vem: o mart carrega a contagem, que é o que o board exibe. O score NÃO muda: a premissa cega já não acendia e continua não acendendo; o que muda é o board passar a dizer o que não levou em conta. premissas_sem_dado é propagado dos cinco modelos de premissas e sai também como aviso em avisos[], SEM pontos entre parênteses: ele não desconta nada, diz que a nota está incompleta e não contrária (#41, ADR 0003). JANELA DE DETECÇÃO (#40, ADR 0004): janela_deteccao é a janela mais cedo (daily<t24h<t1h<t15m) em que ESTA linha passou no gate; janela_usada continua sendo a janela corrente, a que dá o preço publicado. Nunca posterior a janela_usada (guarda assert_janela_deteccao_nao_posterior). O grão NÃO muda — segue 1 linha por (fixture, mercado, saída, linha) —, mas o CUSTO muda: achar a janela mais cedo exige rodar o gate (nota inclusa) em TODAS as janelas coletadas e só depois reduzir, então os joins deste mart abrem ~4x antes do WHERE final. Linha que passou numa janela cedo e não passa na corrente NÃO aparece no board: preço que o usuário não consegue mais pegar não é oportunidade, e o histórico do que já foi anunciado vive no snapshot fact_value_opportunities_hist.'
 ) }}
 
 WITH prem_1x2 AS (
@@ -25,14 +25,18 @@ prem_dc AS (
 ),
 
 -- line_key STRING (NULL-safe) p/ casar a linha entre modelos sem depender de igualdade FLOAT.
--- REDUZIDO À JANELA CORRENTE (#37): o de-vig passou a emitir uma avaliação por janela
--- coletada. Sem a redução, cada join deste mart abriria uma linha por janela e o board
--- inflaria em silêncio — a mesma oportunidade publicada 4 vezes, uma por preço. A
--- redução reproduz exatamente a janela que o de-vig escolhia sozinho antes da #37, e é
--- por isso que a saída deste mart sai idêntica à de antes da mudança de grão.
+-- TODAS AS JANELAS ABERTAS (#40, ADR 0004): até a #37 este mart lia o de-vig já reduzido
+-- à janela corrente. A janela de detecção — a janela mais cedo em que a linha passou no
+-- gate — não é derivável dessa leitura: o gate inclui a NOTA, e a nota depende do preço,
+-- que é o que varia entre janelas. Logo o mart avalia (linha × janela) e só depois reduz.
+-- É mais cálculo por build do que a entrega anterior, e é o que a coluna custa.
+-- O flag `janela_e_corrente` vem carimbado do macro, calculado sobre o de-vig CRU: se
+-- fosse tirado aqui, depois dos filtros de completude dos ramos, uma linha cuja janela
+-- mais recente tem conjunto incompleto veria a anterior virar "a corrente" e seguiria no
+-- board com um preço que já não existe.
 devig AS (
     SELECT *, COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
-    FROM ({{ futebol_devig_janela_corrente() }})
+    FROM ({{ futebol_devig_todas_janelas() }})
 ),
 
 corro AS (
@@ -63,6 +67,8 @@ joined_1x2 AS (
         d.pin_n_outcomes,
         d.valor_fonte,
         d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
         COALESCE(d.penalidades_globais_pts, 0)  AS penalidades_globais_pts,
         d.pen_odd_outlier,
         d.pen_poucas_casas,
@@ -113,6 +119,8 @@ joined_ou AS (
         d.pin_n_outcomes,
         d.valor_fonte,
         d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
         COALESCE(d.penalidades_globais_pts, 0)  AS penalidades_globais_pts,
         d.pen_odd_outlier,
         d.pen_poucas_casas,
@@ -167,6 +175,8 @@ joined_ah AS (
         d.pin_n_outcomes,
         d.valor_fonte,
         d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
         COALESCE(d.penalidades_globais_pts, 0)  AS penalidades_globais_pts,
         d.pen_odd_outlier,
         d.pen_poucas_casas,
@@ -221,6 +231,8 @@ joined_btts AS (
         d.pin_n_outcomes,
         d.valor_fonte,
         d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
         COALESCE(d.penalidades_globais_pts, 0)  AS penalidades_globais_pts,
         d.pen_odd_outlier,
         d.pen_poucas_casas,
@@ -275,6 +287,8 @@ joined_dc AS (
         d.pin_n_outcomes,
         d.valor_fonte,
         d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
         -- penalidades globais SEM odd_juice (a DC tem gate de odd próprio).
         ( 30 * CAST(d.pen_odd_outlier  AS INT64)
         + 12 * CAST(d.pen_poucas_casas AS INT64)
@@ -332,6 +346,73 @@ scored AS (
         -- TRUE só p/ .5; FALSE p/ linha cheia (2.0) e quarter; NULL onde não há linha (1X2/BTTS/DC).
         (MOD(CAST(ROUND(ABS(line_value) * 2) AS INT64), 2) = 1) AS is_half_line
     FROM unioned
+),
+
+-- ============================================================================
+-- O GATE, AGORA POR (LINHA × JANELA) (#40). Era o WHERE final; virou coluna porque a
+-- janela de detecção é "a janela mais cedo em que ESTA linha passou no gate", e não dá
+-- para saber isso sem avaliar o gate em todas elas. A completude do conjunto por
+-- mercado já foi aplicada ramo a ramo (1X2 >=3 saídas, O/U e AH >=2, DC >=3 + odd
+-- >=1,25): janela que não a satisfaz nem chega aqui, e por isso não pode ser detectada.
+-- COALESCE(..., FALSE) mantém a "degradação graciosa" do Motor — insumo NULL reprova a
+-- janela em vez de propagar NULL para dentro da detecção.
+-- ============================================================================
+avaliadas AS (
+    SELECT
+        *,
+        COALESCE(
+            edge > CASE
+                     -- #1: edge de CONSENSO (BTTS — Pinnacle não precifica) é enviesado
+                     -- p/ cima (best_odd=MAX das casas vs prob da MEDIANA) -> exige piso
+                     -- de edge maior. Tunável via var consensus_min_edge (default 3%).
+                     WHEN valor_fonte = 'consenso' THEN {{ var('consensus_min_edge', 0.03) }}
+                     ELSE 0
+                   END
+            -- mercado líquido, de-vig válido e o contrato "abaixo de 40 não vira
+            -- oportunidade" (#c).
+            AND n_casas >= 3
+            AND prob_justa_fechamento IS NOT NULL
+            AND score >= 40
+            -- #2: exclui linha NÃO-meia (cheia/quarter) de Handicap asiático e Gols O/U —
+            -- nessas o resultado pode dar push/meio-push e o de-vig 2-way superdimensiona
+            -- o edge; mercados sem linha (1X2/BTTS/DC) passam direto.
+            AND (market NOT IN ('asian_handicap', 'goals_over_under') OR is_half_line),
+        FALSE) AS passou_no_gate
+    FROM scored
+),
+
+-- ============================================================================
+-- A JANELA DE DETECÇÃO (#40, ADR 0004): a janela mais cedo, entre as coletadas para
+-- esta linha, em que ela passou no gate. Diz há quanto tempo a oportunidade está no
+-- board — para o apostador julgar se o mercado já teve chance de corrigi-la.
+--
+-- É calculada ANTES do filtro final de propósito: a janela que detectou não é (quase
+-- nunca) a janela publicada, e filtrar primeiro apagaria justamente as linhas de onde
+-- ela sai. A ordenação é pela prioridade declarada em futebol_janela_prioridade(),
+-- nunca pelo nome da janela ('daily' < 't15m' em ordem alfabética diria o contrário).
+--
+-- INVARIANTE: janela_deteccao nunca é posterior à janela avaliada. Sai de graça da
+-- construção — a linha publicada passou no gate na janela corrente, então ela mesma é
+-- candidata ao FIRST_VALUE e nenhuma janela posterior a ela existe na partição. A
+-- guarda assert_janela_deteccao_nao_posterior mede isso em produção mesmo assim, porque
+-- "sai da construção" é exatamente o tipo de garantia que um refactor futuro remove sem
+-- perceber.
+--
+-- Linha que passou numa janela cedo e NÃO passa na corrente continua fora do board (o
+-- WHERE final exige as duas coisas): preço que o usuário não consegue mais pegar não é
+-- oportunidade, é ruído com carimbo de oportunidade. O histórico do que já foi
+-- anunciado tem lugar próprio no snapshot fact_value_opportunities_hist.
+-- ============================================================================
+com_deteccao AS (
+    SELECT
+        *,
+        FIRST_VALUE(IF(passou_no_gate, janela_usada, NULL) IGNORE NULLS) OVER (
+            PARTITION BY fixture_id, market, outcome,
+                         COALESCE(CAST(line_value AS STRING), 'NONE')
+            ORDER BY janela_prioridade
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS janela_deteccao
+    FROM avaliadas
 )
 
 SELECT
@@ -392,6 +473,10 @@ SELECT
     prob_justa_fechamento,
     valor_fonte,
     janela_usada,
+    -- #40: a janela mais cedo em que esta linha passou no gate. Igual a janela_usada
+    -- quando a oportunidade nasceu na janela corrente; mais cedo quando ela já estava
+    -- no board antes. Nunca posterior a janela_usada.
+    janela_deteccao,
 
     -- componentes (transparência/debug)
     penalidades_globais_pts,
@@ -404,20 +489,16 @@ SELECT
     -- no edge — um bet de 1% de edge pode ter score maior que um de 6%). Sem coluna ev_rank dedicada.
 
     CURRENT_TIMESTAMP() AS dbt_loaded_at
-FROM scored
--- Gate (a completude da Pinnacle por mercado já foi aplicada por ramo: 1X2 >=3 outcomes,
--- O/U e AH >=2). Aqui: edge positivo, mercado líquido (>=3 casas), de-vig válido E score>=40
--- (#c: honra o contrato "abaixo de 40 não vira oportunidade"). #2: exclui linha NÃO-meia
--- (cheia/quarter) de Handicap asiático e Gols O/U — nessas o resultado pode dar push/meio-push
--- e o de-vig 2-way superdimensiona o edge; mercados sem linha (1X2/BTTS/DC) passam direto.
-WHERE edge > CASE
-               -- #1: edge de CONSENSO (BTTS — Pinnacle não precifica) é enviesado p/ cima
-               -- (best_odd=MAX das casas vs prob da MEDIANA) -> exige piso de edge maior.
-               -- Conservador e TUNÁVEL via var consensus_min_edge (default 0.03 = 3%).
-               WHEN valor_fonte = 'consenso' THEN {{ var('consensus_min_edge', 0.03) }}
-               ELSE 0
-             END
-  AND n_casas >= 3
-  AND prob_justa_fechamento IS NOT NULL
-  AND score >= 40
-  AND (market NOT IN ('asian_handicap', 'goals_over_under') OR is_half_line)
+FROM com_deteccao
+-- A REDUÇÃO A UMA LINHA POR (fixture, mercado, saída, linha) (#40). O grão do mart não
+-- mudou; o que mudou é que a redução agora é explícita aqui, em vez de vir pronta do
+-- macro futebol_devig_janela_corrente(). As duas condições respondem coisas diferentes
+-- e as duas são necessárias:
+--   janela_e_corrente — publica o preço que o usuário consegue pegar AGORA (e é o que
+--                       garante uma linha só: o flag vem de um MAX por (fixture,
+--                       mercado, linha) sobre o de-vig cru);
+--   passou_no_gate    — a oportunidade tem de valer NA janela corrente. Ter valido em
+--                       t24h e não valer mais em t15m é motivo para sair do board, não
+--                       para ficar nele com carimbo antigo (ADR 0004).
+WHERE janela_e_corrente
+  AND passou_no_gate

--- a/dbt_futebol/snapshots/fact_value_opportunities_hist.sql
+++ b/dbt_futebol/snapshots/fact_value_opportunities_hist.sql
@@ -22,6 +22,19 @@
 -- então check_cols='all' quebraria a SQL compilada. dbt_loaded_at também fica de fora (muda a
 -- cada run, geraria versão nova sempre). opportunity_key é NULL-safe (line_value é NULL em
 -- match_winner/btts/double_chance) — mesmo padrão do line_key usado no resto do Motor de Score.
+--
+-- `janela_deteccao` (#40) fica FORA do check_cols de propósito, e a chave não muda por causa
+-- dela. Duas razões:
+--   · o histórico já publicado é preservado: as linhas vivas hoje têm a coluna NULL, e um
+--     check sobre ela fecharia TODAS elas e abriria uma versão nova de cada uma no primeiro
+--     run depois do deploy — um pico de churn fabricado pelo deploy, bem no meio da medição
+--     de churn da ADR 0009 (issue #80);
+--   · a coluna não precisa do check para chegar ao histórico: o snapshot grava a linha
+--     INTEIRA a cada versão nova, e `janela_usada`/`edge` mudam a cada janela antes do apito,
+--     então toda oportunidade viva ganha versão com a coluna preenchida sozinha.
+-- Se um dia a janela de detecção mudar SEM que nada em check_cols mude, a transição não vira
+-- versão — troca aceita: isso só acontece quando a nota de uma janela antiga cruza o gate de
+-- 40 por mudança de PREMISSA, não por mudança de preço.
 SELECT
     CONCAT(
       CAST(fixture_id AS STRING), '|', market, '|', outcome, '|',

--- a/dbt_futebol/tests/assert_janela_deteccao_nao_posterior.sql
+++ b/dbt_futebol/tests/assert_janela_deteccao_nao_posterior.sql
@@ -1,0 +1,44 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DA INVARIANTE DA JANELA DE DETECÇÃO (#40, ADR 0004): a janela em que a linha foi
+-- DETECTADA nunca é posterior à janela em que ela está sendo AVALIADA, e nunca é nula numa
+-- linha publicada.
+--
+-- Hoje a invariante sai da construção do mart: só é publicada a linha que passou no gate na
+-- janela corrente, então ela mesma é candidata ao FIRST_VALUE e não existe janela posterior a
+-- ela na partição. A guarda existe porque "sai da construção" é precisamente o tipo de
+-- garantia que um refactor futuro remove sem perceber — e o sintoma seria o board dizendo que
+-- uma oportunidade nascida no fechamento já estava lá desde a véspera, que é uma mentira que
+-- o apostador não tem como conferir.
+--
+-- As duas direções, e por que as duas importam:
+--
+--   · deteccao POSTERIOR à avaliada — a coluna passou a olhar para a frente. Seria o caso se
+--     alguém trocasse a ordenação do FIRST_VALUE (ASC -> DESC) ou ordenasse pelo NOME da
+--     janela: em ordem alfabética 'daily' < 't15m' < 't1h' < 't24h', e a t24h viraria a mais
+--     tarde de todas;
+--   · deteccao NULA — a linha foi publicada sem ter passado no gate em janela nenhuma, o que
+--     só acontece se o filtro final e o cálculo da detecção pararem de falar do mesmo gate.
+--
+-- ⚠️ Ponto cego declarado: janela desconhecida tem prioridade 0 em futebol_janela_prioridade()
+-- e, comparada com uma janela conhecida, satisfaz "não é posterior" trivialmente. É o mesmo
+-- ponto cego que a #37 registrou no macro, e quem previne de verdade é o accepted_values de
+-- `fact_odds_snapshot.collection_window`, a montante — janela nova só chega aqui se antes
+-- existir lá.
+
+SELECT
+    fixture_id,
+    market,
+    outcome,
+    line_value,
+    janela_usada,
+    janela_deteccao,
+    CASE
+        WHEN janela_deteccao IS NULL
+            THEN 'linha publicada sem janela de detecção — o filtro final e o cálculo da detecção deixaram de usar o mesmo gate'
+        ELSE 'janela de detecção posterior à janela avaliada — a coluna passou a olhar para a frente (ordenação do FIRST_VALUE invertida ou por nome?)'
+    END AS diagnostico
+FROM {{ ref('fact_value_opportunities') }}
+WHERE janela_deteccao IS NULL
+   OR ({{ futebol_janela_prioridade('janela_deteccao') }})
+      > ({{ futebol_janela_prioridade('janela_usada') }})
+ORDER BY fixture_id, market, outcome, line_value


### PR DESCRIPTION
O board dizia em que janela a oportunidade está sendo avaliada (`janela_usada`) e não dizia
desde quando ela está lá. Agora diz: **`janela_deteccao` é a janela mais cedo
(`daily < t24h < t1h < t15m`) em que AQUELA linha passou no gate** — o que o apostador precisa
para julgar se o mercado já teve chance de corrigi-la.

O grão **não** muda: continua 1 linha por `(fixture, mercado, saída, linha)`, avaliada na janela
corrente. O que muda é o custo por build, e é o que a coluna custa: saber qual foi a janela mais
cedo que passou exige rodar o gate em **todas** as janelas, e o gate inclui a nota. Então a nota
passa a ser calculada por (linha × janela) e só depois reduzida. O que era o `WHERE` final virou
a coluna `passou_no_gate`; a redução final passou a ser `janela_e_corrente AND passou_no_gate`.

## O detalhe que carrega a mudança

O carimbo de "esta é a janela corrente" saiu do consumidor e subiu para o macro novo
`futebol_devig_todas_janelas()`, calculado sobre o de-vig **cru**. Não é estética: os ramos do
mart filtram por completude do conjunto (1X2 ≥ 3 saídas, O/U e AH ≥ 2). Se o `MAX(prioridade)`
fosse tirado depois desse filtro, uma linha cuja t15m veio com o conjunto incompleto veria a
t24h virar "a corrente" e seguiria no board **com o preço de ontem** — o oposto do que a ADR
0004 decidiu. É a quarta fixture do unit test, e ela fica vermelha quando o carimbo desce para
o mart (falsificado, não suposto).

`futebol_devig_janela_corrente()` passou a ser um filtro sobre o macro novo em vez de uma
segunda cópia do `QUALIFY` — as duas leituras do de-vig não têm mais como divergir na definição
de janela corrente.

## Medições

**O board não se moveu.** Velho e novo compilados e comparados no mesmo instante, sobre o mesmo
upstream, ignorando só a coluna nova:

| medida | resultado |
|---|---|
| linhas no velho / no novo | **126 / 126** |
| `EXCEPT DISTINCT` nos dois sentidos | **0 / 0** |
| macro `janela_corrente` velho vs novo | **40.061 / 40.061**, `EXCEPT` vazio nos dois sentidos |

**A coluna está viva, não está copiando `janela_usada`** — 111 das 126 linhas têm detecção
anterior à avaliação, e a invariante vale em todas as células:

```
detecção → avaliada     linhas
t1h   → t15m               91
t24h  → t15m               18
t15m  → t15m                9
daily → daily               5
daily → t15m                1
daily → t24h                1
t1h   → t1h                 1
```

**As cinco checagens, medidas sobre produção: 0 falhas cada** — invariante (detecção ≤ avaliada),
`not_null` e `accepted_values` da coluna nova, `not_null` de `janela_usada`, e a unicidade de
`(fixture, mercado, saída, linha)`.

**Unit test** com quatro fixtures construídas, cobrindo as três do aceite mais a do conjunto
incompleto. Falsificado nas duas direções que importam: com `janela_deteccao = janela_usada`
fica vermelho, e com o carimbo de janela corrente calculado pós-join também.

## Snapshot

`janela_deteccao` fica **fora** do `check_cols` de propósito: as linhas vivas hoje têm a coluna
NULL, e um check sobre ela fecharia todas elas no primeiro run depois do deploy — um pico de
churn fabricado pelo deploy, bem no meio da medição de churn da ADR 0009 (#80). A coluna chega
ao histórico sozinha, porque o snapshot grava a linha inteira e `janela_usada`/`edge` mudam a
cada janela antes do apito.

## Guardas: `tag:guarda` vai de 20 para 23

- a guarda nova da invariante (`assert_janela_deteccao_nao_posterior`);
- o `accepted_values` de `janela_deteccao` — leva `tags` junto com `severity` pelo mesmo motivo
  do gêmeo dele em `int_futebol_odds_devig`; sem a tag não rodaria em lugar nenhum;
- o `unique_combination_of_columns` do mart, **que já existia sem tag**. Até aqui a unicidade
  vinha do `QUALIFY` do macro, ANTES dos joins, e o teste confirmava o que a forma da consulta
  já impunha. Agora ela depende do `WHERE janela_e_corrente` deste mart: virou a única coisa que
  separa o board de uma linha por janela — que é exatamente a "guarda de unicidade verde" que o
  aceite da issue nomeia.

O `not_null` de `janela_deteccao` fica sem tag de propósito: o caso NULL é a primeira das duas
condições da guarda da invariante, que roda no agendado.

## ⚠️ Deploy — nenhum passo é opcional

Coluna nova exige `ALTER` no Postgres **antes** do job dbt, senão o parity aborta as 21 tabelas
do sync. São **duas** tabelas, nos **dois** bancos (dev e prd) — o snapshot copia a linha
inteira, então a coluna chega ao `_hist` no primeiro `dbt snapshot`:

```sql
ALTER TABLE futebol.fact_value_opportunities      ADD COLUMN janela_deteccao text;
ALTER TABLE futebol.fact_value_opportunities_hist ADD COLUMN janela_deteccao text;
```

1. `ALTER` nas duas tabelas, nos dois bancos;
2. `build-and-push.sh dbt_futebol` + `gcloud run jobs update` — mudança de modelo dbt só entra
   em produção com imagem nova; sem isso o job roda o SQL velho e a coluna nunca aparece;
3. job dbt: `run` **e** `snapshot` (só o `dbt snapshot` cria a coluna no `hist`);
4. re-disparar o sync à mão (`gcloud workflows execute workflow-futebol-sync`) e conferir a
   linha `env=prd concluído` no log do serviço — o prd aborta **uma** vez sem retry e o workflow
   fica verde de qualquer jeito.

**Nenhuma das 18 RPCs muda:** as duas que leem o mart listam as colunas uma a uma no
`RETURNS TABLE` (verificado no banco vivo), então a coluna nova não as quebra e o board só passa
a exibi-la quando o front pedir.

**O mart NÃO foi materializado**, de propósito — construí-lo antes do `ALTER` é exatamente a
ordem que abre a janela de aborto. Por isso os três testes que leem a tabela (`not_null`,
`accepted_values`, guarda) ficam em `Database Error` até o deploy; a lógica dos três foi
validada em separado contra o dado real, com 0 falhas. **Depois do merge o detector de deriva de
imagem fica vermelho para `dbt_futebol` até o passo 2** — é o detector funcionando, não uma
quebra.

A #80 (expurgo do board, ADR 0009) continua aberta e entra **antes** desta no deploy — ela não
acrescenta coluna e o filtro dela é ortogonal a esta mudança.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
