### PR TITLE
docs(futebol): a remedição do Teste 2 não está destravada — a [F] mediu, o pipeline não mudou

### DIFF
--- a/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
+++ b/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
@@ -4,6 +4,18 @@ status: accepted
 
 # A medição de escopo roda em dataset próprio, atrás de uma var com default de produção
 
+> ⚠️ **Emenda de 2026-08-19 — a exigência de dataset próprio expira quando (c) entra em produção.**
+> A **ADR 0010** decidiu que o pipeline passa a computar a célula `ambos` (`pit_escopo: todas`,
+> `pit_recorte: ultimos_10`) por default. A premissa desta ADR — *"medir histórico juntado
+> significaria publicar histórico juntado"* — deixa de valer no instante em que publicar histórico
+> juntado é a decisão. A partir daí a remedição roda contra `futebol`, sem var, e `futebol_taskF`
+> fica como registro congelado do 2×2 da [F].
+>
+> Nada disto vale **antes** daquele commit: enquanto o default for `da_competicao`/`temporada`,
+> tudo abaixo continua em vigor, inclusive a Costura A. No commit que vira o default, a Costura A
+> (`tests/assert_taskf_pit_default_igual_baseline`) é **recongelada** — a saída que o cabeçalho
+> dela já nomeia.
+
 A task [F] precisa saber o que cada premissa vira quando o PIT do time deixa de ser
 contado dentro da competição. Trocar só o `min_jogos` não responde isso: as flags das premissas
 saem dos 5 modelos de `intermediate/`, que fazem `ref('int_futebol_team_form_pit')` — e são elas

--- a/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
+++ b/dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md
@@ -37,6 +37,16 @@ explícita de não mexer em premissa. Fica registrada como candidata para a [B],
 motivo, com o agravante de que o percentil mistura ligas de níveis diferentes sem nada que
 sinalize isso no número.
 
+⚠️ **Emenda de 2026-08-19 — "adiada para a [B]" não faz da [B] pré-requisito de nada.** Ler o
+parágrafo acima como se a [B] precisasse decidir *antes* de o escopo ser juntado em produção cria
+uma circularidade: parte de (c) esperando a task que (c) bloqueia. A **ADR 0010** cortou isso, e o
+corte é uma releitura desta ADR, não uma exceção a ela. Como esta ADR já decidiu que as quatro
+**permanecem competição-scoped** — *"essa imobilidade é o resultado reportado"* —, o pipeline
+juntado sobe **sem tocar nelas**, e a remedição entrega para as três medidas evidência sob
+`da_competicao`, por construção. A [B] as julga nessa evidência, como julga as outras 36. A
+"competição principal" é, portanto, um **resultado candidato da [B]** — que muda a definição da
+premissa e exige medição própria depois —, nunca um insumo dela.
+
 ## Consequences
 
 O `min_jogos` **continua seguindo a célula**, inclusive nas linhas dessas quatro premissas. O

--- a/dbt_futebol/docs/adr/0010-a-remedicao-do-teste-2-e-janela-nova-sobre-pipeline-juntado.md
+++ b/dbt_futebol/docs/adr/0010-a-remedicao-do-teste-2-e-janela-nova-sobre-pipeline-juntado.md
@@ -1,0 +1,266 @@
+---
+status: accepted
+---
+
+# A remedição do Teste 2 é janela nova sobre pipeline juntado, e a decisão de tabela não a bloqueia
+
+A task **[B] Limpeza do catálogo de premissas** (ClickUp `wdx6zev64y`) está bloqueada desde
+04/08/2026 por uma condição de três partes: *"a remedição do Teste 2 depois de (a) corrigir o bug
+do de-vig de consenso, (b) passar a usar as três janelas de coleta e (c) juntar o histórico do time
+entre campeonatos"*. Duas das três envelheceram, a terceira nunca foi implementada, e a ADR 0008
+delegou à própria [B] uma decisão que parte de (c) parecia exigir.
+
+Decidimos: **a remedição é uma medição nova, sobre um pipeline que junta escopo e recorte, numa
+janela que não contém Copa do Mundo** — e a decisão de tabela adiada pela ADR 0008 **não** é
+pré-requisito dela. A condição de destrave é reescrita em termos conferíveis por query, e está no
+fim deste documento.
+
+O levantamento que fundamenta tudo abaixo é `docs/PESQUISA_REMEDICAO_TESTE2.md` (19/08/2026), com
+fonte em cada afirmação.
+
+---
+
+## Por que a condição de 04/08 não serve mais
+
+**(a) foi feita** — issue #22, commit `398b1d2`, ADR 0002. Sem ressalva.
+
+**(b) foi feita na letra e adjudicada na intenção.** As #37 e #40 puseram a janela na chave do
+de-vig, e hoje são **quatro** janelas, não três (`macros/devig_janela.sql:8-11`). Mas se a intenção
+de (b) era multiplicar a amostra do Teste 2, ela foi **julgada e rejeitada** pela ADR 0004, não
+deixada por fazer: três preços do mesmo palpite liquidados pelo mesmo placar encolhem o intervalo
+de confiança por √3 sem que entre informação. *"Os Testes 2, 3 e 4 seguem com uma observação por
+linha."* Uma condição de destrave não pode exigir o que uma ADR aceita proíbe.
+
+**(c) foi medida e recomendada, nunca implementada.** A [F] (#49–#59) montou o 2×2 de eixos como
+vars com default de produção (`macros/taskf_eixos.sql:43-44`), mediu as quatro células em
+`futebol_taskF` e recomendou juntar — *"é uma mudança de pipeline, não de peso"*
+(`docs/TASKF_RESULTADOS.md:58`). Produção segue em `da_competicao`: os modelos dizem por escrito
+*"Produção nunca as passa"*, nenhum workflow passa `--vars`, e nenhuma issue aberta implementa.
+
+---
+
+## A decisão, em cinco partes
+
+### 1. A medição da [F] é evidência, não é a remedição
+
+A [B] parou por um motivo escrito no corpo dela: *"36 das 39 premissas foram medidas com 40% a 88%
+das linhas vindo de jogo sem histórico"*. A [F] atacou isso e o número melhorou — amostra curta
+média de 45,5% para 34,5%, piso 5 de 69 para 92 jogos — mas **34,5% continua sendo amostra curta**,
+e **46,7% da janela congelada é Copa do Mundo** (79 de 169 jogos encerrados e precificados), o
+pedaço que juntar não conserta: 0% dos pares (jogo, time) ganham uma partida ao soltar a
+competição, porque seleção não joga mais nada na nossa base.
+
+Aceitar as células da [F] como a remedição seria destravar a [B] sobre o mesmo defeito que a fez
+parar, com o número menor.
+
+Há um segundo motivo, de coerência: se a [B] remover premissa com base em evidência sob
+`escopo=todas` enquanto produção computa `da_competicao`, **o catálogo deployado terá sido validado
+sobre um histórico que produção nunca calcula**. O pipeline muda primeiro; a evidência que decide o
+catálogo tem de vir do pipeline que serve o catálogo.
+
+### 2. (c) implementa escopo **e** recorte — a célula `ambos`, não a `escopo`
+
+A Recomendação 1 da [F] fala em soltar `competition_id`. Na janela em que a remedição vai rodar,
+isso não basta, e o motivo é calendário.
+
+O ramo default do PIT mantém `AND l.season = a.season`
+(`models/intermediate/int_futebol_team_form_pit.sql:238`). Todas as competições carregam
+`season = 2026`, então o rótulo não bloqueia o merge — mas a temporada 2026 das europeias **começou
+agora** (Primeira Liga 07/08, La Liga 15/08). Um clube português tem 0,5 partida de histórico na
+season 2026 por mais competições que se juntem.
+
+Piso 5, contado com a mesma aritmética do PIT (a contagem reproduz `base = 57` contra a leitura
+direta de `int_futebol_team_form_pit`, que é a célula onde produção existe):
+
+| piso 5 | `base` | `escopo` | `recorte` | `ambos` |
+|---|---|---|---|---|
+| janela congelada — 169 jogos ([F], #54) | 69 | **92** | 81 | 92 |
+| janela nova — 112 jogos (04/08 12:00 → 19/08) | 57 | 69 | **88** | **94** |
+
+| janela nova, por competição | jogos | `base` | `escopo` | `recorte` | `ambos` |
+|---|---|---|---|---|---|
+| champions_league | 21 | 0 | **0** | 6 | 9 |
+| primeira_liga | 17 | 0 | **0** | 13 | 13 |
+| la_liga | 5 | 0 | **0** | 3 | 3 |
+| copa_do_brasil | 8 | 0 | 8 | 5 | 8 |
+| sudamericana | 9 | 5 | 9 | 9 | 9 |
+
+Na janela congelada o escopo fazia todo o trabalho e o recorte não acrescentava um jogo acima do
+piso 5. Na janela nova é o inverso: **soltar a competição não resgata um único jogo europeu** —
+0 de 43. É exatamente o que a Recomendação 5 da [F] avisou: *"'Escopo sozinho não ajuda a Europa'
+NÃO é regra geral. Vale para esta janela, que cai inteira na virada de temporada… Quem implementar
+precisa decidir o eixo de recorte com o calendário na mão, e não a partir deste número."*
+
+Há um argumento de definição junto do de cobertura: **`temporada` é o recorte que fabrica a escassez
+que a [B] parou para não usar.** Ele significa 30 jogos em novembro e 2 em agosto; um teto fixo de
+10 é mais comparável entre competições e entre meses, não menos.
+
+**O custo está medido e é do lado que dói.** O `margin_stats` do Handicap não tem filtro de season
+nem hoje (ADR 0007), então para ele o recorte é só o teto — e as duas premissas mais fortes da base
+inteira encolhem: `raramente_perde_por_2` `n_p0` 445 → 388 e `favorito_irregular` 453 → 427
+(`docs/TASKF_RESULTADOS.md:898-905`). Do outro lado, `ambos` é a única célula em que `tende_golear`
+e `clean_sheets_altos` saem do vermelho no piso 5 ao mesmo tempo — duas das quatro que a spec da [B]
+apontou como "muito sinal, pouca amostra". A perda do Handicap entra como ressalva com número, ao
+lado das duas da Recomendação 4 da [F].
+
+### 3. A circularidade da ADR 0008 é aparente, e corta-se assim
+
+A ADR 0008 adia para a [B] a alternativa da "competição principal" para `superioridade_tabela`,
+`supremacia` e `sem_rodizio` (+ a coluna interna `x_superioridade_tabela`). Isso parece exigir que a
+[B] decida antes de (c) — a task que (c) bloqueia.
+
+Não exige, e a própria ADR 0008 já diz por quê: as quatro **permanecem competição-scoped**, e
+*"essa imobilidade é o resultado reportado, não uma lacuna a preencher"*. Então:
+
+1. **(c) sobe a produção sem tocar nas quatro.** `rank`, `ppg` e `n_teams` não existem num histórico
+   juntado; o agregado `tabela` do PIT continua competição + temporada em qualquer célula.
+2. **A remedição entrega, para as três premissas de tabela medidas, evidência sob `da_competicao`** —
+   por construção, e a ADR 0008 explica a construção. A [B] as julga nessa evidência, como julga as
+   outras 36. ⚠️ A igualdade entre células é no **piso 0**; nos pisos maiores elas mudam de número
+   porque o `min_jogos` segue a célula, e isso é o mecanismo, não falha.
+3. **"Competição principal" é um resultado candidato da [B], não um insumo dela** — muda a definição
+   da premissa e exige medição própria depois. O `sem_rodizio` é o caso a vigiar: é do Handicap, o
+   mercado com ROI positivo, e mediu −2,7.
+
+Nada em (c) fica esperando a [B], e nada na [B] fica esperando uma decisão que (c) precisasse tomar.
+
+### 4. A remedição roda em produção, ancorada na célula `ambos`
+
+A ADR 0007 mandou medir em `futebol_taskF` porque `dev` e `prod` apontam para o mesmo dataset
+`futebol`, e medir histórico juntado significaria publicar histórico juntado. **Com (c) em
+produção essa premissa expira**: produção passa a *ser* a célula juntada, e a remedição vira um
+`dbt run` normal mais o Teste 2 do `task01_base` contra `futebol`, sem var nenhuma. A ADR 0007 fica
+`superseded` no que toca a exigência de dataset próprio; `futebol_taskF` permanece como registro
+congelado do 2×2.
+
+A reconciliação contra a [0.1] (`macros/taskf_publicado_01.sql`) morre por construção — janela
+diferente e pipeline diferente. **O que a substitui:** rodar o Teste 2 do pipeline novo sobre a
+**janela congelada** e cobrar que ele reproduza a célula `ambos` da [F]. Se reproduzir, a máquina
+está certa e o que mudou é o mundo; se não reproduzir, a implementação de (c) divergiu da medição
+que a autorizou. É a única conferência que sobrevive à troca de janela.
+
+⚠️ **A janela congelada é um INSTANTE, e o `cutoff` do macro é um DIA.** O universo da [F] é
+`kickoff_utc ∈ [2026-06-16, 2026-08-04 12:00 UTC)` (carimbo de execução do `TASKF_RESULTADOS.md`),
+enquanto `macros/task01_base.sql:178` filtra `DATE(kickoff_utc) <= DATE(cutoff)` — fim do dia. Rodar
+a âncora com `cutoff='2026-08-04'` puxaria para dentro os jogos da tarde e da noite de 04/08, que
+pertencem à **janela nova**, e a comparação divergiria da célula `ambos` por um motivo chato que
+alguém investigaria como achado. Quem implementar precisa de granularidade de timestamp na âncora —
+seja estendendo o `cutoff` do macro, seja lendo a definição de universo da própria [F]. As duas
+janelas ladrilham exatamente nesse instante, e é por isso que ele precisa ser o mesmo dos dois lados.
+
+Isso torna a **#82 pré-requisito**, e a reescopa: de *"rebaselinar os 4 números da [F]"* para
+**"reconstruir a célula `ambos` sob o código pós-#78, como âncora da remedição"**. Sem isso a
+comparação falharia justamente em `superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado` e
+`ritmo_alto` — que é o que a #82 previu. A metade dela sobre a calibragem de `taskf_tolerancia_pp`
+não depende disto e virou a **#92**.
+
+**Quem executa esta ADR, e em que ordem:** expurgo do board (#80, #85, #86) → **#91**, que implementa
+(c) — os dois eixos, a Costura A recongelada, a #71 no mesmo commit e o piso cortando o disponível →
+**#82** reescopada, que reconstrói a célula `ambos` **sob o código da #91** e entrega a âncora → a
+remedição em si (termos 3 a 5 abaixo). A **#92** é independente de toda essa cadeia.
+
+### 5. Ordem de entrada em produção
+
+(c) move o `min_jogos` de todo jogo → move quais premissas acendem → move a nota → move o board, o
+snapshot `fact_value_opportunities_hist` e o sync. Há três issues abertas do [A] mexendo no mesmo
+board (#80, #85, #86), e a #86 é uma medição de churn D+7 — ela leria o churn de (c) como se fosse
+do expurgo.
+
+**(c) entra depois do expurgo e depois de a #86 fechar.** O expurgo conserta defeito conhecido e a
+#86 o valida; (c) é mudança de definição e pode esperar. Nenhum `ALTER` é preciso — (c) muda valores,
+não colunas do mart —, então a ordem que a #40 estabeleceu (imagem antes do `ALTER`) não se aplica:
+é `./build-and-push.sh dbt_futebol` e `./scripts/checa_deriva.sh` verde, rodado **de fora do
+worktree**.
+
+⚠️ **Sob `ultimos_10`, o piso de amostra passa a cortar a contagem errada se ninguém mexer.** O
+`played_total` satura no teto do recorte, e a regra da [F] é que o piso corte o **disponível** (ADR
+0007). O `pit` do `macros/task01_base.sql:320` lê `played_total`; com o default virado, ele precisa
+ler `played_total_disponivel` — que o modelo passa a emitir, porque hoje ele só é emitido fora do
+default. No piso 5 a troca é inócua pela identidade `LEAST(d, 10) >= piso ⟺ d >= piso`; no **piso
+10** ela deixa de ser, e "piso 10" passa a querer dizer "exatamente 10" em vez de "pelo menos 10".
+O raio disso é a medição e só ela: nenhum modelo de `marts/` lê `min_jogos` nem
+`int_futebol_team_form_pit`.
+
+⚠️ Virar o default mata a premissa da Costura A (`tests/assert_taskf_pit_default_igual_baseline`),
+que existe para provar que produção nunca usa a var. O cabeçalho dela já nomeia a saída honesta —
+*"recongelar o baseline de propósito, no mesmo commit da mudança que o justifica"*. É isso, e no
+mesmo commit. As outras três guardas da [F] têm tag `taskf`/`costura_b`, não `guarda`: não rodam no
+agendado e se aposentam junto com o dataset, o que é limpeza da [B].
+
+---
+
+## A condição de destrave reescrita
+
+A [B] destrava quando as cinco forem verdade. Cada uma é conferível por query ou por link — nenhuma
+depende de leitura de intenção.
+
+1. **O pipeline junta.** `pit_escopo` e `pit_recorte` têm default `todas` e `ultimos_10` em
+   `macros/taskf_eixos.sql`; os nove predicados de `macros/taskf_fontes_de_historico.sql` compilam
+   sem filtro de competição no default; as quatro premissas de tabela seguem competição-scoped
+   (ADR 0008); o piso de amostra do `task01_base` passou a cortar `played_total_disponivel`; a
+   imagem foi reconstruída e `./scripts/checa_deriva.sh` está verde.
+2. **A #71 entrou no mesmo commit.** `AET` e `PEN` contam no `team_log` — é o mesmo diff, mexe em
+   quais partidas entram no histórico, e medir uma sem a outra obriga a remedir de novo.
+3. **A âncora reproduz.** Com a célula `ambos` reconstruída **sob o mesmo código que virou o
+   default** (#82 reescopada, rodando **depois** da #91), o Teste 2 do pipeline novo rodado sobre a
+   janela congelada — `kickoff_utc ∈ [2026-06-16, 2026-08-04 12:00 UTC)`, o **instante** do carimbo
+   da [F], não o fim do dia 04/08 — reproduz essa célula dentro da tolerância declarada.
+
+   ⚠️ **"Pós-#78" não basta, e a ordem importa.** O pipeline novo carrega também a **#71**
+   (`AET`/`PEN` no `team_log`), que muda quais partidas entram no histórico. A janela congelada tem
+   8 jogos de Copa do Brasil, e sob `ambos` o efeito vaza para o histórico de qualquer clube
+   brasileiro que os tenha jogado. Uma célula `ambos` reconstruída **antes** da #91 não seria
+   reproduzível pelo pipeline que a inclui, e a âncora ficaria vermelha por um motivo já conhecido —
+   que é exatamente o modo de falha que ela existe para não ter.
+4. **A janela nova existe e tem forma.** `kickoff_utc ∈ [2026-08-04 12:00, 2026-10-01 00:00) UTC`,
+   com **≥ 400** jogos encerrados e precificados, **≥ 300** acima do piso 5, **≥ 100** desses vindos
+   de competição split-year, e **zero** de Copa do Mundo. Projeção em 19/08: 568 agendados, taxa
+   observada de encerrado-e-precificado de 96,6% (112/116).
+5. **O Teste 2 rodou nessa janela** e as linhas estão publicadas em `docs/` com carimbo de execução
+   (data, commit, dataset, universo), no padrão de `TASK01_RESULTADOS.md` e `TASKF_RESULTADOS.md`.
+
+### O que NÃO é condição — declarado para não voltar
+
+- **Não** é condição a amostra do Teste 2 crescer pelas janelas de coleta. São quatro janelas hoje,
+  e a ADR 0004 decidiu que elas não multiplicam a amostra: uma observação por linha, janela fixada
+  antes de olhar resultado.
+- **Não** é condição a [A] (#15) ter aterrissado. O universo do Teste 2 **não passa pelo gate** —
+  `macros/task01_base.sql:381-384` filtra `best_odd IS NOT NULL AND edge IS NOT NULL`, escopo de
+  mercado e meia-linha, sem corte por nota nem por edge positivo. A A2 não o toca; a A1 só remove do
+  catálogo `linha_subindo` e `linha_descendo`, que a [B] julgaria de qualquer forma. A emenda de
+  06/08 da ADR 0004 ("remedir, não reaproveitar") fala dos três números de CLV, que saem de um
+  recompute do gate — não do Teste 2.
+- **Não** é condição a "competição principal" da ADR 0008 estar decidida. É resultado candidato da
+  [B].
+- **Não** é condição a Europa estar coberta. Sob `ambos` o que sobra não é eixo, é **fronteira de
+  coleta**: UCL 9/21, Primeira Liga 13/17, La Liga 3/5, com o backfill de 2024 e 2025 completo nas
+  sete europeias. Quem falta são qualificatórias da UCL e clubes recém-promovidos, cuja liga de
+  origem não coletamos. Entra como ressalva com número, ao lado dos 40,7% de partidas emprestadas
+  contra adversário que a coleta não alcança (#57).
+
+---
+
+## Alternativas consideradas
+
+**Aceitar as células da [F] como a remedição, com três ressalvas.** Rejeitada pela parte 1: a
+janela congelada é 46,7% Copa do Mundo, 100% ano-calendário e ainda 34,5% de amostra curta — é o
+defeito que parou a [B], atenuado, não removido. E destravaria a [B] para editar um catálogo
+validado sobre um histórico que produção não calcula.
+
+**Implementar só o escopo (Recomendação 1 da [F], ao pé da letra).** Rejeitada pela parte 2: entrega
+0 de 43 jogos europeus acima do piso 5 na janela em que a remedição vai rodar. A própria [F]
+antecipou isso na Recomendação 5.
+
+**Desacoplar o teto de contagem por site** — aplicar `ultimos_10` só onde havia filtro de season, e
+poupar o `margin_stats` do Handicap. Rejeitada: compra ~400 linhas de Handicap ao preço de a célula
+de produção deixar de ser uma das quatro que a [F] mediu, e portanto ao preço da âncora da parte 4.
+
+**Deixar produção em `da_competicao` e remedir em `futebol_taskF`.** É a alternativa da parte 1 com
+outro nome, e cai pelo mesmo argumento de coerência.
+
+**Esperar a [A] (#15).** Rejeitada: custa semanas e não compra precisão nenhuma no Teste 2, cujo
+universo não é gated.
+
+**Manter a condição antiga e só marcar (c) como pendente.** Rejeitada: a condição exige, em (b),
+algo que a ADR 0004 proíbe, e delega, via ADR 0008, uma decisão à task que ela bloqueia. Uma
+condição que não pode ser satisfeita não é bloqueio, é esquecimento com data.

--- a/docs/PESQUISA_REMEDICAO_TESTE2.md
+++ b/docs/PESQUISA_REMEDICAO_TESTE2.md
@@ -1,0 +1,328 @@
+# Pesquisa — a remedição do Teste 2 está destravada?
+
+Levantamento, não decisão. Escrito em 2026-08-19 contra o código do worktree
+`impl-87-flags-penalidade` (`master` em `2a4ac2a`), o corpo das issues do GitHub, as ADRs do
+`dbt_futebol/docs/adr/` e os dois docs de resultado (`docs/TASK01_RESULTADOS.md`,
+`docs/TASKF_RESULTADOS.md`). Nenhum modelo, macro, teste ou config foi tocado; nenhum `dbt run`
+foi executado.
+
+---
+
+## 1. A pergunta e a resposta curta
+
+> **A pergunta:** a [B] está destravada — (a) o bug do de-vig de consenso foi corrigido, (b) as
+> três janelas de coleta estão em uso e (c) o histórico do time foi juntado entre campeonatos?
+> **A resposta: NÃO.** (a) FEITA e (b) FEITA (com ressalva de domínio), mas (c) foi **medida pela
+> [F] e recomendada — nunca implementada em produção**, e é ela que segura a remedição do Teste 2.
+
+A task `[B] Limpeza do catálogo de premissas` ([ClickUp `wdx6zev64y`](https://app.clickup.com/t/wdx6zev64y),
+status `backlog`) tem, desde 04/08/2026, esta condição de destrave: *"a remedição do Teste 2 depois
+de (a) corrigir o bug do devig de consenso, (b) passar a usar as três janelas de coleta e (c)
+juntar o histórico do time entre campeonatos."*
+
+| Condição | Veredito |
+|---|---|
+| (a) bug do de-vig de consenso | **FEITA** — corrigida na origem em 05/08 (issue #22, commit `398b1d2`) |
+| (b) usar as três janelas de coleta | **FEITA na letra, com ressalva de domínio** — #37 e #40 mergeadas, são QUATRO janelas hoje; mas a ADR 0004 decidiu explicitamente que isso **não** multiplica a amostra do Teste 2 |
+| (c) juntar o histórico entre campeonatos | **NÃO FEITA em produção; MEDIDA na [F]** — o eixo existe como var de medição, o default de produção continua `da_competicao`, e nenhuma issue aberta implementa a mudança |
+
+**Resposta: NÃO destravada.** A [F] respondeu a pergunta de (c) — e recomendou juntar — mas o
+código de produção não mudou: as nove fontes de histórico seguem filtrando por competição. O que
+existe hoje é a *medição* de como o Teste 2 fica com o histórico junto (células `escopo` e `ambos`
+em `futebol_taskF.taskf_teste2`, lote de 13/08), não um pipeline que junta. Se a [B] aceitar ler a
+medição da [F] como "a remedição", ela está **parcialmente** destravada — com três ressalvas
+abertas (#82, #71 e a janela 100% ano-calendário) descritas na seção 3.
+
+---
+
+## 2. Condição por condição
+
+### (a) "corrigir o bug do devig de consenso" — **FEITA**
+
+**A que o bug se refere.** É o achado colateral da [0.1] registrado em
+`docs/TASK01_RESULTADOS.md:79`: *"De-vig de consenso com uma só saída precificada dá
+`prob_justa = 1,0` e edge de até 14.900% (172 linhas, 2 vitórias em 172)"*, com a coluna "Produção
+afetada?" respondida **Não** — *"o gate barra. Mas contamina todo backtest, inclusive o
+publicado"*.
+
+Ele virou a issue **#22** (`Futebol · [D] Conjunto de saídas declarado por mercado: o de-vig para
+de anunciar certeza`, **CLOSED**), cuja origem no ClickUp é `wdx6zevnhx` — *"Corrigir o de-vig de
+consenso que anuncia valor máximo em linha de 1% de acerto"*. O corpo da #22 dimensiona: **404
+linhas** em produção com `prob_justa = 1,0`, **todas de benchmark consenso**, edge de +820% a
++14.900%, odd até 150,0 — 62 no Handicap(4), 206 no Gols(5) e 136 no Gols 1ºT(6). Mecanismo: o
+de-vig normaliza `prob = (1/odd) / Σ(1/odd)` sobre o conjunto de saídas; conjunto de um elemento
+faz a soma valer o próprio termo e a prob virar 1,0.
+
+**A correção está no código.** Commit `398b1d2` (2026-08-05, *"fix(devig): conjunto de saidas
+declarado por mercado — o de-vig para de anunciar certeza"*):
+
+- `dbt_futebol/macros/devig_conjunto_saidas.sql:24` — macro `futebol_conjunto_saidas()`, fonte
+  única do tamanho esperado do conjunto por mercado (`1:3, 4:2, 5:2, 6:2, 8:2, 12:3`).
+  Comparação **exata**, não `>=`, com o argumento escrito no cabeçalho: *"pelo menos duas"
+  deixaria passar o 1X2 com duas das três saídas (booksum ~0,66, probs infladas ~1,5×) — mesmo
+  bug, sem a prob 1,0 que denuncia*.
+- `dbt_futebol/models/intermediate/int_futebol_odds_devig.sql:227-234` — CTE `emissao`:
+  `(c.conjunto_esperado IS NOT NULL AND c.n_outcomes_valor = c.conjunto_esperado) AS emite_valor`.
+  Mercado não declarado → `NULL` → não emite (fail-closed).
+- `int_futebol_odds_devig.sql:251-265` — `prob_justa_fechamento`, `booksum_fechamento`,
+  `valor_fonte`, `edge` e `pts_valor` viram `NULL` quando `emite_valor` é falso;
+  `n_outcomes_valor` permanece real como diagnóstico (linha 258).
+- A regra é escrita **uma vez só**, sobre a coluna já consolidada — cobre Pinnacle, Dupla Chance
+  derivada e consenso de uma vez (CTE `consolidado`, `int_futebol_odds_devig.sql:161-166`), o que
+  fecha o risco latente que a #22 nomeia: *"o de-vig da Pinnacle usa a mesma normalização, sem
+  nenhuma guarda"*.
+- Decisão registrada em `dbt_futebol/docs/adr/0002-conjunto-de-saidas-declarado-por-mercado.md`.
+
+**E a base de medição já foi reapontada para o universo corrigido.**
+`dbt_futebol/macros/task01_base.sql:40-46` (cabeçalho, ⚠️ REAPONTADA em 2026-08-05): *"o universo
+de referência passa a ser o CORRIGIDO — sem as linhas de conjunto de saídas incompleto... O
+headline de consenso se move de −14,9% para −14,5%: ~0,4 ponto, e NENHUMA conclusão da [0.1]
+vira."* O flag `conjunto_incompleto` (`task01_base.sql:231`) não foi removido: **trocou de papel
+para testemunha** — se voltar a ser verdadeiro, a correção regrediu (`task01_base.sql:224-230`).
+
+**O que sobra.** Nada bloqueante. Duas notas de contorno, nenhuma reabre (a):
+
+1. A #22 registrava que *"nenhum `dbt test` roda em lugar nenhum... Todo teste deste projeto é
+   decorativo hoje"*. Isso foi endereçado: `dbt_futebol/macros/devig_janela.sql:20-22` descreve o
+   agendado já com fase própria de teste — *"No `workflow_futebol.yml` a fase de `dbt run` é a 2 e
+   a de `dbt test --select tag:guarda` é a 4, sem gate (de propósito, para teste vermelho não
+   derrubar o board nem o sync)"*. Consequência a ter em conta: guarda vermelha **reporta**, não
+   impede a linha ruim de chegar ao board.
+2. A issue **#87** (`O mart descarta as 4 flags de penalidade e o serving as readivinha errado`,
+   CLOSED em 19/08) mede que **7.710 chaves `(fixture, outcome_side, line_value)` colidem entre os
+   mercados 5 e 6** em `int_futebol_odds_devig` — mas o defeito é do consumidor (o `distinct on`
+   da RPC `get_futebol_fixture_value`, sem `market_id` nem `janela_usada`), não do de-vig. O
+   mercado 6 está declarado no `futebol_conjunto_saidas()` justamente porque carregava **136 das
+   404 linhas podres** da #22 (`devig_conjunto_saidas.sql`, bloco de documentação).
+
+---
+
+### (b) "passar a usar as três janelas de coleta" — **FEITA na letra, com ressalva de domínio**
+
+**O que existia em 04/08 (data da condição).** O `int_futebol_odds_devig` resolvia cada linha para
+**uma** janela — a mais recente disponível, via `QUALIFY window_priority = MAX(...)` — e descartava
+as outras duas. Está escrito na ADR 0004, primeiro parágrafo
+(`dbt_futebol/docs/adr/0004-o-grao-do-devig-e-a-janela.md`), e no comentário histórico que
+sobreviveu no modelo (`int_futebol_odds_devig.sql:25-30`).
+
+**O que foi feito.**
+
+- **Issue #37** (`Motor: o de-vig passa a emitir por janela, com o board inalterado`, **CLOSED**),
+  commit `b684a9a` (2026-08-10). A janela entrou na chave: o grão do de-vig é hoje
+  `(fixture_id, market_id, outcome_side, line_value, janela)` —
+  `int_futebol_odds_devig.sql:3` (description) e a CTE `per_outcome`
+  (`int_futebol_odds_devig.sql:31-56`), com `collection_window` no `GROUP BY`. Todas as três
+  fontes de valor normalizam **dentro da janela**: `pinnacle_devig` (`:75`), `consensus_devig`
+  (`:108`) e `dc_devig` (`:144`, que casa com `x2_pinnacle` em `:132` pela janela). Os joins da
+  consolidação também casam pela janela (`:186-232`), com uma exceção declarada: `pinnacle_move`
+  (`:89`) **não** entra pela janela, porque o sinal de movimento sharp é propriedade da linha
+  (comentário em `:213-217`).
+- **Issue #40** (`Motor: janela de detecção no board`, **CLOSED**), commit `988d0ac`
+  (2026-08-18). O board ganhou `janela_deteccao` — a janela mais cedo em que a linha passou no
+  gate — sem mudar o grão do mart.
+- A redução para a janela corrente virou macro única:
+  `dbt_futebol/macros/devig_janela.sql:94` (`futebol_devig_janela_corrente()`), que desde a #40 é
+  um filtro sobre `futebol_devig_todas_janelas()` (`devig_janela.sql:58`) — as duas leituras não
+  têm como divergir na definição de "janela corrente".
+
+**⚠️ São QUATRO janelas, não três.** `devig_janela.sql:8-11`: *"A `daily` entrou em produção em
+07/08/2026 (`tech-lamjav/data-engineering#34`, horizonte de 7 dias) e o board já publica nela.
+Qualquer coisa que assuma três janelas está desatualizada."* A ordem declarada é
+`daily(1) < t24h(2) < t1h(3) < t15m(4)` (`devig_janela.sql:28-36`). Ou seja: a condição (b) foi
+escrita com o mapa de 04/08 e o mapa mudou a favor dela.
+
+**A medição consome isso — reduzindo a uma janela, de propósito.**
+`dbt_futebol/macros/task01_base.sql:248` lê `FROM ({{ futebol_devig_janela_corrente() }})`, e o
+comentário imediatamente acima (`task01_base.sql:237-247`) explica: *"⚠️ REDUZIDO À JANELA
+CORRENTE (#37). O de-vig passou a emitir uma avaliação por janela coletada; ler sem reduzir faria
+cada aposta entrar no backtest até 4 vezes, uma por preço, todas liquidadas pelo mesmo placar. É
+EXATAMENTE o erro que a ADR 0001 e a ADR 0004 existem para impedir... A redução reproduz
+byte-a-byte a base de antes da #37."*
+
+**A ressalva de domínio, e ela é o ponto.** Se a intenção por trás de (b) era *aumentar a amostra
+do Teste 2*, essa intenção foi **julgada e rejeitada**, não deixada por fazer. ADR 0004, seção *"O
+que esta decisão NÃO compra"*: o multiplicador de 2,84× (21.407 linhas contra 60.818 pares
+linha×janela; no recorte liquidado 19.649 → 56.440 sobre **179 jogos, antes e depois**) é real e a
+conclusão é falsa — *"As três janelas de uma linha são três preços do mesmo palpite, liquidados
+pelo mesmo placar... o ROI esperado não se move e o intervalo de confiança encolhe por √3 sem que
+tenha entrado informação nenhuma."* E a sentença operativa: **"os Testes 2, 3 e 4 seguem com uma
+observação por linha, com a janela fixada antes de olhar resultado."**
+
+**O que (b) então compra para a remedição:** (i) a janela é agora uma escolha declarada e fixável
+antes de olhar resultado, em vez de um `QUALIFY` implícito; (ii) a pergunta de CLV — *o edge de
+t24h prevê melhor ou pior que o de t15m?* — passa a ser formulável (6.885 linhas com as duas
+janelas, ADR 0004); (iii) o board ganhou `janela_deteccao`. Nenhum desses três é pré-requisito da
+limpeza de catálogo, mas nenhum está pendente.
+
+**O que sobra.** Nada de infraestrutura. Sobra uma **decisão de leitura**: quem escrever a
+remedição precisa dizer se aceita a adjudicação da ADR 0004 (uma observação por linha) ou se
+considera (b) não cumprida por a amostra não ter triplicado. Sob a ADR, (b) está cumprida.
+⚠️ A ADR 0004 tem ainda uma *emenda de 2026-08-06* avisando que os três números de CLV dela
+(931 / 1.350 / 368 linhas) **têm prazo de validade**: depois das subtasks A1+A2 da task [A] a nota
+deixa de se mover entre janelas e as 368 passam a ser outro conjunto — *"remedir, não reaproveitar"*.
+
+---
+
+### (c) "juntar o histórico do time entre campeonatos" — **NÃO FEITA em produção; MEDIDA na [F]**
+
+Esta é a condição que decide a resposta, e é onde "a [F] respondeu" e "o código mudou" se separam.
+
+#### O que a [F] fez: mediu
+
+A task [F] são as issues **#49 a #59** (todas **CLOSED**; #59 fecha também a #49). Ela montou um
+2×2 de eixos de medição:
+
+- `dbt_futebol/macros/taskf_eixos.sql:43-44` — os dois eixos são **vars de dbt**:
+  `pit_escopo` (`da_competicao` | `todas`) e `pit_recorte` (`temporada` | `ultimos_10`), com
+  validação fail-closed (`:47-54`).
+- `dbt_futebol/macros/taskf_celula.sql` — o nome da célula é **derivado** dos eixos:
+  `da_competicao|temporada → base`, `todas|temporada → escopo`,
+  `da_competicao|ultimos_10 → recorte`, `todas|ultimos_10 → ambos`
+  (`taskf_celula.sql`, macro `taskf_nomes_de_celula()`).
+- O eixo de escopo alcança **nove predicados em seis modelos** —
+  `dbt_futebol/macros/taskf_fontes_de_historico.sql` (bloco "OS NOVE PREDICADOS DE ESCOPO (#52)"):
+  `team_form_pit` (dois ramos), `premissas_1x2.spine`, `premissas_ah.margin`,
+  `premissas_btts.last5`, `premissas_dc.hist`, `premissas_ou.spine`, `premissas_ou.pool`,
+  `premissas_ou.last5`.
+- A medição roda em **dataset próprio** (`futebol_taskF`), por decisão registrada na
+  `dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md`, e a saída é
+  `futebol_taskF.taskf_teste2` (`dbt_futebol/analyses/taskf_teste2.sql`, cabeçalho: *"POR QUE ESTA
+  ANÁLISE É UM SCRIPT DDL, E NÃO UM MODELO dbt"*).
+
+**Resultado medido** (`docs/TASKF_RESULTADOS.md`, seção Veredito, linhas 20-56):
+32 das 39 premissas mudam de número quando o escopo é solto; o universo com `min_jogos >= 5` sobe
+de **69 para 92 jogos** (`TASKF_RESULTADOS.md:30-31, 367-368, 1979, 2421`); a amostra curta média
+cai de **45,5% para 34,5%**; premissas com peso positivo no piso 5 **caem de 15 para 11**
+(`:604`) — o merge não infla o catálogo.
+
+#### O que a [F] NÃO fez: mudar o pipeline
+
+Este é o cerne, e a evidência é direta:
+
+1. **O default é competição-scoped.** `dbt_futebol/macros/taskf_eixos.sql:43-44` —
+   `var('pit_escopo', 'da_competicao')` e `var('pit_recorte', 'temporada')`. Sem `--vars`, o SQL
+   compilado é o antigo.
+2. **Produção nunca passa as vars, e isso está escrito no próprio modelo.**
+   `dbt_futebol/models/intermediate/int_futebol_team_form_pit.sql:4` (description): *"aceita as
+   vars pit_escopo (da_competicao|todas) e pit_recorte (temporada|ultimos_10), cujos DEFAULTS
+   reproduzem exatamente o descrito acima — no default o SQL compilado é idêntico ao de antes das
+   vars existirem. **Produção nunca as passa**; elas servem às células de medição, materializadas
+   no dataset futebol_taskF."* A mesma frase está nos cinco modelos de premissas
+   (`int_futebol_premissas_1x2.sql:3`, `_ah.sql:4`, `_ou.sql:3`, `_btts.sql:3`, `_dc.sql:3`).
+3. **O predicado de competição continua lá no caminho default.**
+   `int_futebol_team_form_pit.sql:186-187`:
+   `{%- if pit_escopo == 'da_competicao' %} AND l.competition_id = a.competition_id`.
+4. **Nada no agendado passa `--vars`.** As únicas ocorrências de `pit_escopo`/`pit_recorte` neste
+   repo, fora dos modelos/macros, são em `docs/TASKF_RESULTADOS.md` (linhas de comando de medição,
+   ex. `:633, 965-967, 1223-1225, 2345-2347`) e em testes da própria [F]
+   (`dbt_futebol/tests/assert_taskf_*.sql`). Nenhum script de `scripts/` passa vars, e um `grep -r`
+   por `pit_escopo|pit_recorte` em `data-engineering/` — onde moram os workflows que disparam o
+   job dbt — devolve **zero ocorrências**.
+5. **A própria [F] declara que juntar é trabalho futuro.** `docs/TASKF_RESULTADOS.md:58`,
+   Recomendação 1: *"**Juntar o escopo — sim, e é uma mudança de pipeline, não de peso.** A
+   medição sustenta soltar `competition_id` nas nove fontes de histórico."* Uma recomendação, não
+   uma execução.
+6. **Nenhuma issue aberta implementa isso.** As 8 issues abertas hoje são #86, #85, #82, #80, #71,
+   #38, #26 e #15 (`gh issue list --state open`); nenhuma delas é "soltar `competition_id` nas nove
+   fontes".
+
+#### O impedimento que sobra, e a circularidade
+
+`dbt_futebol/docs/adr/0008-premissa-de-tabela-nao-tem-escopo-juntado.md` decide que **quatro
+premissas de tabela** — `superioridade_tabela` (1X2), `supremacia` e `sem_rodizio` (Handicap) e a
+coluna interna `x_superioridade_tabela` (reusada pela Dupla Chance) — **permanecem
+competição-scoped em todas as células**, porque `rank`, `ppg` e `n_teams` não existem num histórico
+juntado. A ADR nomeia a alternativa séria (eleger uma "competição principal" por time) e a **adia
+explicitamente para a [B]**: *"Fica registrada como candidata para a [B], onde o `sem_rodizio`
+merece atenção por ser do Handicap, o mercado com ROI positivo."*
+
+⚠️ **Isso é uma circularidade real:** parte de (c) está delegada à própria task que (c) bloqueia.
+Ela não pode ser resolvida por evidência — é chamada de escopo de quem despacha a [B].
+
+#### O que falta em (c)
+
+Soltar `competition_id` nos nove predicados em produção (as sete premissas cobertas pela ADR 0008 e
+pelas fontes imunes ficam de fora por construção), com as duas ressalvas que a [F] já mediu e
+precificou (`TASKF_RESULTADOS.md:66-68`, Recomendação 4): **1,46 titular a mais de rodízio** entre
+liga e copa, e **40,7% das partidas emprestadas contra adversário que a coleta não alcança**.
+Nenhuma das duas inverte a recomendação — as duas entram na [B] como ressalva com número.
+
+---
+
+## 3. O que ainda falta para a remedição rodar
+
+Ordenado do que bloqueia para o que qualifica.
+
+1. **Decidir o que "remedição" significa** — é a bifurcação, e é humana:
+   - **Leitura estrita** ("o pipeline junta e aí se remede"): falta implementar a Recomendação 1
+     da [F] (soltar `competition_id` nas nove fontes em produção). Não existe issue; precisa ser
+     escrita.
+   - **Leitura pragmática** ("a [F] já mediu o Teste 2 com o histórico junto"): a medição existe —
+     `futebol_taskF.taskf_teste2`, células `base`/`escopo`/`recorte`/`ambos`, lote único de
+     13/08/2026 17:49–17:56 UTC, commit `7fdd1a3`, universo congelado `kickoff ∈ [16/06, 04/08
+     12:00 UTC)` = **169 jogos** (`TASKF_RESULTADOS.md`, seção "Carimbo de execução"). Ela roda
+     sobre a base já corrigida por (a) e já reduzida por (b). Nesse caminho, o que falta são os
+     itens 2 a 5 abaixo.
+2. **Fechar a #82 antes de reconstruir qualquer célula.** `Rebaselinar os 4 números da [F] medidos
+   sob a regra antiga de média` (**OPEN**, follow-up da #78, que trocou `AVG`/`APPROX_QUANTILES`
+   por `SAFE_DIVIDE(SUM, COUNT)` + `NUMERIC`). O corpo é explícito: as células hoje em
+   `futebol_taskF` são as da **regra antiga**; a guarda
+   `tests/assert_taskf_base_reproduz_01.sql` *"fica verde enquanto ninguém reconstruir as células
+   da [F]"* e **fica vermelha de propósito na próxima remedição**, em `superioridade_xg`,
+   `xg_combinado_alto`, `xg_baixo_combinado` e `ritmo_alto`. Qualquer remedição real reconstrói as
+   células, logo cai nisto.
+3. **Resolver, ou aceitar como ressalva, a decisão adiada pela ADR 0008** (competição principal
+   para `superioridade_tabela`, `supremacia`, `sem_rodizio`). É a circularidade da seção 2c.
+4. **Decidir o que fazer com a #71** (`Jogo decidido nos pênaltis ou na prorrogação não entra no
+   histórico de time nenhum`, **OPEN**). Ela bate exatamente no histórico de copa que (c) resgata:
+   `status_short = 'FT'` exclui `AET`/`PEN` do `team_log` e dos `last5` — **14,2% dos jogos
+   encerrados da Copa do Brasil**. O próprio ticket mede que, nas contagens que o PIT usa, o efeito
+   é pequeno (Copa do Brasil 409 → 412 partidas, **+0,7%**), mas ele existe e é do mesmo lado do
+   dado que (c) mexe.
+5. **Aceitar que a janela congelada não responde pela Europa nem pelas seleções.**
+   `TASKF_RESULTADOS.md:44-56`: **Copa do Mundo e Champions somam 53,7% das partidas encerradas da
+   janela (145 de 270)** e seguem sem conserto — na Copa do Mundo o deserto é real (0% dos pares
+   (jogo, time) ganham uma partida ao soltar a competição); a Champions **não tem um jogo** no
+   universo congelado. E ⚠️ *"o universo congelado é 100% ano-calendário: as ligas split-year não
+   tinham começado em 16/06–04/08. Célula vazia é sem amostra, nunca efeito nulo."* Uma limpeza de
+   catálogo feita sobre essa janela herda esse limite.
+6. **Reler a instrução da [0.1] antes de usar o resultado.** A conclusão que sobreviveu a tudo é
+   que **peso individual não se replica fora da amostra** (+8,3% in-sample virando −6,2%
+   out-of-sample; 14,5 pontos de viés de seleção) — repetida na Recomendação 1 da [F]
+   (`TASKF_RESULTADOS.md:58-61`). A [B] é **remover premissa sem evidência**, não reescrever peso;
+   a remedição serve à primeira coisa.
+
+---
+
+## 4. Incertezas e o que eu não consegui determinar
+
+- **A intenção exata de (b) não está escrita em lugar nenhum.** A condição diz "passar a usar as
+  três janelas de coleta" e não diz para quê. Duas leituras são compatíveis com o texto: "o de-vig
+  para de jogar duas janelas fora" (cumprida, #37/#40) ou "o Teste 2 passa a medir sobre as três
+  janelas" (rejeitada pela ADR 0004, que a chama de amostra falsa). Reportei as duas em vez de
+  escolher. **Não sei** qual o Victor tinha em mente quando escreveu em 04/08.
+- **Não confirmei em BigQuery** que a tabela `futebol.int_futebol_odds_devig` de hoje tem zero
+  linhas com `prob_justa_fechamento = 1,0` nem que `futebol_taskF.taskf_teste2` está com o lote de
+  13/08 intacto. A instrução era não materializar; consultas de leitura seriam seguras, mas optei
+  por não gastar quota já que o código e os docs decidem os três vereditos. Se alguém quiser
+  fechar por dado vivo, são duas queries de leitura.
+- **A task `wdx6zev64y` não tem nenhum comentário** (`clickup_get_task_comments`, `count: 0`) — a
+  condição de destrave de 04/08 é o texto mais recente sobre o assunto no ClickUp, e nada a
+  reinterpretou por lá. A task foi atualizada pela última vez em 04/08/2026
+  (`date_updated: 1785883853106`).
+- **Não li as tasks-irmãs do ClickUp** (`wdx6zevnhy`, origem da [F], e `wdx6zevnhx`, origem da
+  #22) — só as conheço pelas citações dentro das issues do GitHub e dos macros. Se alguma delas
+  tiver contexto que muda a leitura de (b) ou (c), ele não está neste levantamento.
+- **Nomenclatura que engana:** `dbt_futebol/analyses/taskf_remedicao.sql` **não** é a "remedição do
+  Teste 2" desta pergunta. É a análise de **estabilidade** da [F] (#56): compara duas execuções das
+  quatro células campo a campo para provar que reconstruir devolve o mesmo número. O próprio
+  cabeçalho avisa: *"Ela não confere que a medição está certa... Duas execuções idênticas e ambas
+  erradas passariam aqui."*
+- **Não sei quanto custa** implementar a Recomendação 1 em produção. Os nove predicados estão
+  enumerados (`taskf_fontes_de_historico.sql`) e a var já existe em todos os seis modelos, então o
+  diff mecânico é pequeno — mas a mudança move o `min_jogos` de todo jogo, logo move o board, o
+  snapshot histórico e o sync. Nada nas fontes lidas dimensiona esse impacto a jusante.
+- **Não avaliei** se a [A] (issue #15, redesenho do Score — tira o preço da nota) deveria vir antes
+  da remedição. A emenda de 2026-08-06 da ADR 0004 diz que A1+A2 mudam a população das linhas que
+  passam no gate, e a [B] herda essa população. Isso é uma pergunta de sequenciamento de tasks que
+  está fora do que esta pesquisa foi pedida para responder.

--- a/docs/PESQUISA_REMEDICAO_TESTE2.md
+++ b/docs/PESQUISA_REMEDICAO_TESTE2.md
@@ -1,5 +1,13 @@
 # Pesquisa — a remedição do Teste 2 está destravada?
 
+> **A decisão que este levantamento pedia foi tomada em 2026-08-19:**
+> `dbt_futebol/docs/adr/0010-a-remedicao-do-teste-2-e-janela-nova-sobre-pipeline-juntado.md`.
+> Ela responde a bifurcação da seção 3 (leitura estrita, e não a pragmática), corta a circularidade
+> da ADR 0008 descrita na seção 2c, e substitui a condição de destrave de 04/08 por cinco termos
+> conferíveis. Duas incertezas da seção 4 foram fechadas com dado vivo — o universo do Teste 2 não
+> passa pelo gate, e o eixo que resgata a Europa na janela nova é o **recorte**, não o escopo.
+> Este documento fica como está: é o levantamento que a ADR cita, não um documento vivo.
+
 Levantamento, não decisão. Escrito em 2026-08-19 contra o código do worktree
 `impl-87-flags-penalidade` (`master` em `2a4ac2a`), o corpo das issues do GitHub, as ADRs do
 `dbt_futebol/docs/adr/` e os dois docs de resultado (`docs/TASK01_RESULTADOS.md`,


### PR DESCRIPTION
Levantamento pedido antes de escolher o próximo trabalho do AE: **a task [B] (Limpeza do catálogo de premissas) pode voltar do backlog?**

A condição de destrave dela, escrita em 04/08, é *"a remedição do Teste 2 depois de (a) corrigir o bug do de-vig de consenso, (b) passar a usar as três janelas de coleta e (c) juntar o histórico do time entre campeonatos"*.

## Resposta: NÃO destravada

| Condição | Veredito |
|---|---|
| (a) bug do de-vig de consenso | **FEITA** — o edge de +14.900% em conjunto de uma saída só (achado da [0.1]) virou a #22 e foi corrigido em `398b1d2`, 05/08 |
| (b) três janelas de coleta | **FEITA na letra** — #37 e #40 mergeadas, e hoje são **quatro** janelas |
| (c) juntar o histórico entre campeonatos | **MEDIDA, NÃO IMPLEMENTADA** |

**A (c) é o que segura tudo.** A [F] mediu o 2×2 num dataset próprio e recomendou juntar — o `TASKF_RESULTADOS.md` diz *"é uma mudança de pipeline, não de peso"*. Mas o default de produção segue `da_competicao`, os seis modelos carregam a frase *"Produção nunca as passa"*, o predicado continua no código, não há `--vars` em workflow nenhum (zero hits também no `data-engineering/`), e **nenhuma das 8 issues abertas implementa a mudança**. A [F] respondeu a pergunta; o código não mudou.

## Duas coisas que o levantamento achou e que não estavam na pergunta

**1. A ressalva da (b).** A ADR 0004 decidiu *explicitamente* que usar as quatro janelas **não** multiplica a amostra do Teste 2 — *"os Testes 2, 3 e 4 seguem com uma observação por linha"* — e o `task01_base.sql` reduz de propósito via `futebol_devig_janela_corrente()`. Ou seja: se a intenção de (b) era triplicar a amostra, ela foi **rejeitada por decisão de domínio**, não deixada por fazer. Quem for reescrever a condição de destrave da [B] precisa saber disso.

**2. Uma circularidade que não se resolve lendo código.** A ADR 0008 adia para a **própria [B]** a decisão sobre as premissas de tabela (`superioridade_tabela`, `supremacia`, `sem_rodizio`). Parte de (c) depende da task que (c) bloqueia. É chamada humana.

## A leitura alternativa

Se a [B] aceitar a medição da [F] **como** a remedição — leitura pragmática, e defensável —, ela fica **parcialmente** destravada, com três ressalvas abertas:

- **#82** — as células materializadas hoje são da regra antiga de média; a guarda `assert_taskf_base_reproduz_01` fica vermelha na próxima reconstrução, de propósito
- **#71** — jogo em prorrogação/pênaltis fora do histórico de time nenhum (+14,2% na Copa do Brasil)
- a janela congelada da [F] ser **100% ano-calendário**, com 53,7% de Copa do Mundo + Champions

## Sobre o documento

Levantamento, **não decisão**. Nenhum modelo, macro, teste ou config foi tocado e nenhum `dbt run` foi executado (dev e prod apontam para o mesmo dataset de produção). Cada afirmação cita `arquivo:linha`, número de issue ou commit, e há uma seção final de **incertezas declaradas** — o que não deu para determinar está escrito como não determinado.

Fica em `docs/`, ao lado de `TASK01_RESULTADOS.md` e `TASKF_RESULTADOS.md`, que é onde este repo guarda medição. Decisão, quando vier, é ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
