### PR TITLE
Futebol: a régua da [F] desce para 0,25 pp, e agora é medida (#92)

### DIFF
--- a/dbt_futebol/analyses/taskf_exclusao.sql
+++ b/dbt_futebol/analyses/taskf_exclusao.sql
@@ -14,8 +14,13 @@
     ────────────────────────────────────────────────────────────────────────────────
     A RÉGUA, DECLARADA ANTES DE MEDIR
 
-    Mesmo padrão da tolerância de 0,5 pp da #51: o número existe antes do resultado, para não ser
-    escolhido depois de ver qual lado ele favorece.
+    Mesmo padrão da tolerância da #51: o número existe antes do resultado, para não ser escolhido
+    depois de ver qual lado ele favorece.
+
+    ⚠️ O paralelo vale para o MÉTODO, não para o número: aquela tolerância era 0,5 pp e a #92 a
+    remediu para 0,25 pp — ou seja, "declarado antes de medir" foi o começo dela, e não onde ela
+    ficou. Declarar antes protege da escolha conveniente; não dispensa remedir quando o fenômeno
+    que justificava o número muda.
 
     O que é ORDENAR. As 39 premissas do benchmark preferido (`usado_para_peso`), ordenadas por
     `diferenca_p<piso>` — o sinal medido, decrescente. É a ordenação que a [B] leria para decidir

--- a/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_01.sql
@@ -34,8 +34,18 @@
        sobre o mesmo universo congelado: deveria ser DETERMINÍSTICA. Diferença aqui não tem
        explicação pronta e é achado até que se prove o contrário.
 
-    A régua está em `taskf_tolerancia_pp` (default 0,5 pp), aplicada só sobre a origem 1. O valor
+    A régua está em `taskf_tolerancia_pp` (default 0,25 pp), aplicada só sobre a origem 1. O valor
     é declarado e justificado por escrito em `docs/TASKF_RESULTADOS.md` — aqui ele é só o número.
+
+    ⚠️ ERA 0,5 pp ATÉ 19/08/2026, e desceu na #92 porque o 0,5 nunca tinha sido medido: ele saiu
+    de uma frase sobre deltas de ROI do TESTE 3 ("0,2–0,4 pp entre execuções"), enquanto esta
+    régua governa campos do TESTE 2 — que, na reconciliação de 04/08, reproduziram com delta
+    exatamente 0,0. A #78 tirou o ruído de instrumento que alimentava aqueles 0,2–0,4, e a #92
+    remediu: 0,00 pp em 8 execuções, nas duas camadas (reconstrução das premissas e agregação do
+    Teste 2). O que sobrou dentro do 0,25 é o resíduo conhecido do `linha_descendo` (0,2 pp
+    medido) mais meia grade do `ROUND(·, 1)`, que tira o número de cima da grade. A decomposição
+    inteira está no cabeçalho da tests/assert_taskf_base_reproduz_01.sql — a régua existe uma vez,
+    o argumento também.
 
     ⚠️ O QUE A PRIMEIRA EXECUÇÃO MOSTROU, e que muda como esta saída deve ser lida (12/08/2026):
 
@@ -89,7 +99,7 @@
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 #}
 
-{%- set tol = var('taskf_tolerancia_pp', 0.5) -%}
+{%- set tol = var('taskf_tolerancia_pp', 0.25) -%}
 {%- set j   = taskf_universo() -%}
 
 {#- As duas premissas que leem odds ao vivo. Não é uma lista de exceções conveniente: é o

--- a/dbt_futebol/analyses/taskf_reconciliacao_01.sql
+++ b/dbt_futebol/analyses/taskf_reconciliacao_01.sql
@@ -66,9 +66,13 @@
 
     Consequência: nesta janela NENHUMA linha se classifica como `deriva_de_odds`, porque o
     mecanismo não existe — `linha_descendo` cai em `INVESTIGAR`, que é o veredito honesto, e o
-    resíduo está documentado em `docs/TASKF_RESULTADOS.md`, aberto e delimitado. A régua de 0,5 pp
-    continua declarada e continua valendo: ela volta a ter mordida no universo estendido da spec,
-    que alcança o presente e onde `capturas_apos_o_teto` deixa de ser zero.
+    resíduo está documentado em `docs/TASKF_RESULTADOS.md`, aberto e delimitado. A régua continua
+    declarada e continua valendo — mas vale **0,25 pp desde a #92**, e não os 0,5 que esta seção
+    dizia. A frase que estava aqui ("volta a ter mordida no universo estendido da spec") deixou de
+    ser a justificativa do número: o estendido nunca foi medido, e o que sustenta o 0,25 é o
+    resíduo do `linha_descendo` mais meia grade. O estendido segue sendo onde
+    `capturas_apos_o_teto` deixa de ser zero — e por isso segue precisando de medição PRÓPRIA
+    antes que alguém reuse este número lá.
 
     É por isso que os dois mecanismos são MEDIDOS e vão na saída (`capturas_apos_o_teto`,
     `linhas_da_22_no_preferido`): quem lê não precisa acreditar no rótulo, ele vem com o número

--- a/dbt_futebol/analyses/taskf_ruido_do_instrumento.sql
+++ b/dbt_futebol/analyses/taskf_ruido_do_instrumento.sql
@@ -1,0 +1,151 @@
+{#
+    [F] RUÍDO DO INSTRUMENTO — quanto o Teste 2 anda entre duas execuções idênticas (issue #92).
+
+    Esta análise existe para responder UMA pergunta, e ela é sobre a RÉGUA, não sobre o dado:
+    com o insumo parado e o mesmo SQL, quanto os campos em pontos percentuais do Teste 2 se
+    mexem de uma execução para a outra? Esse número é o PISO da tolerância — abaixo dele a
+    régua fica vermelha sem que nada tenha divergido.
+
+    A `taskf_tolerancia_pp` foi calibrada em 0,5 pp por uma frase de `docs/TASK01_RESULTADOS.md`
+    ("o mercado de Gols anda 0,2–0,4 pp entre execuções sem que nada mude"), e a #78 mostrou que
+    parte daquele movimento era ruído de instrumento que já saiu. Daí a remedição.
+
+    ⚠️ AQUELA FRASE MEDIU OUTRA COISA, e isso importa para lê-la. Os 0,2–0,4 pp são deltas de
+    ROI do TESTE 3 (`docs/TASK01_RESULTADOS.md`, ticket #4): a porta "N+ premissas" é um limiar,
+    e 0,07% das linhas trocando de lado moveu o ROI do mercado em 0,4 pp. A `taskf_tolerancia_pp`
+    governa os campos por premissa do TESTE 2, que são médias, não um agregado atrás de um
+    limiar. A régua nasceu calibrada por uma métrica diferente da que ela mede — e é por isso que
+    remedir vale mesmo que o número não mude.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    AS DUAS CAMADAS, E POR QUE SÓ UMA DELAS É MEDIDA AQUI
+
+    Uma re-medição do Teste 2 tem dois pontos onde a mesma SQL pode devolver número diferente:
+
+      CAMADA 1, as premissas. Os cinco `int_futebol_premissas_*` são `materialized: table` — uma
+                re-medição os RECONSTRÓI. Era aqui que morava o ruído da #78 (`AVG` fundindo
+                médias parciais de shards em ponto flutuante). Depois da #78 as duas premissas de
+                odds saem de `SAFE_DIVIDE(SUM(CAST(1.0/odd AS NUMERIC)), COUNT(...))`: soma em
+                ponto FIXO, que é exata e não depende da ordem. A camada 1 é determinística POR
+                CONSTRUÇÃO, não por sorte de medição — e a #78 a mediu em 8 execuções
+                (`linha_subindo`/`linha_descendo` cravadas em 1967/2579).
+
+      CAMADA 2, a agregação do Teste 2 — esta análise. `AVG(IF(pl.acesa, ...))` sobre FLOAT64, o
+                MESMO agregado instável que a #78 tirou dos modelos. A guarda
+                `assert_premissas_sem_agregado_instavel` cobre MODELO, não análise, então ele
+                continua aqui, e continua sendo o instrumento com que a [F] se mede. Ninguém
+                tinha medido esta camada sozinha.
+
+    A saída traz o valor BRUTO ao lado do arredondado de propósito. O `ROUND(·, 1)` do Teste 2
+    esconde o tremor: duas execuções podem diferir no 15º dígito e imprimir o mesmo número — até
+    a linha cair em cima da grade, e aí ela pula 0,1 de uma vez. O bruto diz o tamanho REAL do
+    tremor; o arredondado diz se ele já chegou a atravessar a grade. Sem os dois lado a lado,
+    "8 execuções idênticas" pode significar "não há tremor" ou "não houve empate nesta rodada",
+    e essas duas coisas pedem decisões diferentes.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O QUE ELA MEDE, E SOBRE QUE UNIVERSO
+
+    Universo congelado da [F] (`macros/taskf_universo.sql`), os mesmos 169 jogos, porque é ele o
+    universo da guarda que consome a régua (`assert_taskf_base_reproduz_01` compara
+    `universo = 'completo'`). No congelado a coleta de odds já parou, então o insumo é imóvel e
+    tudo que sobrar entre execuções é instrumento — que é exatamente o que se quer isolar.
+
+    Os campos são os SEIS que a guarda cobra em pp, e só eles. Os `n_p*` vão junto como camada de
+    contagem: se eles se mexerem, o problema não é arredondamento, é linha entrando e saindo.
+
+    ⚠️ ELA NÃO MEDE A OUTRA COMPONENTE DA TOLERÂNCIA — o movimento LEGÍTIMO de odds no universo
+    estendido, que a #78 não tocou. Ali a coleta ainda alcança o presente e uma janela t15m nova
+    muda quais linhas acendem. Nenhum consumidor da var compara esse universo hoje (a guarda e a
+    `analyses/taskf_reconciliacao_01.sql` são as duas, e as duas leem `completo`), mas quem
+    escrever a primeira comparação sobre o `estendido` precisa medir essa componente ANTES de
+    reusar o número desta análise.
+
+    Rodar N vezes seguidas e comparar as saídas — sem `dbt run`, sem escrever em dataset nenhum:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskf_ruido_do_instrumento
+      for i in $(seq 1 8); do
+        bq query --use_legacy_sql=false --project_id=smartbetting-dados --format=csv \
+          < target/compiled/dbt_futebol/analyses/taskf_ruido_do_instrumento.sql > /tmp/run_$i.csv
+      done
+      for i in $(seq 2 8); do diff -q /tmp/run_1.csv /tmp/run_$i.csv; done
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    → RESULTADOS: `docs/TASKF_RESULTADOS.md`, seção do ticket #92.
+#}
+
+{%- set pisos_em_pp = [0, 5, 10] -%}
+
+WITH {{ task01_base() }},
+
+{#- A agregação do Teste 2, recortada no universo congelado. É uma cópia da
+    `analyses/taskf_teste2.sql` pelo mesmo motivo que ela é cópia da `analyses/task01_teste2.sql`:
+    o que se quer reproduzir aqui é o INSTRUMENTO, com o `AVG` e tudo, e não uma versão limpa
+    dele. Extrair para macro compartilhado trocaria o instrumento medido por outro.
+
+    Usa `a.min_jogos` (o USADO) e não a contagem disponível da #54: na célula `base` o recorte é
+    `temporada`, sem teto, e as duas são o mesmo número por construção. -#}
+agregado AS (
+    SELECT
+        a.market_id,
+        pl.premissa,
+        a.benchmark,
+        AVG(IF(pl.acesa, IF(a.min_jogos < 5, 1.0, 0.0), NULL))   AS frac_curta
+        {%- for piso in pisos_em_pp %},
+        COUNTIF(pl.acesa AND a.min_jogos >= {{ piso }})          AS n_{{ piso }},
+        AVG(IF(pl.acesa AND a.min_jogos >= {{ piso }},
+               a.prob_justa_fechamento, NULL))                   AS p_odd_{{ piso }},
+        AVG(IF(pl.acesa AND a.min_jogos >= {{ piso }},
+               CAST(a.ganhou AS INT64), NULL))                   AS p_real_{{ piso }}
+        {%- endfor %}
+    FROM apostas AS a
+    JOIN prem_long AS pl
+      ON  pl.market_id                  = a.market_id
+      AND pl.fixture_id                 = a.fixture_id
+      AND pl.outcome_side               = a.outcome_side
+      AND COALESCE(pl.line_value, -999) = COALESCE(a.line_value, -999)
+    WHERE {{ taskf_universo_filtro('a.') }}
+    GROUP BY a.market_id, pl.premissa, a.benchmark
+    HAVING COUNTIF(pl.acesa) > 0
+),
+
+{#- O carimbo da construção dos fatos entra na SAÍDA para que "as 8 execuções leram o mesmo
+    insumo" seja conferível na linha, e não acreditado. Se um rebuild agendado cair no meio da
+    medição, este número muda e as 8 deixam de ser 8 execuções idênticas — sem ele, a diferença
+    apareceria como tremor do instrumento, que é a leitura errada. -#}
+fatos AS (
+    SELECT MAX(dbt_loaded_at) AS odds_loaded_at
+    FROM {{ ref('fact_odds_snapshot') }}
+)
+
+SELECT
+    f.odds_loaded_at,
+    CASE g.market_id
+        {%- for mid, m in task01_markets().items() %}
+        WHEN {{ mid }} THEN '{{ m.nome }}'
+        {%- endfor %}
+    END                                                          AS mercado,
+    g.premissa,
+    g.benchmark,
+    -- A camada de contagem. Ela se mexer é outro fenômeno, e a saída tem de saber distinguir.
+    {%- for piso in pisos_em_pp %}
+    g.n_{{ piso }}                                               AS n_p{{ piso }},
+    {%- endfor %}
+    -- Os seis campos em pp que a `assert_taskf_base_reproduz_01` cobra, cada um em duas versões:
+    -- o arredondado que a guarda compara e o bruto que mostra o tremor antes de ele chegar à
+    -- grade. `bruto` em 12 casas — o tremor do `AVG` vive na 15ª, então 12 é folga e não corta
+    -- nada que importe.
+    ROUND(g.frac_curta * 100, 1)                                 AS pct_amostra_curta,
+    ROUND(g.frac_curta * 100, 12)                                AS pct_amostra_curta_bruto,
+    ROUND(g.p_odd_0  * 100, 1)                                   AS a_odd_dava_p0,
+    ROUND(g.p_odd_0  * 100, 12)                                  AS a_odd_dava_p0_bruto,
+    ROUND(g.p_real_0 * 100, 1)                                   AS aconteceu_p0,
+    ROUND(g.p_real_0 * 100, 12)                                  AS aconteceu_p0_bruto
+    {%- for piso in pisos_em_pp %},
+    ROUND((g.p_real_{{ piso }} - g.p_odd_{{ piso }}) * 100, 1)   AS diferenca_p{{ piso }},
+    ROUND((g.p_real_{{ piso }} - g.p_odd_{{ piso }}) * 100, 12)  AS diferenca_p{{ piso }}_bruto
+    {%- endfor %}
+FROM agregado AS g
+CROSS JOIN fatos AS f
+ORDER BY mercado, g.premissa, g.benchmark

--- a/dbt_futebol/analyses/taskf_ruido_do_instrumento.sql
+++ b/dbt_futebol/analyses/taskf_ruido_do_instrumento.sql
@@ -61,6 +61,17 @@
     escrever a primeira comparação sobre o `estendido` precisa medir essa componente ANTES de
     reusar o número desta análise.
 
+    ⚠️ SEM `--target taskF`, E ISSO É DELIBERADO — é a única análise `taskf_*` que roda no target
+    default, então vale a linha. As outras leem as CÉLULAS materializadas em `futebol_taskF`; esta
+    não lê célula nenhuma, ela reexecuta o instrumento. E o que ela precisa reexecutar é o código
+    de HOJE sobre os fatos de HOJE: em `futebol_taskF` as tabelas de premissas guardam a última
+    célula que a receita construiu, sob o código PRÉ-#78 — medir o ruído pós-#78 ali seria medir o
+    ruído que a #78 já tirou. O dataset `futebol` é também, por definição, a configuração da célula
+    `base` (os defaults de produção), que é a célula da guarda.
+
+    Nada é materializado: `dbt compile` + `bq query` sobre um SELECT não escreve, então a ADR 0007
+    continua respeitada na letra e no espírito — o que ela proíbe é PUBLICAR medição no board.
+
     Rodar N vezes seguidas e comparar as saídas — sem `dbt run`, sem escrever em dataset nenhum:
 
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskf_ruido_do_instrumento
@@ -75,7 +86,19 @@
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`, seção do ticket #92.
 #}
 
-{%- set pisos_em_pp = [0, 5, 10] -%}
+{#- OS PISOS SÃO OS DA GUARDA, E NÃO OS DE `macros/taskf_pisos()` — a diferença é de propósito e
+    tem de estar escrita, porque o macro diz que a lista "precisa existir num lugar só".
+
+    `taskf_pisos()` é `[0, 3, 5, 10]`: a varredura de piso da MEDIÇÃO, que a spec #49 pediu para
+    distinguir achado de escolha de corte. Aqui a lista é outra coisa — são os pisos que aparecem
+    nos seis campos `em_pp: true` da `tests/assert_taskf_base_reproduz_01.sql`, isto é, os campos
+    que a RÉGUA governa. Nenhum campo em pp da guarda está no piso 3, então medir p3 seria medir
+    ruído de um campo que a régua não cobre.
+
+    ⚠️ As duas listas são independentes e podem derivar: se a guarda passar a cobrar um campo em
+    pp num piso novo, ELE PRECISA ENTRAR AQUI À MÃO. O acoplamento é com o `campos` da guarda, não
+    com `taskf_pisos()` — e é por isso que herdar do macro seria o erro, não a correção. -#}
+{%- set pisos_da_guarda = [0, 5, 10] -%}
 
 WITH {{ task01_base() }},
 
@@ -84,15 +107,23 @@ WITH {{ task01_base() }},
     o que se quer reproduzir aqui é o INSTRUMENTO, com o `AVG` e tudo, e não uma versão limpa
     dele. Extrair para macro compartilhado trocaria o instrumento medido por outro.
 
-    Usa `a.min_jogos` (o USADO) e não a contagem disponível da #54: na célula `base` o recorte é
-    `temporada`, sem teto, e as duas são o mesmo número por construção. -#}
+    Usa `a.min_jogos` (o USADO) e não a `min_jogos_disponivel` da #54, e a igualdade das duas na
+    célula `base` é conferível LENDO, não uma alegação sobre o dado: sob recorte `temporada` o
+    `taskf_teste2.sql` resolve `col_disponivel = 'played_total'`, e aí o `pit_disponivel` dele
+    (linhas 269-280) fica sendo a MESMA expressão do `pit` do `macros/task01_base.sql` (linhas
+    316-327) — mesma tabela, mesmos dois LEFT JOIN por time, mesmo
+    `LEAST(COALESCE(h.played_total, 0), COALESCE(a.played_total, 0))`. Não são dois números que
+    coincidem: é uma expressão escrita duas vezes.
+
+    ⚠️ Isso vale porque a célula é a `base`. Sob `ultimos_10` o `played_total` satura no teto e as
+    duas contagens divergem de verdade (é o achado da #54) — esta análise mediria outra coisa. -#}
 agregado AS (
     SELECT
         a.market_id,
         pl.premissa,
         a.benchmark,
         AVG(IF(pl.acesa, IF(a.min_jogos < 5, 1.0, 0.0), NULL))   AS frac_curta
-        {%- for piso in pisos_em_pp %},
+        {%- for piso in pisos_da_guarda %},
         COUNTIF(pl.acesa AND a.min_jogos >= {{ piso }})          AS n_{{ piso }},
         AVG(IF(pl.acesa AND a.min_jogos >= {{ piso }},
                a.prob_justa_fechamento, NULL))                   AS p_odd_{{ piso }},
@@ -129,7 +160,7 @@ SELECT
     g.premissa,
     g.benchmark,
     -- A camada de contagem. Ela se mexer é outro fenômeno, e a saída tem de saber distinguir.
-    {%- for piso in pisos_em_pp %}
+    {%- for piso in pisos_da_guarda %}
     g.n_{{ piso }}                                               AS n_p{{ piso }},
     {%- endfor %}
     -- Os seis campos em pp que a `assert_taskf_base_reproduz_01` cobra, cada um em duas versões:
@@ -142,7 +173,7 @@ SELECT
     ROUND(g.p_odd_0  * 100, 12)                                  AS a_odd_dava_p0_bruto,
     ROUND(g.p_real_0 * 100, 1)                                   AS aconteceu_p0,
     ROUND(g.p_real_0 * 100, 12)                                  AS aconteceu_p0_bruto
-    {%- for piso in pisos_em_pp %},
+    {%- for piso in pisos_da_guarda %},
     ROUND((g.p_real_{{ piso }} - g.p_odd_{{ piso }}) * 100, 1)   AS diferenca_p{{ piso }},
     ROUND((g.p_real_{{ piso }} - g.p_odd_{{ piso }}) * 100, 12)  AS diferenca_p{{ piso }}_bruto
     {%- endfor %}

--- a/dbt_futebol/macros/taskf_universos.sql
+++ b/dbt_futebol/macros/taskf_universos.sql
@@ -51,10 +51,19 @@
 
     ⚠️ E O ESTENDIDO NÃO É COMPARÁVEL COM O CONGELADO COMO SE FOSSE OUTRA CÉLULA. Ele contém os
     169 mais o que veio depois; as duas linhas do Teste 2 não são um A/B de um eixo, são dois
-    recortes encaixados. O que se compara DENTRO dele é o par com/sem Champions. A tolerância de
-    0,5 pp declarada na #51 para `linha_subindo`/`linha_descendo` volta a ter mordida aqui: no
+    recortes encaixados. O que se compara DENTRO dele é o par com/sem Champions. A tolerância
+    `taskf_tolerancia_pp` para `linha_subindo`/`linha_descendo` volta a ter mordida aqui: no
     congelado a coleta de odds já tinha parado (zero capturas após 04/08, medido), no estendido
     não.
+
+    ⚠️ MAS O VALOR DELA NÃO SERVE AQUI SEM MEDIÇÃO NOVA (#92, 19/08/2026). Ela era 0,5 pp e passou
+    a ser **0,25 pp**, e o 0,25 foi calibrado sobre o universo `completo`: nele o ruído de
+    instrumento mede 0,00 pp (8 execuções, pós-#78) e a deriva de odds é zero por falta de
+    mecanismo, então o que sobra dentro da régua é o resíduo conhecido do `linha_descendo` mais
+    meia grade do `ROUND(·, 1)`. Aqui no estendido a componente de deriva NÃO é zero e **nunca foi
+    medida** — a #78 não a tocou. Quem escrever a primeira comparação sobre o estendido mede essa
+    componente antes de reusar o número; herdá-lo às cegas é trocar um falso-verde por um
+    falso-vermelho. Ver `analyses/taskf_ruido_do_instrumento.sql`.
 
     ────────────────────────────────────────────────────────────────────────────────
     O GABARITO (`jogos_esperados`), e por que só dois dos quatro têm um.

--- a/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+++ b/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
@@ -29,13 +29,45 @@
 --                      ou tabela — insumos determinísticos sobre um universo congelado. Não há
 --                      deriva legítima para acomodar, e acomodar assim mesmo seria a régua
 --                      virando desculpa.
---   linha_subindo e    `taskf_tolerancia_pp` (0,5 pp) nos campos medidos EM PONTOS PERCENTUAIS.
+--   linha_subindo e    `taskf_tolerancia_pp` (0,25 pp) nos campos medidos EM PONTOS PERCENTUAIS.
 --   linha_descendo     São as duas únicas que comparam preço com preço: acendem quando a média
 --                      das probabilidades implícitas de todas as casas sobe de t24h para t15m, e
 --                      o fechamento é a última janela disponível no momento do build.
 --
--- O valor 0,5 pp foi declarado ANTES de medir, calibrado pelo que o repositório já sabia (o
--- mercado de Gols anda 0,2–0,4 pp entre execuções sem que nada mude — `docs/TASK01_RESULTADOS.md`).
+-- ⚠️ O VALOR É 0,25 pp DESDE 19/08/2026 (#92). ANTES ERA 0,5, E O 0,5 NUNCA FOI MEDIDO.
+--
+-- Ele foi declarado antes de medir, calibrado por uma frase de `docs/TASK01_RESULTADOS.md` — "o
+-- mercado de Gols anda 0,2–0,4 pp entre execuções sem que nada mude". Aqueles 0,2–0,4 pp são
+-- deltas de ROI do TESTE 3 (ticket #4 daquele doc), e o Teste 3 é um agregado atrás de um
+-- LIMIAR: 0,07% das linhas trocando de lado moveu o ROI do mercado em 0,4 pp. Esta régua governa
+-- os campos por premissa do TESTE 2, que são médias. Na MESMA reconciliação de 04/08 as seis
+-- linhas do Teste 2 reproduziram com delta EXATAMENTE 0,0. Ou seja: a régua foi calibrada por
+-- uma métrica diferente da que ela mede, e a métrica que ela mede nunca tinha se mexido.
+--
+-- O 0,25 é medido, e é a soma de quatro parcelas, cada uma com número (#92, 19/08, N=8 —
+-- `analyses/taskf_ruido_do_instrumento.sql` e `docs/TASKF_RESULTADOS.md`):
+--
+--   ruído de instrumento       0,00 pp. Duas camadas, as duas em 8 execuções: a reconstrução das
+--                              premissas devolve fingerprint XOR por linha IDÊNTICO (pós-#78 a
+--                              soma é NUMERIC, exata, não depende da ordem), e a agregação do
+--                              Teste 2 não move um único campo arredondado.
+--   deriva legítima de odds    0,00 pp NESTE universo. `capturas_apos_o_teto` remedido em 19/08:
+--                              zero, última captura em 03/08. Ver o ⚠️ da janela congelada acima.
+--   resíduo conhecido do       0,2 pp, medido: com `--vars '{taskf_tolerancia_pp: 0}'` a guarda
+--   `linha_descendo`           acende 6 campos e só eles, deltas 0,1/0,1/0,1/0,2/0,2/0,2.
+--   grade do ROUND(·, 1)       0,05 pp de meia-grade, para o número não ficar EM CIMA da grade —
+--                              ver o parágrafo do knife-edge logo abaixo.
+--
+-- Por que 0,25 e não 0,2: os dois lados da comparação são impressos em UMA casa, então a
+-- subtração em FLOAT64 de dois valores da grade não devolve 0,2 e sim 0,20000000000000284 — que
+-- é `> 0.2` e deixaria a guarda vermelha no próprio resíduo que a régua declara cobrir. 0,25 cai
+-- no meio da grade: admite |Δ| até 0,2 e recusa a partir de 0,3, sem depender do último bit.
+--
+-- ⚠️ E 0,25 É CALIBRADO PARA O UNIVERSO `completo`, QUE É O ÚNICO QUE ESTA GUARDA COMPARA. A
+-- segunda parcela é zero porque a coleta parou antes do teto; no universo `estendido`, que
+-- alcança o presente, ela NÃO é zero e não foi medida — a #78 não a tocou. Quem escrever a
+-- primeira comparação sobre o estendido mede essa componente ANTES de reusar este número.
+--
 -- Ele mora em `taskf_tolerancia_pp`, o MESMO var da reconciliação: a régua existe uma vez.
 --
 -- ⚠️ NOS CAMPOS FORA DA ESCALA EM PP (`n_p0`, `n_p5`, `jogos_medios`, os dois pesos) essas duas
@@ -70,6 +102,19 @@
 -- cima de um múltiplo de meia unidade da grade (51/400 = 12,75; 308/320 = 96,25; 492/48 = 10,25) e,
 -- se cair, é empate. `analyses/taskf_remedicao.sql` faz essa comparação entre duas medições e é
 -- onde o caso se confirma.
+--
+-- ⚠️ ESSE MODO DE FALHA ESTÁ MORTO DESDE A #78, E ISSO FOI MEDIDO NA #92 — descarte-o em dois
+-- segundos, não em duas horas. O parágrafo acima fica porque descreve um fenômeno que de fato
+-- aconteceu (5 campos em 7.200 viraram 0,1 entre duas medições, e é assim que ele se
+-- diagnostica); o que mudou é o tamanho do tremor que o alimenta:
+--
+--     tremor da agregação entre 8 execuções sobre insumo imóvel   ~1e-12 pp
+--     menor folga até a fronteira do ROUND(·, 1), em 360 campos    4,1e-4 pp
+--     idem, só nas duas premissas de odds que a régua cobre        3,6e-3 pp
+--
+-- São OITO ordens de grandeza de distância. O empate não é raro nesta base: ele é impossível,
+-- e continua impossível até algum campo chegar a 1e-12 da grade. Quem vir esta guarda vermelha
+-- agora está olhando para divergência de verdade — a regra de descarte se inverteu.
 --
 -- ⚠️ CORREÇÃO DE DUAS COISAS DITAS ACIMA, MEDIDAS NA #78 — leia antes de usar este parágrafo.
 --
@@ -116,9 +161,11 @@
 --
 -- Falsificada de propósito com `--vars '{taskf_tolerancia_pp: 0}'`, que tira a folga e deixa a
 -- divergência de `linha_descendo` vermelha; o comando e o resultado estão em
--- `docs/TASKF_RESULTADOS.md`, seção do ticket #55.
+-- `docs/TASKF_RESULTADOS.md`, seção do ticket #55. A #92 acrescentou a falsificação do valor
+-- NOVO — `--vars '{taskf_tolerancia_pp: 0.15}'` derruba só os três campos de delta 0,2 —, que é
+-- o que prova que 0,25 ainda morde em vez de ser folga de sobra.
 
-{% set tol = var('taskf_tolerancia_pp', 0.5) %}
+{% set tol = var('taskf_tolerancia_pp', 0.25) %}
 
 {#- As duas que leem odds ao vivo. Não é lista de exceção conveniente: é o conjunto exato das que
     comparam preço com preço, e é a MESMA lista da analyses/taskf_reconciliacao_01.sql. -#}

--- a/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+++ b/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
@@ -80,9 +80,12 @@
 --
 -- ⚠️ E A JUSTIFICATIVA DA TOLERÂNCIA NÃO SE APLICA A UMA JANELA CONGELADA — achado da #51. A
 -- coleta de odds é forward-only e para no apito: para os 169 jogos do universo congelado há ZERO
--- capturas posteriores ao teto, então o insumo dessas duas é imóvel e a folga de 0,5 pp está
--- cobrindo um mecanismo que ali não existe. Ela continua declarada porque volta a ter mordida no
--- universo estendido da spec, que alcança o presente. Quem quiser o veredito honesto sobre a
+-- capturas posteriores ao teto, então o insumo dessas duas é imóvel e a folga está cobrindo um
+-- mecanismo que ali não existe. (⚠️ A #92 tirou daqui a conclusão que estava escrita nesta linha —
+-- "ela continua declarada porque volta a ter mordida no universo estendido". A folga continua
+-- declarada, mas por OUTRO motivo, e menor: o resíduo conhecido do `linha_descendo`, medido. O
+-- universo estendido nunca foi medido e deixou de ser a justificativa; ver a decomposição das
+-- quatro parcelas acima.) Quem quiser o veredito honesto sobre a
 -- divergência de hoje lê a reconciliação, que se recusa a chamá-la de deriva e a marca
 -- `INVESTIGAR`. A guarda é deliberadamente a mais frouxa das duas leituras: ela protege o
 -- caminho da medição, não a explicação do resíduo.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -2771,3 +2771,191 @@ gravada e não reconstrói nada; a deriva de odds que a #51 documentou não o al
 
 ⚠️ **Sem `--max_rows` o `bq query` corta em 100 linhas sem avisar**, e são 60 mais o cabeçalho de
 progresso; com o anexo junto a margem é pequena. É o mesmo corte silencioso da #57.
+
+---
+
+## Ticket #92 — a régua remedida: `taskf_tolerancia_pp` de 0,5 pp para 0,25 pp
+
+`analyses/taskf_ruido_do_instrumento.sql` · medição de **19/08/2026**, N = 8 execuções por camada
+
+### Veredito
+
+**O Gols não anda mais entre execuções idênticas. Anda 0,0 pp, contra os 0,2–0,4 pp que
+calibraram a régua — e aqueles 0,2–0,4 nunca foram medidos sobre o que a régua mede.**
+
+A régua desce para **0,25 pp**. Ela deixa de ser um número declarado e passa a ser uma soma de
+quatro parcelas, cada uma com medição atrás.
+
+### A descoberta que muda a leitura do número antigo: ele foi calibrado na métrica errada
+
+O 0,5 pp saiu de uma frase de `docs/TASK01_RESULTADOS.md` — *"o mercado de Gols anda 0,2–0,4 pp
+entre execuções sem que nada mude"*. Voltando ao ticket #4 daquele doc, de onde a frase vem, os
+0,2–0,4 pp são **deltas de ROI do Teste 3**:
+
+| Bloco | Métrica | n | Esperado | Obtido | Delta |
+|---|---|---|---|---|---|
+| Teste 3 | 2+ premissas | 4.066 | −7,6 | −7,4 | **+0,2** |
+| Teste 3 por mercado | Gols | 2.182 | −7,3 | −6,9 | **+0,4** |
+
+O Teste 3 é um agregado atrás de um **limiar**: a porta "N+ premissas" faz uma linha que sai de
+`n_prem = 1` para `2` entrar inteira no universo, e o próprio doc mede que **0,07% das linhas
+virando moveu o ROI do mercado em 0,4 pp**. A `taskf_tolerancia_pp` não governa nada disso — ela
+governa os campos por premissa do **Teste 2**, que são médias, sem porta.
+
+E o mesmo ticket #4 diz o que o Teste 2 fez naquela execução: *"22 das 25 linhas de comparação com
+delta exatamente 0,0 — **incluindo as seis do Teste 2**"*. Ou seja, a métrica que a régua mede
+**já reproduzia exato em 04/08**, e nunca fez parte da calibragem. O 0,5 pp era folga emprestada de
+outro fenômeno.
+
+Isso é o argumento mais forte para remedir, e ele independe do resultado da remedição.
+
+### As quatro medições
+
+Todas em SELECT — nenhum `dbt run`, nenhuma escrita em `futebol` nem em `futebol_taskF`.
+
+#### 1. A métrica que produziu os 0,2–0,4 pp, remedida
+
+`analyses/task01_reconciliacao.sql` é o artefato que gerou aquela tabela. Rodado **8 vezes
+seguidas** com o código pós-#78, as 8 saídas são **byte-idênticas** (mesmo `md5`), incluindo a
+linha do Gols. O movimento entre execuções idênticas é **0,0 pp**.
+
+⚠️ **As linhas dessa saída dizem `DIVERGE` contra os valores publicados em 04/08 — e isso NÃO é
+instabilidade.** O Gols sai hoje em −5,5 contra os −7,3 publicados, e o `n` da porta 2+ em 4.023
+contra 4.066. Entre 04/08 e hoje o pipeline mudou de verdade: o de-vig de consenso (#22), as
+janelas de coleta na chave (#37, #40) e a própria #78. A afirmação da #92 é sobre a **variância
+entre execuções do mesmo código**, não sobre reprodução do publicado — e ela é a igualdade dos 8
+`md5`. Quem confundir as duas vai caçar um fantasma que a ADR 0010 já explicou.
+
+#### 2. Camada 1 — a reconstrução das premissas
+
+Os cinco `int_futebol_premissas_*` são `materialized: table`: uma re-medição os **reconstrói**, e
+era aí que morava o ruído da #78. O modelo do Gols compilado e rodado como SELECT, 8 vezes:
+
+| | valor nas 8 execuções |
+|---|---|
+| `linha_subindo` | 2.010 |
+| `linha_descendo` | 2.713 |
+| `ataque_combinado` / `defesas_firmes` | 11.011 / 11.526 |
+| `xg_combinado_alto` / `xg_baixo_combinado` / `ritmo_alto` | 11.516 / 10.647 / 16.895 |
+| linhas | 76.520 |
+| `BIT_XOR` do fingerprint por linha | `-2294657971955933595` |
+
+O fingerprint é o que a contagem sozinha não dá: dois flips em sentidos opostos se cancelam num
+`COUNTIF` e **não** se cancelam num XOR de `FARM_FINGERPRINT` por linha. As 8 execuções são
+idênticas linha a linha, não só no total.
+
+E aqui a estabilidade é **por construção, não por sorte de rodada**: pós-#78 as duas premissas de
+odds saem de `SAFE_DIVIDE(SUM(CAST(1.0/odd AS NUMERIC)), COUNT(...))`. Soma em ponto FIXO é exata,
+e soma exata não depende da ordem em que o BigQuery funde os shards.
+
+#### 3. Camada 2 — a agregação do Teste 2, que ninguém tinha medido
+
+A #78 corrigiu **modelos**; a guarda `assert_premissas_sem_agregado_instavel` cobre modelo, não
+análise. O `AVG(IF(pl.acesa, ...))` sobre FLOAT64 — exatamente o agregado instável que a #78 tirou
+da produção — continua sendo o instrumento com que a [F] se mede. 8 execuções sobre insumo imóvel
+(`odds_loaded_at` idêntico nas 8, conferido na própria saída):
+
+- **nenhum** dos campos arredondados mudou, em nenhuma das 60 linhas;
+- **4 de 360** campos brutos tremeram, todos na 12ª casa decimal:
+
+| linha | campo | amplitude nas 8 |
+|---|---|---|
+| Gols · `ritmo_alto` · sharp | `diferenca_p0` | 1,0e-12 pp |
+| Gols · `xg_baixo_combinado` · consenso | `aconteceu_p0` | 9,9e-13 pp |
+| Handicap · `defesa_fora_solida` · sharp | `diferenca_p0` | 1,0e-12 pp |
+| Dupla Chance · `invicto_recente` · derivada | `diferenca_p10` | 1,0e-12 pp |
+
+**Ver o bruto ao lado do arredondado é o ponto da análise.** Só com o arredondado, "8 execuções
+idênticas" seria ambíguo entre *não há tremor* e *não houve empate nesta rodada* — e essas duas
+pedem decisões diferentes.
+
+#### 4. O empate de arredondamento está morto, e dá para dizer por quanto
+
+O modo de falha que o cabeçalho da guarda manda descartar antes de procurar bug — um valor em cima
+da grade do `ROUND(·, 1)` caindo para lados diferentes — precisa que o tremor alcance a fronteira.
+Distância medida nos 360 campos:
+
+| | |
+|---|---|
+| tremor da agregação (item 3) | ~1e-12 pp |
+| menor folga até a fronteira, 360 campos | **4,1e-4 pp** (`defesas_firmes`, `pct_amostra_curta` = 40,650406…) |
+| menor folga, só nas duas premissas de odds | **3,6e-3 pp** (`linha_descendo`, `pct_amostra_curta`) |
+
+**Oito ordens de grandeza.** O empate não ficou raro: ficou impossível nesta base. A regra de
+descarte do cabeçalho se inverteu — guarda vermelha agora é divergência de verdade.
+
+#### 5. A componente que a #78 não tocou, remedida hoje
+
+A deriva **legítima** de odds. Na janela congelada ela não tem mecanismo, e o número foi
+reconferido em 19/08:
+
+```
+capturas_apos_o_teto = 0    (última captura do universo: 2026-08-03 00:00:01)
+```
+
+### A régua nova, parcela a parcela
+
+| parcela | o que cobre | medido |
+|---|---|---|
+| ruído de instrumento | camadas 1 e 2, 8 execuções cada | **0,00 pp** |
+| deriva legítima de odds | capturas após o teto, universo `completo` | **0,00 pp** |
+| resíduo conhecido do `linha_descendo` | as 2 linhas de aposta de 405 que o medido perdeu | **0,2 pp** |
+| meia grade do `ROUND(·, 1)` | tirar o número de cima da grade — ver abaixo | **0,05 pp** |
+| | | **0,25 pp** |
+
+**Por que 0,25 e não 0,2, medido e não deduzido.** Os dois lados da comparação são impressos em uma
+casa decimal, então a subtração em FLOAT64 de dois valores da grade não devolve 0,2 — devolve
+0,20000000000000284, que é `> 0.2`. Com `--vars '{taskf_tolerancia_pp: 0.2}'` a guarda fica
+**vermelha nos três campos de delta 0,2**, isto é, no próprio resíduo que a régua declara cobrir.
+0,25 cai no meio da grade: admite |Δ| até 0,2 e recusa a partir de 0,3, sem depender do último bit.
+
+⚠️ **O que a #92 deliberadamente NÃO faz: apertar até o zero.** O ruído mede 0,00 pp, mas zerar a
+régua deixaria a guarda vermelha no resíduo do `linha_descendo` — que está documentado,
+delimitado e não é defeito do caminho de medição que a guarda protege. Trocar um falso-verde por
+um falso-vermelho é o que o próprio ticket #92 avisou para não fazer.
+
+⚠️ **E 0,25 vale para o universo `completo`, o único que os dois consumidores da var comparam**
+(`tests/assert_taskf_base_reproduz_01.sql` e `analyses/taskf_reconciliacao_01.sql`, ambos em
+`universo = 'completo'`). No `estendido`, que alcança o presente, a segunda parcela deixa de ser
+zero e **não foi medida** — a #78 não a tocou. Quem escrever a primeira comparação sobre o
+estendido mede essa componente antes de reusar este número.
+
+### Verificação, nas duas direções
+
+```bash
+# verde com o valor novo — 0 linhas
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt test --target taskF --select assert_taskf_base_reproduz_01
+#   1 of 1 PASS assert_taskf_base_reproduz_01
+
+# falsificação do valor NOVO: 0,15 derruba só os três campos de delta 0,2
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select assert_taskf_base_reproduz_01 \
+  --vars '{taskf_tolerancia_pp: 0.15}'
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+#   3 linhas: linha_descendo · pct_amostra_curta, diferenca_p5, diferenca_p10 (delta 0,2)
+
+# o knife-edge, medido: 0,2 EM CIMA da grade também derruba os mesmos três
+#   --vars '{taskf_tolerancia_pp: 0.2}'  ->  3 linhas
+```
+
+### Como remedir
+
+```bash
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskf_ruido_do_instrumento
+for i in $(seq 1 8); do
+  bq query --use_legacy_sql=false --project_id=smartbetting-dados --format=csv --max_rows=500 \
+    < target/compiled/dbt_futebol/analyses/taskf_ruido_do_instrumento.sql > /tmp/r$i.csv
+done
+for i in $(seq 2 8); do diff -q /tmp/r1.csv /tmp/r$i.csv; done
+```
+
+⚠️ Confira o `odds_loaded_at` da saída antes de ler a diferença: se um rebuild agendado cair no
+meio das 8, elas deixam de ser 8 execuções idênticas e a diferença vira insumo novo lido como
+tremor do instrumento. A coluna está lá para essa conferência.
+
+### O que a #92 não toca
+
+O rebaseline dos quatro números da [F] que a #78 avisou que ficariam vermelhos na próxima
+reconstrução das células (`superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado`,
+`ritmo_alto`). Isso é a #82 reescopada, sequenciada pela ADR 0010, e exige `dbt run --target
+taskF`. A #92 termina na régua.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -165,6 +165,12 @@ preço depois do teto. A conclusão não muda; a explicação, sim.
 
 ### A tolerância, declarada
 
+⚠️ **REGISTRO CONGELADO DA #51 — o valor mudou. A tolerância vale 0,25 pp desde 19/08/2026 (#92),
+e a justificativa abaixo é a de então, não a de hoje.** Esta seção fica como está porque é o que se
+sabia ao declarar o número; a remedição, a decomposição em quatro parcelas e o motivo de o 0,5
+nunca ter sido medido sobre a métrica que ele governa estão na seção do ticket #92, no fim deste
+documento. O mesmo vale para as outras menções a "0,5 pp" nas seções da #51 e da #58.
+
 > **Tolerância: 0,5 pp de diferença absoluta, em qualquer piso, e SÓ para `linha_subindo` e
 > `linha_descendo`.**
 
@@ -2884,6 +2890,26 @@ Distância medida nos 360 campos:
 **Oito ordens de grandeza.** O empate não ficou raro: ficou impossível nesta base. A regra de
 descarte do cabeçalho se inverteu — guarda vermelha agora é divergência de verdade.
 
+#### 4b. Um rebuild caiu no meio da sessão, e isso virou corroboração de graça
+
+As 8 execuções do item 3 leram `odds_loaded_at = 2026-08-19 12:11:15`. Uma nona, rodada depois do
+fixup do code review, saiu com **`18:01:15`**: o agendado reconstruiu o `fact_odds_snapshot` a
+partir da landing zone nesse intervalo. (Os dois carimbos são a única grandeza medida aqui — o
+intervalo entre as execuções em si não foi cronometrado e não entra na conta.) **A coluna de carimbo pegou isso sozinha** — que é exatamente para o que ela
+está na saída, e a razão de a receita mandar conferi-la antes de ler qualquer diferença.
+
+Ela **não** entra no N=8: são builds diferentes, e a medição de ruído de instrumento é sobre
+execuções do mesmo insumo. Mas o que ela mostra vale registrar, porque é uma verificação
+independente do item 5 abaixo:
+
+> Entre os dois builds do `fact_odds_snapshot`, as 60 linhas do universo congelado saem
+> **idênticas** — todos os `n_p0`/`n_p5`/`n_p10` e todos os campos arredondados. As únicas
+> diferenças são os mesmos ~1e-12 pp em 3 dos 4 campos brutos do item 3.
+
+Reconstruir os fatos e não mover um campo é a afirmação "a coleta é forward-only e parou no apito"
+medida por outro caminho: se houvesse captura nova alcançando aqueles 169 jogos, ela teria entrado
+neste rebuild.
+
 #### 5. A componente que a #78 não tocou, remedida hoje
 
 A deriva **legítima** de odds. Na janela congelada ela não tem mecanismo, e o número foi
@@ -2908,6 +2934,13 @@ casa decimal, então a subtração em FLOAT64 de dois valores da grade não devo
 0,20000000000000284, que é `> 0.2`. Com `--vars '{taskf_tolerancia_pp: 0.2}'` a guarda fica
 **vermelha nos três campos de delta 0,2**, isto é, no próprio resíduo que a régua declara cobrir.
 0,25 cai no meio da grade: admite |Δ| até 0,2 e recusa a partir de 0,3, sem depender do último bit.
+
+⚠️ **Para a `analyses/taskf_reconciliacao_01.sql` o aperto é NO-OP hoje, e isso precisa estar
+dito.** Lá o `tol` só se aplica à origem `deriva_de_odds`, e nesta janela nenhuma linha se
+classifica assim — o mecanismo não existe, e o `linha_descendo` cai em `INVESTIGAR`. O valor novo
+só muda comportamento na guarda. Mudar os dois assim mesmo é o que mantém a régua existindo uma
+vez; deixar a reconciliação em 0,5 criaria duas réguas com o mesmo nome, e a segunda ficaria errada
+em silêncio no dia em que a origem 1 deixar de ser vazia.
 
 ⚠️ **O que a #92 deliberadamente NÃO faz: apertar até o zero.** O ruído mede 0,00 pp, mas zerar a
 régua deixaria a guarda vermelha no resíduo do `linha_descendo` — que está documentado,


### PR DESCRIPTION
`taskf_tolerancia_pp` valia **0,5 pp** por uma frase de `docs/TASK01_RESULTADOS.md` — *"o mercado
de Gols anda 0,2–0,4 pp entre execuções sem que nada mude"*. Passa a valer **0,25 pp**, e o número
deixa de ser declarado para ser uma soma de parcelas medidas.

## A descoberta que muda a leitura do número velho

Voltando ao ticket #4 de onde a frase vem, os **0,2–0,4 pp são deltas de ROI do Teste 3** — um
agregado atrás de um **limiar** (o próprio doc mede que 0,07% das linhas trocando de lado moveu o
ROI do mercado em 0,4 pp). Esta régua governa os campos por premissa do **Teste 2**, que são
médias, sem porta.

E o mesmo ticket registra o que o Teste 2 fez naquela execução: *"22 das 25 linhas de comparação
com delta exatamente 0,0 — **incluindo as seis do Teste 2**"*.

**A régua foi calibrada por uma métrica diferente da que ela mede, e a métrica que ela mede nunca
tinha se mexido.** Isso justifica remedir independentemente do resultado.

## O que foi medido (19/08, N=8 por camada, tudo em SELECT)

Sem `dbt run`, sem escrita em `futebol` nem em `futebol_taskF`.

| medição | resultado |
|---|---|
| **Teste 3 ROI do Gols** — a métrica que produziu os 0,2–0,4 pp, remedida | 8 execuções do `task01_reconciliacao`, saídas **byte-idênticas** (md5). Anda **0,0 pp** |
| **Camada 1** — reconstrução das premissas (são `materialized: table`) | `BIT_XOR` do fingerprint **por linha** idêntico nas 8. Pós-#78 a soma é NUMERIC, exata: determinístico **por construção** |
| **Camada 2** — a agregação do Teste 2, que ninguém tinha medido | 0 campos arredondados mudaram; 4 de 360 brutos tremeram **~1e-12 pp** |
| **Folga até a fronteira do `ROUND(·,1)`** | mínima **4,1e-4 pp** em 360 campos (3,6e-3 pp nas duas premissas de odds) |
| **Deriva legítima de odds** na janela congelada | `capturas_apos_o_teto` = **0**, reconferido hoje |
| **Resíduo conhecido do `linha_descendo`** | **0,2 pp** — guarda com `tol: 0` acende 6 campos e só eles |

A camada 2 não estava coberta: a `assert_premissas_sem_agregado_instavel` cobra **modelo**, não
análise, então o `AVG` sobre FLOAT64 que a #78 tirou da produção segue sendo o instrumento com que
a [F] se mede.

## A régua nova

| parcela | medido |
|---|---|
| ruído de instrumento (camadas 1 e 2) | **0,00 pp** |
| deriva legítima de odds (universo `completo`) | **0,00 pp** |
| resíduo conhecido do `linha_descendo` | **0,2 pp** |
| meia grade do `ROUND(·, 1)` | **0,05 pp** |
| | **0,25 pp** |

**Por que não 0,2 — medido, não deduzido.** Os dois lados são impressos em uma casa decimal, e a
subtração em FLOAT64 devolve `0,20000000000000284 > 0,2`. Com `--vars '{taskf_tolerancia_pp: 0.2}'`
a guarda fica **vermelha nos três campos de delta 0,2**, isto é, no próprio resíduo que a régua
declara cobrir. 0,25 cai no meio da grade.

**Por que não 0.** Zerar deixaria a guarda vermelha num resíduo documentado e delimitado, que não é
defeito do caminho de medição que a guarda protege — o falso-vermelho que o ticket avisou para não
trocar pelo falso-verde.

## O empate de arredondamento acabou

O modo de falha que o cabeçalho da guarda manda descartar **antes** de procurar bug precisa que o
tremor alcance a fronteira da grade. Tremor ~1e-12 pp contra folga mínima 4,1e-4 pp: **oito ordens
de grandeza**. Não ficou raro — ficou impossível nesta base. O parágrafo fica no cabeçalho, com a
correção datada em cima: **a regra de descarte se inverteu**, e guarda vermelha agora é divergência
de verdade.

## Verificação, nas duas direções

```
dbt test --target taskF --select assert_taskf_base_reproduz_01   ->  PASS
--vars '{taskf_tolerancia_pp: 0.15}'  ->  exatamente os 3 campos de delta 0,2
--vars '{taskf_tolerancia_pp: 0.2}'   ->  os mesmos 3 (o knife-edge, medido)
dbt test  ->  298 PASS, 11 WARN (pré-existentes), 0 ERROR
```

## Code review (2 eixos, sub-agentes paralelos) — 2º commit

Zero violação dura. Entraram: a explicação do `--target` ausente (deliberado: `futebol_taskF` tem
as premissas da última célula, sob código **pré-#78**); `pisos_em_pp` -> `pisos_da_guarda` (são
pisos de `min_jogos`, não pontos percentuais); o porquê de `[0,5,10]` não herdar de
`taskf_pisos()` (o acoplamento é com o `campos` da guarda); e a equivalência
`min_jogos` == `min_jogos_disponivel`, que estava **alegada** e agora está citada com arquivo e
linha — sob `temporada` as duas são a mesma expressão escrita duas vezes.

Achei também **quatro cabeçalhos vivos ainda dizendo 0,5 pp**, um deles (`macros/taskf_universos.sql`)
fora do diff, onde nenhum revisor ia olhar. Em dois, o texto trazia a *justificativa* velha
("continua declarada porque volta a ter mordida no universo estendido") — que esta issue derruba.
As seções congeladas do `TASKF_RESULTADOS.md` ficam como estão, com ponteiro para a seção #92.

## ⚠️ O 0,25 vale para o universo `completo`

É o único que os dois consumidores da var comparam. No `estendido`, que alcança o presente, a
componente de deriva de odds **não é zero e nunca foi medida** — a #78 não a tocou. Quem escrever a
primeira comparação sobre o estendido mede essa componente antes de reusar o número. Está escrito
nos cabeçalhos da guarda, da reconciliação e do `macros/taskf_universos.sql`.

## Deploy

**Não precisa de `./build-and-push.sh dbt_futebol`.** Nada aqui alcança o comportamento da imagem
agendada: analyses nunca rodam no agendado, a guarda é `costura_b` e não `tag:guarda`, e a mudança
em `macros/taskf_universos.sql` é só comentário (só analyses e testes o leem). Se o
`deriva-imagem.yml` acusar deriva de path depois do merge, é cosmético — e o `./scripts/checa_deriva.sh`
tem de rodar **do checkout principal**, não de worktree, senão ele mente.

## Fora daqui

O rebaseline dos quatro números que a #78 avisou que ficariam vermelhos na próxima reconstrução das
células (`superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado`, `ritmo_alto`) é a **#82**
reescopada, sequenciada pela ADR 0010, e exige `dbt run --target taskF`. A #92 termina na régua.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
