### PR TITLE
feat(futebol): as duas fases da escalação coexistem nos fatos (#38)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -259,6 +259,9 @@ The starting eleven as announced before kickoff, roughly forty minutes out — d
 from the escalação real recorded after the match. It is the only pre-kickoff evidence of
 who actually plays, and it arrives too late to inform any janela but t15m. Its value is
 therefore corroboration and measurement, not the desfalque premissa itself.
+Since #38 the phase is part of the grain of both lineup facts, so the two coexist and the
+confirmada is no longer overwritten by the real — reading either one means filtering
+`lineup_phase`, and anything measured before kickoff must read `'confirmed'`.
 _Avoid_: escalação provável (the source does not publish one)
 
 **Titular importante**:

--- a/dbt_futebol/docs/contrato-serving-rpcs.md
+++ b/dbt_futebol/docs/contrato-serving-rpcs.md
@@ -41,7 +41,7 @@ e ele deixa de ser tabela de análise para virar fonte de duas telas.
 | `fact_odds_snapshot` | 2 | `distinct on (…, bookmaker_name)` com desempate por janela | ⛔ **DEFEITO VIVO** — ver abaixo |
 | `fact_value_opportunities` | 2 | 1 linha por (fixture, market, outcome, line) | ✅ hoje; ⚠️ #40/#41/A1 mexem nas COLUNAS |
 | `int_futebol_odds_devig` | 1 (`get_futebol_fixture_value`) | `distinct on (fixture_id, outcome_side, line_value)` **sem desempate** | ⛔ bloqueia a #37 |
-| `fact_fixture_lineups` + `_players` | 1 (`get_futebol_fixture_extras`) | `jsonb_agg` de TODAS as linhas do fixture, sem filtro de fase | ⛔ bloqueia a #38 |
+| `fact_fixture_lineups` + `_players` | 1 (`get_futebol_fixture_extras`) | `jsonb_agg` de TODAS as linhas do fixture, sem filtro de fase | ⛔ **bloqueia o DEPLOY da #38** — o lado dbt está pronto; ver abaixo |
 | `fact_injuries_snapshot` | 1 | `distinct on (player_id)` + `order by snapshot_date desc` | ✅ desempate correto e semântico |
 | 5 × `int_futebol_premissas_*` | 2 cada | join por (fixture, outcome[, line]) | ✅ hoje; ⚠️ #41 pode adicionar coluna |
 | `fact_h2h`, `fact_predictions_api`, `fact_standings_snapshot`, `fact_team_season_stats`, `fact_fixture_stats`, `fact_fixture_events`, `fact_fixture_player_stats` | 1–2 cada | leitura direta, sem suposição de unicidade além da chave natural | ✅ |
@@ -73,6 +73,31 @@ Conserto: acrescentar `when collection_window = 't24h' then 2` deslocando os dem
 derivar a prioridade de um lugar só. No dbt esse lugar já existe — o macro
 `futebol_janela_prioridade` — mas ele não atravessa para o Postgres, então aqui é duplicação
 inevitável e o que resta é **manter as duas listas juntas na mesma mudança**.
+
+## ⛔ Gate aberto: a #38 mergeou no dbt e o `get_futebol_fixture_extras` ainda não filtra fase
+
+**Não rodar `./build-and-push.sh dbt_futebol` até a RPC ser corrigida.** O lado dbt da #38 está
+no `master`: `lineup_phase` entrou no grão dos dois fatos e as duas fases coexistem. Enquanto a
+imagem não for reconstruída, o agendado segue materializando o grão ANTIGO e o app não vê
+diferença — é isso que segura o gate. No dia em que a imagem subir sem a RPC:
+
+- `lineups` passa de 2 para **4** elementos nos jogos com as duas fases (279 hoje). O front faz
+  `extras.lineups.find(l => l.team_side === 'home')?.formation` sobre array sem ordem — a
+  formação exibida vira sorteio entre a anunciada e a que entrou em campo, e pode virar entre
+  dois carregamentos da mesma página.
+- `lineup_players` **dobra** (275 fixtures hoje): cada jogador desenhado duas vezes no campinho,
+  com `is_starter`/`grid` contraditórios entre as duas cópias.
+
+Conserto, do lado do app (`prop-play-predictor`, escopo do Victor): filtrar
+`lineup_phase = 'real'` nos dois sub-selects quando o jogo já terminou e `'confirmed'` antes do
+apito — ou, mais simples e suficiente para não regredir, `distinct on` com desempate explícito
+de fase. Vale expor `lineup_phase` na projeção junto: sem ela o front não tem como dizer ao
+usuário que está vendo a escalação anunciada e não a que jogou, que é o produto que a #38
+destrava.
+
+⚠️ **A spec da #38 afirmava "a aplicação não os consulta".** É falso, e este documento já
+registrava isso desde 10/08 — a spec é de 06/08 e não foi revisada depois. A verificação de
+grão da spec não substituiu a consulta ao banco vivo do passo 1 abaixo.
 
 ## A regra que vale daqui pra frente
 

--- a/dbt_futebol/models/marts/_fact_fixture_lineups__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_fixture_lineups__unit_tests.yml
@@ -1,0 +1,87 @@
+version: 2
+
+# ==============================================================================
+# Unit tests das DUAS FASES DA ESCALAÇÃO (#38).
+#
+# Por que unit test e não data test: a fase confirmada e a fase real do mesmo jogo
+# são a mesma escalação vista em dois momentos, e uma contagem sobre produção não
+# separa "as duas coexistem" de "a real chegou e a confirmada nunca existiu". A
+# maior parte da base é backfill histórico, que só tem fase real — um fato com
+# 100% de linhas 'real' é compatível tanto com o grão novo quanto com o dedup
+# antigo, que apagava a confirmada. Só linha construída separa as duas.
+#
+# Cada teste sustenta as duas metades do aceite, uma em cada fixture:
+#
+#   fixture 1  o mesmo jogo tem as duas fases -> as duas sobrevivem
+#   fixture 2  duas cargas da MESMA fase (re-execução do pipeline) -> colapsam em 1
+#
+# A fixture 1 carrega o valor que a issue pede: no nível time a formação muda entre
+# o que se anunciou (4-4-2) e o que entrou em campo (4-3-3); no nível jogador o
+# titular anunciado começa no banco. É exatamente essa diferença que o dedup antigo
+# apagava, e ela é look-ahead: a versão real só existe depois do apito.
+# ==============================================================================
+unit_tests:
+  - name: fixture_lineups_as_duas_fases_do_mesmo_jogo_coexistem
+    model: fact_fixture_lineups
+    description: >
+      Nível time: confirmed e real do mesmo (fixture, time) coexistem — a real deixa
+      de sobrescrever a confirmada. Duas cargas da mesma fase continuam colapsando
+      em uma (latest-wins dentro da fase), para absorver re-execução do pipeline.
+    given:
+      - input: ref('stg_futebol_fixture_lineups')
+        rows:
+          # -- fixture 1: as duas fases do mandante; só a confirmada do visitante. ----
+          # A formação anunciada não é a que entrou em campo.
+          - {fixture_id: 1, team_id: 10, team_name: 'Mandante', lineup_phase: 'confirmed', formation: '4-4-2', coach_id: 900, coach_name: 'Tecnico A', loaded_at: '2026-08-01 20:30:00'}
+          - {fixture_id: 1, team_id: 10, team_name: 'Mandante', lineup_phase: 'real', formation: '4-3-3', coach_id: 900, coach_name: 'Tecnico A', loaded_at: '2026-08-01 23:00:00'}
+          - {fixture_id: 1, team_id: 20, team_name: 'Visitante', lineup_phase: 'confirmed', formation: '3-5-2', coach_id: 901, coach_name: 'Tecnico B', loaded_at: '2026-08-01 20:30:00'}
+
+          # -- fixture 2: a MESMA fase coletada duas vezes (re-execução do pipeline). -
+          # A segunda carga corrige a formação; vence por loaded_at, sem duplicar.
+          - {fixture_id: 2, team_id: 10, team_name: 'Mandante', lineup_phase: 'confirmed', formation: '4-4-2', coach_id: 900, coach_name: 'Tecnico A', loaded_at: '2026-08-02 20:30:00'}
+          - {fixture_id: 2, team_id: 10, team_name: 'Mandante', lineup_phase: 'confirmed', formation: '4-2-3-1', coach_id: 900, coach_name: 'Tecnico A', loaded_at: '2026-08-02 20:45:00'}
+
+      - input: ref('fact_fixtures')
+        rows:
+          - {fixture_id: 1, competition: 'brasileirao', competition_id: 71, season: 2026, date_utc: '2026-08-01', home_team_id: 10, away_team_id: 20}
+          - {fixture_id: 2, competition: 'brasileirao', competition_id: 71, season: 2026, date_utc: '2026-08-02', home_team_id: 10, away_team_id: 20}
+
+    expect:
+      rows:
+        - {fixture_id: 1, team_id: 10, lineup_phase: 'confirmed', formation: '4-4-2', team_side: 'home'}
+        - {fixture_id: 1, team_id: 10, lineup_phase: 'real', formation: '4-3-3', team_side: 'home'}
+        - {fixture_id: 1, team_id: 20, lineup_phase: 'confirmed', formation: '3-5-2', team_side: 'away'}
+        - {fixture_id: 2, team_id: 10, lineup_phase: 'confirmed', formation: '4-2-3-1', team_side: 'home'}
+
+  - name: fixture_lineups_players_as_duas_fases_do_mesmo_jogo_coexistem
+    model: fact_fixture_lineups_players
+    description: >
+      Nível jogador: o mesmo jogador no mesmo jogo existe nas duas fases, e é o caso
+      em que elas discordam — anunciado titular, entrou reserva. Duas cargas da mesma
+      fase colapsam em uma. Slot de escalação sem player_id continua fora do fato.
+    given:
+      - input: ref('stg_futebol_fixture_lineups_players')
+        rows:
+          # -- fixture 1: o jogador 100 é titular na confirmada e reserva na real. ----
+          - {fixture_id: 1, team_id: 10, team_name: 'Mandante', lineup_phase: 'confirmed', is_starter: true, player_slot: 0, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'M', grid: '3:1', loaded_at: '2026-08-01 20:30:00'}
+          - {fixture_id: 1, team_id: 10, team_name: 'Mandante', lineup_phase: 'real', is_starter: false, player_slot: 0, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'M', grid: , loaded_at: '2026-08-01 23:00:00'}
+          # Só a fase confirmada: é o que se sabia antes do apito, e nada a sobrescreve.
+          - {fixture_id: 1, team_id: 20, team_name: 'Visitante', lineup_phase: 'confirmed', is_starter: true, player_slot: 0, player_id: 200, player_name: 'Camisa 9', shirt_number: 9, position: 'F', grid: '4:1', loaded_at: '2026-08-01 20:30:00'}
+          # Lixo da API: slot sem player_id não é jogador e não entra no fato.
+          - {fixture_id: 1, team_id: 20, team_name: 'Visitante', lineup_phase: 'confirmed', is_starter: false, player_slot: 1, player_id: , player_name: , shirt_number: , position: , grid: , loaded_at: '2026-08-01 20:30:00'}
+
+          # -- fixture 2: a MESMA fase coletada duas vezes (re-execução do pipeline). -
+          - {fixture_id: 2, team_id: 10, team_name: 'Mandante', lineup_phase: 'confirmed', is_starter: true, player_slot: 0, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'M', grid: '3:1', loaded_at: '2026-08-02 20:30:00'}
+          - {fixture_id: 2, team_id: 10, team_name: 'Mandante', lineup_phase: 'confirmed', is_starter: true, player_slot: 0, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'D', grid: '2:1', loaded_at: '2026-08-02 20:45:00'}
+
+      - input: ref('fact_fixtures')
+        rows:
+          - {fixture_id: 1, competition: 'brasileirao', competition_id: 71, season: 2026, date_utc: '2026-08-01', home_team_id: 10, away_team_id: 20}
+          - {fixture_id: 2, competition: 'brasileirao', competition_id: 71, season: 2026, date_utc: '2026-08-02', home_team_id: 10, away_team_id: 20}
+
+    expect:
+      rows:
+        - {fixture_id: 1, player_id: 100, lineup_phase: 'confirmed', is_starter: true, team_side: 'home', position: 'M'}
+        - {fixture_id: 1, player_id: 100, lineup_phase: 'real', is_starter: false, team_side: 'home', position: 'M'}
+        - {fixture_id: 1, player_id: 200, lineup_phase: 'confirmed', is_starter: true, team_side: 'away', position: 'F'}
+        - {fixture_id: 2, player_id: 100, lineup_phase: 'confirmed', is_starter: true, team_side: 'home', position: 'D'}

--- a/dbt_futebol/models/marts/_fact_fixture_lineups__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_fixture_lineups__unit_tests.yml
@@ -85,3 +85,41 @@ unit_tests:
         - {fixture_id: 1, player_id: 100, lineup_phase: 'real', is_starter: false, team_side: 'home', position: 'M'}
         - {fixture_id: 1, player_id: 200, lineup_phase: 'confirmed', is_starter: true, team_side: 'away', position: 'F'}
         - {fixture_id: 2, player_id: 100, lineup_phase: 'confirmed', is_starter: true, team_side: 'home', position: 'D'}
+
+  - name: fixture_lineups_players_desempate_dentro_da_fase_e_deterministico
+    model: fact_fixture_lineups_players
+    description: >
+      O desempate dentro da fase é determinístico quando loaded_at NÃO desempata. É o
+      único teste que o sustenta: a guarda de unicidade fica verde sem ele, porque
+      ROW_NUMBER() = 1 devolve uma linha por partição sob qualquer ORDER BY. Sem o
+      desempate o vencedor vira entre builds do mesmo código — a classe da #78.
+    given:
+      - input: ref('stg_futebol_fixture_lineups_players')
+        rows:
+          # -- fixture 1: o MESMO jogador em dois slots da mesma fase e do MESMO --------
+          # loaded_at, um no startXI e outro no banco. É o caso real: 11 grupos assim
+          # na base hoje. Titular vence — é a linha mais informativa.
+          - {fixture_id: 1, team_id: 10, team_name: 'Mandante', lineup_phase: 'real', is_starter: false, player_slot: 6, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'M', grid: , loaded_at: '2026-08-01 23:00:00'}
+          - {fixture_id: 1, team_id: 10, team_name: 'Mandante', lineup_phase: 'real', is_starter: true, player_slot: 5, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'M', grid: '3:1', loaded_at: '2026-08-01 23:00:00'}
+
+          # -- fixture 2: dois slots do MESMO startXI (também existe na base). ---------
+          # is_starter empata; o menor player_slot decide.
+          - {fixture_id: 2, team_id: 10, team_name: 'Mandante', lineup_phase: 'real', is_starter: true, player_slot: 4, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'D', grid: '2:2', loaded_at: '2026-08-02 23:00:00'}
+          - {fixture_id: 2, team_id: 10, team_name: 'Mandante', lineup_phase: 'real', is_starter: true, player_slot: 3, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'M', grid: '3:1', loaded_at: '2026-08-02 23:00:00'}
+
+          # -- fixture 3: o mesmo jogador nos blocos dos DOIS times, tudo mais igual. --
+          # Só `team_id` separa — sem ele o team_side viraria entre builds.
+          - {fixture_id: 3, team_id: 20, team_name: 'Visitante', lineup_phase: 'real', is_starter: true, player_slot: 0, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'F', grid: '4:1', loaded_at: '2026-08-03 23:00:00'}
+          - {fixture_id: 3, team_id: 10, team_name: 'Mandante', lineup_phase: 'real', is_starter: true, player_slot: 0, player_id: 100, player_name: 'Camisa 10', shirt_number: 10, position: 'M', grid: '3:1', loaded_at: '2026-08-03 23:00:00'}
+
+      - input: ref('fact_fixtures')
+        rows:
+          - {fixture_id: 1, competition: 'brasileirao', competition_id: 71, season: 2026, date_utc: '2026-08-01', home_team_id: 10, away_team_id: 20}
+          - {fixture_id: 2, competition: 'brasileirao', competition_id: 71, season: 2026, date_utc: '2026-08-02', home_team_id: 10, away_team_id: 20}
+          - {fixture_id: 3, competition: 'brasileirao', competition_id: 71, season: 2026, date_utc: '2026-08-03', home_team_id: 10, away_team_id: 20}
+
+    expect:
+      rows:
+        - {fixture_id: 1, player_id: 100, lineup_phase: 'real', is_starter: true, player_slot: 5, team_side: 'home'}
+        - {fixture_id: 2, player_id: 100, lineup_phase: 'real', is_starter: true, player_slot: 3, team_side: 'home'}
+        - {fixture_id: 3, player_id: 100, lineup_phase: 'real', is_starter: true, player_slot: 0, team_side: 'home'}

--- a/dbt_futebol/models/marts/fact_fixture_lineups.sql
+++ b/dbt_futebol/models/marts/fact_fixture_lineups.sql
@@ -2,7 +2,7 @@
     materialized='table',
     partition_by={'field': 'date_utc', 'data_type': 'date'},
     cluster_by=['fixture_id', 'team_id'],
-    description='Formação e técnico por time por jogo (/fixtures/lineups). 2 linhas por fixture_id (mandante e visitante) — insumo de desfalques p/ o modelo. Particionada por DATE(date_utc) e clusterizada por (fixture_id, team_id). Latest-wins: dedup por (fixture_id, team_id) mantendo o loaded_at mais recente — "real" (pós-jogo) vence "confirmed" (~T-30min); lineup_phase mostra qual snapshot venceu. Cobre Brasileirão (71) 2024/25/26 e Copa do Mundo (1) 2026.'
+    description='Formação e técnico por time por jogo (/fixtures/lineups). Grão (fixture_id, team_id, lineup_phase): até 4 linhas por fixture_id — os dois times × as duas fases. "confirmed" (~T-30min) e "real" (pós-jogo) COEXISTEM; não são versões melhor e pior uma da outra, são o que se sabia em dois momentos, e a confirmada é a única que existe antes do apito. Particionada por DATE(date_utc) e clusterizada por (fixture_id, team_id). Latest-wins DENTRO de cada fase (dedup por loaded_at), só para absorver re-execução do pipeline. Cobre Brasileirão (71) 2024/25/26 e Copa do Mundo (1) 2026.'
 ) }}
 
 WITH lineups AS (
@@ -44,10 +44,12 @@ SELECT
     CURRENT_TIMESTAMP() AS dbt_loaded_at
 FROM lineups l
 INNER JOIN fixtures f ON l.fixture_id = f.fixture_id
--- Latest-wins: "real" (pós-jogo, loaded_at maior) vence "confirmed" (~T-30min).
--- Mantém o idioma de dedup de fact_fixture_stats/events. Desempate determinístico por
--- lineup_phase='real' (em loaded_at empatado, "real" vence — regra explícita, tie-stable).
+-- A fase entra no grão (#38). Antes o dedup era por (fixture_id, team_id) e a "real",
+-- que chega depois do jogo, sobrescrevia a "confirmed" — look-ahead entrando pela porta
+-- do dedup, e a confirmada é a única evidência pré-apito de quem entra em campo.
+-- O latest-wins continua existindo DENTRO de cada fase, com o mesmo idioma de
+-- fact_fixture_stats/events, para absorver re-execução do pipeline.
 QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY l.fixture_id, l.team_id
-    ORDER BY l.loaded_at DESC, (l.lineup_phase = 'real') DESC
+    PARTITION BY l.fixture_id, l.team_id, l.lineup_phase
+    ORDER BY l.loaded_at DESC
 ) = 1

--- a/dbt_futebol/models/marts/fact_fixture_lineups_players.sql
+++ b/dbt_futebol/models/marts/fact_fixture_lineups_players.sql
@@ -2,7 +2,7 @@
     materialized='table',
     partition_by={'field': 'date_utc', 'data_type': 'date'},
     cluster_by=['fixture_id', 'team_id'],
-    description='Escalação de jogadores por jogo (/fixtures/lineups). ~22-30 linhas por fixture_id (titulares + reservas dos dois times) — base p/ ajustar o modelo por desfalques. is_starter separa startXI de substitutes; position/grid/shirt_number do jogador. Particionada por DATE(date_utc) e clusterizada por (fixture_id, team_id). Latest-wins: dedup por (fixture_id, player_id) mantendo o loaded_at mais recente — "real" vence "confirmed". Cobre Brasileirão (71) 2024/25/26 e Copa do Mundo (1) 2026.'
+    description='Escalação de jogadores por jogo (/fixtures/lineups). Grão (fixture_id, player_id, lineup_phase): ~22-30 linhas por fixture POR FASE (titulares + reservas dos dois times) — base p/ ajustar o modelo por desfalques. is_starter separa startXI de substitutes; position/grid/shirt_number do jogador. "confirmed" (~T-30min) e "real" (pós-jogo) COEXISTEM, e é onde elas discordam que está o valor: anunciado titular, entrou reserva. Só a confirmada existe antes do apito. Particionada por DATE(date_utc) e clusterizada por (fixture_id, team_id). Latest-wins DENTRO de cada fase, só para absorver re-execução do pipeline. Cobre Brasileirão (71) 2024/25/26 e Copa do Mundo (1) 2026.'
 ) }}
 
 WITH players AS (
@@ -51,10 +51,16 @@ INNER JOIN fixtures f ON p.fixture_id = f.fixture_id
 -- Descarta slots de escalação sem player_id (lixo da API; ~4 linhas) — não são jogadores reais
 -- e quebrariam o not_null do mart (a staging mantém raw e só avisa via severity:warn).
 WHERE p.player_id IS NOT NULL
--- Latest-wins: "real" (pós-jogo) vence "confirmed" (~T-30min). Um jogador aparece 1x por
--- fase; dedup por (fixture_id, player_id) mantém a fase mais recente. Desempate determinístico
--- por lineup_phase='real' (em loaded_at empatado, "real" vence — regra explícita, tie-stable).
+-- A fase entra no grão (#38). Antes o dedup era por (fixture_id, player_id) e a "real",
+-- que chega depois do jogo, sobrescrevia a "confirmed" — look-ahead entrando pela porta
+-- do dedup, e a confirmada é a única evidência pré-apito de quem entra em campo.
+-- O latest-wins continua existindo DENTRO de cada fase, para absorver re-execução do pipeline.
+-- O desempate por (is_starter, player_slot) NÃO é decorativo: a API às vezes repete o mesmo
+-- jogador em dois slots da MESMA fase e do MESMO loaded_at (11 grupos hoje, alguns startXI +
+-- substitutes, outros dois slots do startXI). Sem ele o vencedor muda entre builds do mesmo
+-- código — a classe de irreprodutibilidade que a #78 já custou uma vez. Titular vence reserva
+-- (a linha mais informativa), e o menor slot desempata o resto.
 QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY p.fixture_id, p.player_id
-    ORDER BY p.loaded_at DESC, (p.lineup_phase = 'real') DESC
+    PARTITION BY p.fixture_id, p.player_id, p.lineup_phase
+    ORDER BY p.loaded_at DESC, p.is_starter DESC, p.player_slot ASC
 ) = 1

--- a/dbt_futebol/models/marts/fact_fixture_lineups_players.sql
+++ b/dbt_futebol/models/marts/fact_fixture_lineups_players.sql
@@ -59,8 +59,14 @@ WHERE p.player_id IS NOT NULL
 -- jogador em dois slots da MESMA fase e do MESMO loaded_at (11 grupos hoje, alguns startXI +
 -- substitutes, outros dois slots do startXI). Sem ele o vencedor muda entre builds do mesmo
 -- código — a classe de irreprodutibilidade que a #78 já custou uma vez. Titular vence reserva
--- (a linha mais informativa), e o menor slot desempata o resto.
+-- (a linha mais informativa), o menor slot desempata o resto, e `team_id` fecha a ordenação:
+-- os três primeiros critérios empatam por completo se o mesmo jogador aparecer nos blocos dos
+-- DOIS times (a API já trocou identidade de clube antes), e aí team_side viraria entre builds.
+--
+-- ⚠️ Nenhum teste de unicidade pega a remoção deste desempate — ROW_NUMBER()=1 devolve uma
+-- linha por partição sob QUALQUER ORDER BY. Quem protege é o unit test
+-- `fixture_lineups_players_desempate_dentro_da_fase_e_deterministico`.
 QUALIFY ROW_NUMBER() OVER (
     PARTITION BY p.fixture_id, p.player_id, p.lineup_phase
-    ORDER BY p.loaded_at DESC, p.is_starter DESC, p.player_slot ASC
+    ORDER BY p.loaded_at DESC, p.is_starter DESC, p.player_slot ASC, p.team_id ASC
 ) = 1

--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -516,10 +516,13 @@ models:
       do Mundo (1) 2026, Série B (72)
       2024/25/26, Copa do Brasil (73) 2024/25/26, Libertadores (13) 2024/25/26 e Sudamericana (11) 2024/25/26.
     tests:
-      # Gêmea da guarda de grão de fact_fixture_lineups (#38) — mesma justificativa, e
-      # aqui ela tem um alvo a mais: é neste nível que a API repete o mesmo jogador em
-      # dois slots da mesma fase, e é o desempate por (is_starter, player_slot) no modelo
-      # que garante uma linha só. Se alguém tirar o desempate, é esta guarda que acusa.
+      # Gêmea da guarda de grão de fact_fixture_lineups (#38) — mesma justificativa.
+      #
+      # O que ela NÃO cobre, e é bom estar escrito: o desempate do modelo. É neste nível
+      # que a API repete o mesmo jogador em dois slots da mesma fase, mas ROW_NUMBER()=1
+      # devolve uma linha por partição sob qualquer ORDER BY — tirar o desempate deixa
+      # esta guarda VERDE e o vencedor nondeterminístico. Quem falsifica isso é o unit
+      # test `fixture_lineups_players_desempate_dentro_da_fase_e_deterministico`.
       - dbt_utils.unique_combination_of_columns:
           name: assert_lineups_players_grao_por_fase
           arguments:

--- a/dbt_futebol/models/marts/models.yml
+++ b/dbt_futebol/models/marts/models.yml
@@ -415,20 +415,36 @@ models:
 
   - name: fact_fixture_lineups
     description: >
-      Formação e técnico por time por jogo (/fixtures/lineups). 2 linhas por fixture_id
-      (mandante e visitante) — insumo de desfalques p/ o modelo de value betting.
-      Particionada por DATE(date_utc) (data do jogo) e clusterizada por (fixture_id,
-      team_id). Latest-wins: dedup por (fixture_id, team_id) mantendo o loaded_at mais
-      recente — "real" (pós-jogo) vence "confirmed" (~T-30min); lineup_phase mostra qual
-      snapshot venceu. Backfill histórico (2024/2025) só tem fase "real" (não dá pra obter
-      a confirmada retroativa). Cobre Brasileirão (71) 2024/25/26, Copa do Mundo (1) 2026,
+      Formação e técnico por time por jogo (/fixtures/lineups). Grão (fixture_id, team_id,
+      lineup_phase): até 4 linhas por fixture_id — os dois times × as duas fases — e insumo
+      de desfalques p/ o modelo de value betting. As duas fases COEXISTEM (#38): "confirmed"
+      (~T-30min) e "real" (pós-jogo) não são versões melhor e pior uma da outra, são o que se
+      sabia em dois momentos, e só a confirmada existe antes do apito. Particionada por
+      DATE(date_utc) (data do jogo) e clusterizada por (fixture_id, team_id). Latest-wins
+      DENTRO de cada fase (dedup por loaded_at), só para absorver re-execução do pipeline.
+      Backfill histórico (2024/2025) só tem fase "real" (não dá pra obter a confirmada
+      retroativa). Cobre Brasileirão (71) 2024/25/26, Copa do Mundo (1) 2026,
       Série B (72) 2024/25/26, Copa do Brasil (73) 2024/25/26, Libertadores (13) 2024/25/26 e Sudamericana (11) 2024/25/26.
     tests:
+      # GRÃO NOVO (#38): a fase entra na chave. Sem `lineup_phase` aqui, o próprio efeito
+      # pretendido da mudança (as duas fases coexistindo) deixaria esta guarda
+      # permanentemente vermelha — e guarda sempre vermelha morre ignorada.
+      #
+      # TAG `guarda` pela mesma razão que a #37 tagueou a dela: teste sem tag não roda no
+      # agendado, só no laptop de quem lembrar. A guarda irmã
+      # (assert_escalacao_confirmada_preservada) prova que a fase confirmada CHEGOU ao
+      # fato; esta prova que ela chegou UMA VEZ. Duplicata dentro da fase é o modo de
+      # falha que infla contagem em silêncio, e só vale se rodar em produção.
       - dbt_utils.unique_combination_of_columns:
+          name: assert_lineups_grao_por_fase
           arguments:
             combination_of_columns:
               - fixture_id
               - team_id
+              - lineup_phase
+          config:
+            severity: error
+            tags: ['guarda']
     columns:
       - name: fixture_id
         description: "ID do jogo na API-Football (FK p/ fact_fixtures; 2 linhas por fixture; cluster key)"
@@ -466,7 +482,21 @@ models:
       - name: coach_name
         description: "Nome do técnico"
       - name: lineup_phase
-        description: "Fase do snapshot que venceu o dedup: 'real' (pós-jogo) ou 'confirmed' (~T-30min)"
+        description: "Momento do registro, e parte do grão: 'confirmed' (~T-30min, a única evidência pré-apito) ou 'real' (pós-jogo). As duas coexistem para o mesmo jogo."
+        # Taguear junto com a guarda de grão: os dois defendem a mesma chave. NULL ou fase
+        # nova colapsam/abrem o grão sem que a unicidade acuse, e quem lê o fato antes do
+        # apito filtra por este valor — errar aqui é voltar a servir look-ahead calado.
+        tests:
+          - not_null:
+              config:
+                severity: error
+                tags: ['guarda']
+          - accepted_values:
+              arguments:
+                values: ['confirmed', 'real']
+              config:
+                severity: error
+                tags: ['guarda']
       - name: extracted_at
         description: "Timestamp UTC quando o extractor coletou a linha"
       - name: dbt_loaded_at
@@ -474,19 +504,32 @@ models:
 
   - name: fact_fixture_lineups_players
     description: >
-      Escalação de jogadores por jogo (/fixtures/lineups). ~22-30 linhas por fixture_id
-      (titulares + reservas dos dois times) — base p/ ajustar o modelo por desfalques.
-      is_starter separa startXI de substitutes; position/grid/shirt_number do jogador.
-      Particionada por DATE(date_utc) e clusterizada por (fixture_id, team_id). Latest-wins:
-      dedup por (fixture_id, player_id) mantendo o loaded_at mais recente — "real" vence
-      "confirmed". Cobre Brasileirão (71) 2024/25/26, Copa do Mundo (1) 2026, Série B (72)
+      Escalação de jogadores por jogo (/fixtures/lineups). Grão (fixture_id, player_id,
+      lineup_phase): ~22-30 linhas por fixture POR FASE (titulares + reservas dos dois times)
+      — base p/ ajustar o modelo por desfalques. is_starter separa startXI de substitutes;
+      position/grid/shirt_number do jogador. As duas fases COEXISTEM (#38), e é onde elas
+      discordam que está o valor: anunciado titular, entrou reserva. Só a confirmada existe
+      antes do apito. Particionada por DATE(date_utc) e clusterizada por (fixture_id,
+      team_id). Latest-wins DENTRO de cada fase, só para absorver re-execução do pipeline;
+      o desempate por (is_starter, player_slot) existe porque a API repete o mesmo jogador em
+      dois slots da mesma fase e do mesmo loaded_at. Cobre Brasileirão (71) 2024/25/26, Copa
+      do Mundo (1) 2026, Série B (72)
       2024/25/26, Copa do Brasil (73) 2024/25/26, Libertadores (13) 2024/25/26 e Sudamericana (11) 2024/25/26.
     tests:
+      # Gêmea da guarda de grão de fact_fixture_lineups (#38) — mesma justificativa, e
+      # aqui ela tem um alvo a mais: é neste nível que a API repete o mesmo jogador em
+      # dois slots da mesma fase, e é o desempate por (is_starter, player_slot) no modelo
+      # que garante uma linha só. Se alguém tirar o desempate, é esta guarda que acusa.
       - dbt_utils.unique_combination_of_columns:
+          name: assert_lineups_players_grao_por_fase
           arguments:
             combination_of_columns:
               - fixture_id
               - player_id
+              - lineup_phase
+          config:
+            severity: error
+            tags: ['guarda']
     columns:
       - name: fixture_id
         description: "ID do jogo na API-Football (FK p/ fact_fixtures; N linhas por fixture; cluster key)"
@@ -542,7 +585,21 @@ models:
       - name: grid
         description: "Posição no grid tático (ex: '1:1', '4:2'). NULL p/ reservas."
       - name: lineup_phase
-        description: "Fase do snapshot que venceu o dedup: 'real' (pós-jogo) ou 'confirmed' (~T-30min)"
+        description: "Momento do registro, e parte do grão: 'confirmed' (~T-30min, a única evidência pré-apito) ou 'real' (pós-jogo). As duas coexistem para o mesmo jogo."
+        # Taguear junto com a guarda de grão: os dois defendem a mesma chave. NULL ou fase
+        # nova colapsam/abrem o grão sem que a unicidade acuse, e quem lê o fato antes do
+        # apito filtra por este valor — errar aqui é voltar a servir look-ahead calado.
+        tests:
+          - not_null:
+              config:
+                severity: error
+                tags: ['guarda']
+          - accepted_values:
+              arguments:
+                values: ['confirmed', 'real']
+              config:
+                severity: error
+                tags: ['guarda']
       - name: extracted_at
         description: "Timestamp UTC quando o extractor coletou a linha"
       - name: dbt_loaded_at

--- a/dbt_futebol/models/staging/models.yml
+++ b/dbt_futebol/models/staging/models.yml
@@ -447,7 +447,7 @@ models:
         description: "Timestamp ISO UTC do extractor"
 
   - name: stg_futebol_fixture_lineups
-    description: "Flatten do raw_futebol_fixture_lineups (nível time). 2 linhas por (fixture, fase) — formation/coach de cada time; grain (fixture_id, lineup_phase, team_id). lineup_phase distingue confirmed (~T-30min) de real (pós-jogo); fact_fixture_lineups faz dedup latest-wins por loaded_at (real vence confirmed)."
+    description: "Flatten do raw_futebol_fixture_lineups (nível time). 2 linhas por (fixture, fase) — formation/coach de cada time; grain (fixture_id, lineup_phase, team_id). lineup_phase distingue confirmed (~T-30min) de real (pós-jogo); fact_fixture_lineups preserva as duas fases (#38) e faz latest-wins por loaded_at DENTRO de cada uma."
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -480,7 +480,7 @@ models:
         description: "Timestamp ISO UTC do extractor"
 
   - name: stg_futebol_fixture_lineups_players
-    description: "Flatten/UNNEST do raw_futebol_fixture_lineups (nível jogador). ~22-30 linhas por (fixture, fase): startXI (is_starter=TRUE) + substitutes (is_starter=FALSE) dos dois times; grain (fixture_id, lineup_phase, player_id) — o teste de unicidade dispara se um jogador aparecer em startXI E substitutes na mesma fase. fact_fixture_lineups_players faz dedup latest-wins por loaded_at."
+    description: "Flatten/UNNEST do raw_futebol_fixture_lineups (nível jogador). ~22-30 linhas por (fixture, fase): startXI (is_starter=TRUE) + substitutes (is_starter=FALSE) dos dois times; grain (fixture_id, lineup_phase, player_id) — o teste de unicidade dispara se um jogador aparecer em startXI E substitutes na mesma fase. fact_fixture_lineups_players preserva as duas fases (#38), com latest-wins por loaded_at dentro de cada uma."
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/dbt_futebol/models/staging/models.yml
+++ b/dbt_futebol/models/staging/models.yml
@@ -489,7 +489,7 @@ models:
               - lineup_phase
               - player_id
           config:
-            severity: warn  # grain raw pré-dedup; fact_fixture_lineups_players deduppa latest-wins (1 grupo dup hoje)
+            severity: warn  # grain raw pré-dedup; fact_fixture_lineups_players deduppa dentro da fase (11 grupos dup hoje, todos com loaded_at único — daí o desempate por (is_starter, player_slot) lá)
     columns:
       - name: fixture_id
         description: "ID do jogo na API-Football (FK p/ fact_fixtures)"

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -187,8 +187,9 @@ sources:
           (mandante e visitante), 1 arquivo por (fixture_id, fase). Wildcard cobre
           _confirmed (escalação ~T-30min) + _real (pós-jogo). team/coach + startXI/
           substitutes ficam aninhados — o flatten/UNNEST acontece em
-          stg_futebol_fixture_lineups(_players). lineup_phase distingue a fase; o fato é
-          latest-wins (dedup por loaded_at). Arquivos:
+          stg_futebol_fixture_lineups(_players). lineup_phase distingue a fase e faz parte
+          do grão dos dois fatos (#38): as duas fases coexistem, e o latest-wins (dedup por
+          loaded_at) acontece DENTRO de cada uma. Arquivos:
           gs://smartbetting-landingzone/futebol/fixture_lineups/raw_futebol_fixture_lineups_{fixture_id}_{confirmed|real}.json.
         external:
           # Documentação apenas — external table criada por
@@ -202,7 +203,7 @@ sources:
           - name: loaded_at
             description: "Timestamp ISO UTC quando o extractor coletou a linha"
           - name: lineup_phase
-            description: "'confirmed' (escalação ~T-30min) | 'real' (pós-jogo). Fato é latest-wins por loaded_at."
+            description: "'confirmed' (escalação ~T-30min) | 'real' (pós-jogo). Parte do grão dos dois fatos (#38); latest-wins por loaded_at dentro de cada fase."
           - name: total_teams
             description: "Metadata: nº de blocos de time no jogo (sempre 2). Ignorado downstream."
           - name: formation

--- a/dbt_futebol/models/staging/stg_futebol_fixture_lineups.sql
+++ b/dbt_futebol/models/staging/stg_futebol_fixture_lineups.sql
@@ -1,5 +1,5 @@
 {{ config(
-    description='Flatten do raw_futebol_fixture_lineups (nível time). 2 linhas por (fixture, fase) — formation e coach de cada time. lineup_phase distingue confirmed (escalação ~T-30min) de real (pós-jogo); fact_fixture_lineups faz dedup latest-wins por loaded_at e junta fact_fixtures p/ competition/season/date_utc e rótulo home/away.'
+    description='Flatten do raw_futebol_fixture_lineups (nível time). 2 linhas por (fixture, fase) — formation e coach de cada time. lineup_phase distingue confirmed (escalação ~T-30min) de real (pós-jogo); fact_fixture_lineups preserva as duas fases (#38), com latest-wins por loaded_at dentro de cada uma, e junta fact_fixtures p/ competition/season/date_utc e rótulo home/away.'
 ) }}
 
 WITH src AS (

--- a/dbt_futebol/models/staging/stg_futebol_fixture_lineups_players.sql
+++ b/dbt_futebol/models/staging/stg_futebol_fixture_lineups_players.sql
@@ -1,5 +1,5 @@
 {{ config(
-    description='Flatten do raw_futebol_fixture_lineups (nível jogador). ~22-30 linhas por (fixture, fase): startXI (is_starter=TRUE) + substitutes (is_starter=FALSE), dos dois times. player_slot = índice no array (WITH OFFSET; preserva a ordem). lineup_phase distingue confirmed/real; fact_fixture_lineups_players faz dedup latest-wins por loaded_at.'
+    description='Flatten do raw_futebol_fixture_lineups (nível jogador). ~22-30 linhas por (fixture, fase): startXI (is_starter=TRUE) + substitutes (is_starter=FALSE), dos dois times. player_slot = índice no array (WITH OFFSET; preserva a ordem). lineup_phase distingue confirmed/real e faz parte do grao do fato; fact_fixture_lineups_players preserva as duas fases (#38), com latest-wins por loaded_at dentro de cada uma.'
 ) }}
 
 WITH src AS (

--- a/dbt_futebol/tests/assert_escalacao_confirmada_preservada.sql
+++ b/dbt_futebol/tests/assert_escalacao_confirmada_preservada.sql
@@ -33,6 +33,8 @@
 -- corte, a guarda acusaria isso como `perdida_no_dedup`, que é dizer "regressão de código"
 -- sobre pipeline saudável. Guarda que fica vermelha sozinha morre ignorada. O corte é o
 -- maior extracted_at que o fato chegou a ver: tudo anterior a ele teve chance de entrar.
+-- COALESCE p/ o fato vazio: sem ele o corte seria NULL, filtraria a staging inteira e a
+-- guarda ficaria verde justamente no cenário mais grave (fato vazio = tudo sumiu).
 
 WITH spine AS (
     SELECT fixture_id FROM {{ ref('fact_fixtures') }}
@@ -51,7 +53,7 @@ stg_time AS (
     SELECT DISTINCT fixture_id, team_id
     FROM {{ ref('stg_futebol_fixture_lineups') }}
     WHERE lineup_phase = 'confirmed'
-      AND loaded_at <= (SELECT ate FROM corte_time)
+      AND loaded_at <= COALESCE((SELECT ate FROM corte_time), loaded_at)
 ),
 
 fato_time AS (
@@ -78,7 +80,7 @@ stg_jogador AS (
     FROM {{ ref('stg_futebol_fixture_lineups_players') }}
     WHERE lineup_phase = 'confirmed'
       AND player_id IS NOT NULL  -- espelha o filtro do fato
-      AND loaded_at <= (SELECT ate FROM corte_jogador)
+      AND loaded_at <= COALESCE((SELECT ate FROM corte_jogador), loaded_at)
 ),
 
 fato_jogador AS (

--- a/dbt_futebol/tests/assert_escalacao_confirmada_preservada.sql
+++ b/dbt_futebol/tests/assert_escalacao_confirmada_preservada.sql
@@ -1,0 +1,86 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DA ESCALAÇÃO CONFIRMADA (#38): toda escalação confirmada que existe na staging
+-- tem que existir no fato, nos dois níveis.
+--
+-- É a guarda do modo de falha que a #38 consertou, e o ponto dela é que esse modo de falha
+-- era MUDO. O dedup dos dois fatos era por (fixture, time) / (fixture, jogador), sem a fase:
+-- a escalação "real", que só chega DEPOIS do apito, sobrescrevia a "confirmed" de ~T-30min.
+-- 97% do que se sabia antes do jogo era apagado pelo que se soube depois — look-ahead
+-- entrando pela porta do dedup — e nada ficava vermelho, porque a tabela continuava
+-- populada, única no grão antigo e reconciliada com o spine. O único sintoma era a contagem
+-- de fixtures com fase confirmada despencar de 279 na staging para 2 no fato.
+--
+-- Por isso a guarda compara CHAVE A CHAVE, e não contagem de linhas: contagem de linhas
+-- fecharia por acidente sempre que uma fase substituísse a outra 1-para-1, que é exatamente
+-- o que acontecia. Anti-join da staging confirmada contra o fato confirmado.
+--
+-- O que ela NÃO cobre, de propósito: a direção oposta (fixture do spine sem nenhuma linha no
+-- fato) já é assert_per_fixture_coverage, e o dedup dentro da fase é o unit test em
+-- _fact_fixture_lineups__unit_tests.yml — este é sobre a fase inteira sumir.
+--
+-- `motivo` separa as duas causas possíveis de uma chave sumir, porque o conserto é diferente:
+-- perdida_no_dedup é regressão de código (o grão perdeu a fase de novo); fora_do_spine é
+-- fixture ausente de fact_fixtures, cortada pelo INNER JOIN dos dois fatos — hoje 0 de 279,
+-- e se aparecer é perda de jogo inteiro, a montante.
+--
+-- Nível jogador: o lado da staging aplica o mesmo `player_id IS NOT NULL` que o fato aplica.
+-- Sem isso, os slots de escalação sem jogador (lixo conhecido da API) acusariam para sempre.
+
+WITH spine AS (
+    SELECT fixture_id FROM {{ ref('fact_fixtures') }}
+),
+
+-- ── Nível time ───────────────────────────────────────────────────────────────
+stg_time AS (
+    SELECT DISTINCT fixture_id, team_id
+    FROM {{ ref('stg_futebol_fixture_lineups') }}
+    WHERE lineup_phase = 'confirmed'
+),
+
+fato_time AS (
+    SELECT DISTINCT fixture_id, team_id
+    FROM {{ ref('fact_fixture_lineups') }}
+    WHERE lineup_phase = 'confirmed'
+),
+
+faltando_time AS (
+    SELECT
+        'fact_fixture_lineups' AS fato,
+        s.fixture_id,
+        s.team_id              AS chave,
+        CASE WHEN sp.fixture_id IS NULL THEN 'fora_do_spine' ELSE 'perdida_no_dedup' END AS motivo
+    FROM stg_time s
+    LEFT JOIN fato_time f ON f.fixture_id = s.fixture_id AND f.team_id = s.team_id
+    LEFT JOIN spine sp    ON sp.fixture_id = s.fixture_id
+    WHERE f.fixture_id IS NULL
+),
+
+-- ── Nível jogador ────────────────────────────────────────────────────────────
+stg_jogador AS (
+    SELECT DISTINCT fixture_id, player_id
+    FROM {{ ref('stg_futebol_fixture_lineups_players') }}
+    WHERE lineup_phase = 'confirmed'
+      AND player_id IS NOT NULL  -- espelha o filtro do fato
+),
+
+fato_jogador AS (
+    SELECT DISTINCT fixture_id, player_id
+    FROM {{ ref('fact_fixture_lineups_players') }}
+    WHERE lineup_phase = 'confirmed'
+),
+
+faltando_jogador AS (
+    SELECT
+        'fact_fixture_lineups_players' AS fato,
+        s.fixture_id,
+        s.player_id                    AS chave,
+        CASE WHEN sp.fixture_id IS NULL THEN 'fora_do_spine' ELSE 'perdida_no_dedup' END AS motivo
+    FROM stg_jogador s
+    LEFT JOIN fato_jogador f ON f.fixture_id = s.fixture_id AND f.player_id = s.player_id
+    LEFT JOIN spine sp       ON sp.fixture_id = s.fixture_id
+    WHERE f.fixture_id IS NULL
+)
+
+SELECT * FROM faltando_time
+UNION ALL
+SELECT * FROM faltando_jogador

--- a/dbt_futebol/tests/assert_escalacao_confirmada_preservada.sql
+++ b/dbt_futebol/tests/assert_escalacao_confirmada_preservada.sql
@@ -25,9 +25,25 @@
 --
 -- Nível jogador: o lado da staging aplica o mesmo `player_id IS NOT NULL` que o fato aplica.
 -- Sem isso, os slots de escalação sem jogador (lixo conhecido da API) acusariam para sempre.
+--
+-- CORTE POR `loaded_at`: a staging é VIEW sobre o NDJSON vivo no GCS e o fato é TABELA. O
+-- poll pré-jogo (workflow_futebol_lineups) pousa escalação confirmada de 15 em 15 minutos,
+-- e as guardas rodam na fase 4 do workflow_futebol, depois do `dbt run` da fase 2. Escalação
+-- que pousa nessa fresta está na staging e legitimamente ainda não está no fato — sem o
+-- corte, a guarda acusaria isso como `perdida_no_dedup`, que é dizer "regressão de código"
+-- sobre pipeline saudável. Guarda que fica vermelha sozinha morre ignorada. O corte é o
+-- maior extracted_at que o fato chegou a ver: tudo anterior a ele teve chance de entrar.
 
 WITH spine AS (
     SELECT fixture_id FROM {{ ref('fact_fixtures') }}
+),
+
+corte_time AS (
+    SELECT MAX(extracted_at) AS ate FROM {{ ref('fact_fixture_lineups') }}
+),
+
+corte_jogador AS (
+    SELECT MAX(extracted_at) AS ate FROM {{ ref('fact_fixture_lineups_players') }}
 ),
 
 -- ── Nível time ───────────────────────────────────────────────────────────────
@@ -35,6 +51,7 @@ stg_time AS (
     SELECT DISTINCT fixture_id, team_id
     FROM {{ ref('stg_futebol_fixture_lineups') }}
     WHERE lineup_phase = 'confirmed'
+      AND loaded_at <= (SELECT ate FROM corte_time)
 ),
 
 fato_time AS (
@@ -61,6 +78,7 @@ stg_jogador AS (
     FROM {{ ref('stg_futebol_fixture_lineups_players') }}
     WHERE lineup_phase = 'confirmed'
       AND player_id IS NOT NULL  -- espelha o filtro do fato
+      AND loaded_at <= (SELECT ate FROM corte_jogador)
 ),
 
 fato_jogador AS (


### PR DESCRIPTION
> ✅ **GATE FECHADO em 20/08 — o bloqueio abaixo foi resolvido e este PR está liberado.**
> O bloco original dizia *"DRAFT DE PROPÓSITO — não mergear antes de consertar a RPC"*, porque
> `get_futebol_fixture_extras` agregava as duas tabelas **sem filtro de fase**: com as duas
> fases no ar, a tela de jogo exibiria formação sorteada entre a anunciada e a que entrou em
> campo, e desenharia cada jogador duas vezes no campinho.
>
> A correção chegou na **migration 103** (release #271, 19/08). Conferido em 20/08 no PRD com
> `pg_get_functiondef` — no banco vivo, não no `deploy.sql`, que é a disciplina que o próprio
> bloqueio exigia. A RPC agora escolhe **uma fase só**, com a regra por **tempo**
> (`kickoff_utc <= now()` → `real`, senão `confirmed`), decidindo as duas tabelas em separado
> porque elas discordam entre si. A regra por EXISTÊNCIA que a 098 tinha estava errada: nos 154
> jogos com as duas fases, a `confirmed` tem 2,0 jogadores por jogo contra 46,5 da `real`.
>
> Duas atualizações neste PR desde então:
> · **conflito com o #99 resolvido** (`2847fda`) — os dois editam o `contrato-serving-rpcs.md`;
> · a matriz do contrato foi corrigida: as **duas** linhas ⛔ (esta e a do `int_futebol_odds_devig`)
>   viraram ✅, com a verificação de 20/08. Nenhuma função de `public` referencia mais o de-vig.
>
> ⚠️ **A spec da #38 afirmava "a aplicação não os consulta" — é falso**, e o contrato já
> registrava isso desde 10/08. Fica registrado porque é o padrão que a spec seguinte repete.

## O quê

O dedup dos dois fatos de escalação era por `(fixture, time)` e `(fixture, jogador)`, sem a
fase. A escalação **real**, que só chega depois do apito, sobrescrevia a **confirmed** de
~T-30min — look-ahead entrando pela porta do dedup, num repositório que acabou de gastar uma
task inteira tirando look-ahead das premissas.

A fase entra no grão dos dois fatos. As duas coexistem; o latest-wins continua existindo
**dentro** de cada fase, para absorver re-execução do pipeline.

## Medido no build

| nível | fixtures confirmed antes | depois | staging |
|---|---|---|---|
| time | 3 (6 linhas) | **279 (558)** | 279 |
| jogador | 157 (440 linhas) | **275 (12.952)** | 275 |

A fase `real` não se move (16.249 / 352.437 linhas, idênticas) — a mudança é puramente aditiva.
⚠️ Esses números **não sobrevivem** até o deploy: o agendado reconstrói os dois fatos da imagem
velha, com o grão velho, a cada rodada. É isso que segura o gate.

Sync: TRUNCATE+COPY, sem PK no Postgres, conjunto de colunas inalterado → **sem DDL**.

## Guardas

- **`assert_escalacao_confirmada_preservada`** (`tag:guarda`, `severity: error`) — anti-join
  chave a chave, nos dois níveis. Compara chaves e não contagem de linhas de propósito:
  contagem fecharia por acidente sempre que uma fase substituísse a outra 1-para-1, que é
  exatamente o que acontecia. **Falsificada**: 13.064 chaves perdidas sob o grão antigo, 0 sob
  o novo.
- **Unicidade do grão novo** nos dois fatos + `not_null`/`accepted_values` em `lineup_phase`,
  os quatro com `tag:guarda` — teste sem tag não roda no agendado, só no laptop de quem
  lembrar. `dbt test --select tag:guarda` vai de 25 para 30.
- **3 unit tests**: as duas fases coexistem (com elas discordando — formação anunciada ≠ a que
  entrou, titular anunciado que começou no banco); duas cargas da mesma fase colapsam em uma; e
  o desempate dentro da fase é determinístico. O terceiro é o único que sustenta o desempate —
  a guarda de unicidade fica verde sem ele, porque `ROW_NUMBER() = 1` devolve uma linha por
  partição sob qualquer `ORDER BY`. **Falsificado**: tirando o desempate, fica vermelho.

## Além do ticket

A API repete o mesmo jogador em dois slots da **mesma fase e do mesmo `loaded_at`** (11 grupos
hoje). Com a fase no grão, `loaded_at` sozinho empata neles e o vencedor viraria entre builds do
mesmo código — a classe de irreprodutibilidade da #78. Desempate por
`(is_starter, player_slot, team_id)`, total.

## Testes

`dbt test` completo: **PASS=305 WARN=11 ERROR=0**. Os 11 warns são pré-existentes; o único que
se mexeu é `relationships` de `player_id → dim_players`, 6.233 → 6.441 — os +208 são reservas da
fase confirmada que faltam no catálogo, a mesma lacuna que o yml já documenta, na mesma
proporção (1,6% nas duas fases).

Closes #38

