### PR TITLE
docs(futebol): a grelha da A7 — o funil é append-only e congela no apito (ADR 0011)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -45,7 +45,19 @@ _Avoid_: feature, predictor
 
 **Gate**:
 The eliminatory precondition (positive edge and enough bookmakers). Failing the gate
-means the bet is not an opportunity at all. Dupla Chance has its own gate.
+means the bet is not an opportunity at all. Dupla Chance has its own gate. The gate is
+the **conjunction of the portas** — it says whether a line publishes, never which
+condition stopped it.
+_Avoid_: using gate where the individual condition is meant (that is a **porta**)
+
+**Porta**:
+One named eliminatory condition, recorded as one boolean per candidato. Portas are
+counted one at a time on purpose: a line can fail several at once, so a single "reason"
+column is a win for whichever is checked first and destroys the only two readings the
+funil exists for — how many lines a porta removes **alone**, and how many it still
+removes **after** the ones before it. A primary reason derived on top of the booleans is
+a reading convenience, never the source.
+_Avoid_: motivo de rejeição as a single column
 
 **Faixa**:
 The confidence band over the score: Alta (>= 60), Média (40–59), Baixa (< 40).
@@ -67,8 +79,37 @@ universe the gates act on, and the denominator of every funnel reading. A line n
 priced is not a rejected candidato, it is absence of market: that belongs to coleta, not
 to the funil. A candidato whose conjunto de saídas came in incomplete still counts —
 it exists, it just lost its fair probability.
+The universe is bounded by the markets the Motor scores. A priced line in a market with
+no premissa model at all (first-half goals) is **outside** the funil, not rejected by it
+— we never wrote that model, so its absence is not our decision. A priced **saída** the
+Motor declines to score inside a market it does model is the opposite case, and stays in
+(see **saída não catalogada**).
 _Avoid_: counting every premissa row (they are generated for canonical lines with no
 market at all, and are unbounded)
+
+**Funil**:
+Every candidato with the verdict of each porta on it, the score it got, and nothing
+filtered away. It is a **record of what the Motor said**, not a re-derivation of what
+today's code would say: a row is written once, refined while the fixture is still ahead,
+and frozen at kickoff. It keeps the played fixture — that is the only thing that can
+answer what the discarded faixa would have returned — and it lives in BigQuery only; the
+app never reads it.
+_Avoid_: reading the funil as a board with more rows, or expecting a rebuilt table to
+preserve a funil at all
+
+**Saída não catalogada**:
+An outcome that was priced, inside a market the Motor does model, that the Motor chooses
+not to score — Dupla Chance prices 1X, 12 and X2, and only 1X and X2 are published. It
+had a price, so it is a candidato, and the choice is ours: it is a rejection with its own
+porta, never a silent absence.
+
+**Congelamento no apito**:
+The moment a funil row stops being rewritten: kickoff. After it, no build and no deploy
+touches the row. The boundary is the whistle and not the final status, because the two
+hours of play are exactly where a score nobody could have read before betting would be
+written. A postponed fixture whose kickoff moves back into the future becomes writable
+again — it went back to being bettable.
+_Avoid_: confusing it with expurgo (that is the board's boundary, and it runs on status)
 
 **Board**:
 The window of what is **still bettable**: the value opportunities of fixtures that have

--- a/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
+++ b/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
@@ -1,0 +1,142 @@
+---
+status: proposed
+---
+
+# O funil é append-only e congela no apito
+
+A ADR 0006 decidiu **o que** gravar — toda linha candidata, com a nota e o veredito de cada
+porta — e deixou aberto **como**. As duas leituras de "gravar o funil" não são variações de
+implementação, são tabelas diferentes:
+
+- **tabela reconstruída**: o que o código de hoje diria sobre as odds que ainda estão em disco;
+- **registro append-only**: o que o motor de fato disse, no dia em que disse.
+
+O custo não decide. Medido em 19/08/2026, o universo inteiro de candidatos — cinco mercados
+pontuados, quatro janelas, de 16/06 (primeira odd coletada) até hoje — são **91.385 linhas** em
+**384 fixtures**, e o `int_futebol_odds_devig` de onde elas saem ocupa **18,4 MB**. Cerca de
+**45 mil linhas por mês**. Qualquer das duas cabe em qualquer orçamento que este projeto tenha.
+
+Quem decide é o motivo pelo qual a A7 entra **antes** das outras subtasks da [A]: *"senão
+perde-se o funil antigo"*. Uma tabela reconstruída não preserva funil nenhum. No dia em que a
+A1 tirar o preço da nota, o rebuild seguinte reescreve 16/06 em diante sob as regras novas, e o
+funil antigo — a coisa inteira que a A7 existe para salvar — deixa de existir sem deixar rastro.
+
+Decidimos que o funil é **append-only**: cada `(candidato, janela)` é escrito uma vez, atualizado
+enquanto o jogo ainda não começou, e **congelado no apito**. Depois disso a linha não é
+reescrita por build nenhum, nem por deploy nenhum.
+
+## Por que o congelamento é no apito, e não no status final
+
+A alternativa era congelar quando o jogo termina (`FT`/`AET`/`PEN`/…), aproveitando a mesma
+fronteira que a ADR 0009 usa no expurgo do board. Ela abre exatamente a fresta que a 0009
+existe para fechar: entre o apito inicial e o final há duas horas em que os modelos de premissa
+continuam rodando, e tudo que fosse escrito ali seria **nota nascida depois de a bola rolar**.
+O funil serve para responder quanto rendeu a faixa descartada — uma nota que ninguém podia ter
+lido antes de apostar não responde essa pergunta, contamina ela.
+
+Status terminal continua governando outra coisa, e só ela: **até quando a fonte emite** aquele
+fixture. É parâmetro de coleta e vai mudar com a [C]; o congelamento não depende dele.
+
+⚠️ **Jogo adiado reabre.** `PST`/`SUSP` mantêm o jogo por acontecer e o kickoff muda de lugar.
+Com o congelamento amarrado ao kickoff de registro, as linhas daquele fixture voltam a ser
+graváveis quando a nova data entra — e é o comportamento certo: o jogo voltou a ser apostável,
+as janelas são recoletadas, e o que estava escrito descrevia uma partida que não aconteceu.
+
+## A fronteira do universo tem duas bordas, não uma
+
+A ADR 0006 fixou a borda de fora: candidato é linha que **teve preço**. Faltavam as duas de
+dentro, e elas se separam:
+
+**Mercado não modelado fica fora.** O de-vig emite Gols do 1º tempo (mercado 6) — **22.363
+linhas** hoje — e não existe modelo de premissa para ele. Gravar isso como "rejeitado" seria
+registrar como decisão nossa a ausência de um modelo que nunca escrevemos. O universo do funil
+são os **cinco mercados pontuados** (1, 4, 5, 8, 12), e é contra eles que a guarda reconcilia.
+
+**Saída não catalogada fica dentro.** Dentro de um mercado que o Motor pontua pode haver uma
+saída precificada que ele não avalia: a Dupla Chance tem três saídas cotadas (1X, 12, X2) e o
+mart só publica 1X e X2. São **1.059 linhas**, um terço exato do universo de DC, hoje
+invisíveis — o `INNER JOIN` com as premissas as descarta antes de qualquer porta. Elas tiveram
+preço, então são candidatas, e a decisão de não pontuá-las é nossa: viram uma **porta própria**
+(`porta_saida_catalogada`), não um sumiço.
+
+Medido: nas outras quatro combinações a cobertura é exata — 3.177/3.177 no 1X2, 40.393/40.393
+no Handicap, 42.520/42.520 no Gols, 2.118/2.118 no Ambos Marcam. A DC é o único vazamento, e é
+estrutural.
+
+## O filtro de completude tem que virar coluna
+
+Isto não é preferência de estilo, é condição de existência da tabela. Hoje cada ramo do mart
+carrega `WHERE d.pin_n_outcomes >= N` **dentro do join**, antes de qualquer nota. A maior
+rejeição do funil — conjunto incompleto, que a ADR 0006 dimensionou em 49% do universo — nunca
+chegaria ao funil se essa estrutura fosse mantida. A tabela nasceria respondendo uma pergunta
+diferente da que foi encomendada, e o número que ela publicasse pareceria certo.
+
+O mesmo vale, em grau menor, para o gate de odd próprio da Dupla Chance (`best_odd >= 1.25`),
+que também mora no `WHERE` do ramo.
+
+## O expurgo não é porta do funil
+
+Tentador, e errado. Uma coluna `porta_expurgo` gravada sob esta ADR seria **FALSE para sempre**:
+no instante do congelamento nenhum fixture está encerrado, por construção. Coluna morta no dia
+do deploy.
+
+O expurgo continua onde a ADR 0009 o colocou — no board, sobre o status vindo de
+`fact_fixtures`. E daí sai a consequência que precisa estar escrita antes de alguém tentar o
+atalho: quando o board passar a ler o funil, **`WHERE janela_e_corrente AND passou_no_gate` não
+basta**. O funil guarda o jogo encerrado de propósito; um board que só filtrasse essas duas
+colunas voltaria a emitir jogo velho para sempre — reintroduzindo, pela porta dos fundos, o
+defeito de 121 linhas com 2 jogos futuros. A junção com o status vai junto no flip.
+
+## A entrega é em dois passos, e o segundo espera a #85
+
+1. **O funil, com o board intacto.** Modelo novo, backfill de 16/06 em diante, guarda de
+   reconciliação, e uma guarda de paridade que exige `board == funil filtrado`. Nada em
+   produção muda de comportamento; o que a paridade compra é a prova de que o funil descreve o
+   board de verdade, antes de qualquer um depender disso.
+2. **O flip**: o board passa a ler o funil, a lógica sai duplicada e a guarda de paridade vira
+   tautologia e é aposentada no mesmo commit.
+
+O passo 2 vai **depois** do passo do mart da #85 (expurgo). Os dois reescrevem o mesmo arquivo e
+os dois mudam o conjunto que o sync leva para o Postgres; empilhá-los na mesma janela é trocar
+duas mudanças de comportamento por um único diagnóstico.
+
+O funil **não vai para o Supabase** (ADR 0006), então nenhum dos dois passos toca migração,
+`check_schema_parity` ou RPC. É não-objetivo declarado, não omissão.
+
+## A guarda lê a fonte
+
+A reconciliação é *candidatos no de-vig (cinco mercados) = linhas no funil*, contada **contra o
+de-vig**, nunca contra o próprio funil. Uma guarda que soma as rejeições do funil e compara com
+o total do funil fecha sempre — é a mesma armadilha que a costura B da task [F] já pagou uma
+vez: guarda que lê o próprio produto não é guarda, é uma segunda cópia da exclusão.
+
+⚠️ Ela herda o ponto cego conhecido: teste em dbt só alarma pela seleção `tag:guarda`, e mesmo
+lá o job devolve sucesso até a C4 fechar (ADR 0005).
+
+## Retenção, agora com número
+
+A ADR 0006 deixou a política sem número de propósito, esperando medir. O número existe: **~45
+mil linhas/mês**. Dez anos de operação, com o dobro de ligas, não chegam a 10 milhões de linhas
+nem a 5 GB. **Não há expurgo do funil**, e a política se revisita se a tabela passar de 10
+milhões de linhas — que é uma forma de dizer que ela não se revisita.
+
+## Os carimbos, e o que eles tornam legível
+
+Cada linha carrega `gravado_em` e `origem` (`backfill` | `corrente`). O backfill recalcula
+16/06 em diante sob o código de hoje: é a única parte do funil que **não** é registro do que
+foi dito na época, e tem que dizer isso de si mesma. Com o carimbo, o dia da virada da A1 fica
+legível na série sem ninguém precisar lembrar a data.
+
+## O que esta decisão NÃO compra
+
+**Não conserta a irreprodutibilidade das premissas.** A issue #78 mostrou premissa que acende
+em número diferente de linhas a cada build com o insumo congelado. O congelamento no apito
+guarda o valor que existia no apito e para de reescrevê-lo — o que torna a oscilação **inócua
+para o histórico** e, ao mesmo tempo, **invisível nele**. Quem for medir reprodutibilidade
+continua medindo antes do apito, não aqui.
+
+**Não muda a nota de ninguém.** O funil de hoje é o mart de hoje com os `WHERE` virados coluna.
+Se a primeira linha de base tirada dele não bater com a cópia à mão, o errado é o funil.
+
+⚠️ E uma correção de fato na ADR 0006, que a citava de memória: são **quatro** janelas por
+candidato, não três — a `daily` entrou em 07/08/2026 e o de-vig já emite nas quatro.

--- a/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
+++ b/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # O funil é append-only e congela no apito


### PR DESCRIPTION
Sessão de `/grill-with-docs` sobre a **A7** (guardar o funil completo, não só o que passa), mais a spec que saiu dela. Só documentação — nenhum modelo dbt muda aqui.

## O que entra

- `dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md`, `accepted` — fecha o "como" que a ADR 0006 (*as portas classificam, não apagam*) deixou aberto.
- A spec publicada na #94, desmembrada em #95 (A7-1, o funil nasce), #96 (A7-2, append-only e congelamento) e #97 (A7-3, o flip do board).

## As decisões que sustentam a ADR

- **Append-only, não tabela reconstruída.** O motivo declarado da A7 — entrar antes de as portas mudarem, para não perder o funil antigo — é inalcançável com rebuild: o deploy da A1 reescreveria 16/06 em diante sob as regras novas. Custo não decide nada aqui (91.385 candidatos hoje, ~45k linhas/mês, 18,4 MB no de-vig).
- **Congelamento no apito, não no status final.** As duas horas de bola rolando são exatamente onde nasceria a nota que ninguém podia ler antes de apostar — o defeito da ADR 0009. Jogo adiado reabre.
- **A fronteira do universo tem duas bordas.** Mercado não modelado (Gols do 1º tempo, 22.363 linhas) fica **fora**; saída precificada não catalogada fica **dentro**, com porta própria — a "12" da Dupla Chance, 1.059 linhas, um terço exato do universo de DC, hoje invisível.
- **O `WHERE` de completude vira coluna**, senão a maior rejeição do funil (49% do universo) nunca chega nele.
- **Expurgo não é porta do funil** (seria `FALSE` para sempre) — e por isso o flip do board carrega a junção com o status, senão o board volta a emitir jogo velho.
- **A guarda reconcilia contra o de-vig** (a fonte), nunca contra o próprio funil.

## ⚠️ Um ponto que precisa do teu aval, @diodtoyofuku-svg

A **D13** da spec está marcada *"não passou pelo Victor"*: ela ancora o A7-3 (o flip) apenas **depois do passo do mart da #85**.

Proponho apertar: **o flip vai depois da medição da #86**, não só depois da #85. O A7-3 reescreve o mesmo mart durante a exata janela de 7 dias que a #86 precisa limpa, e a própria spec avisa que filtragem ingênua reintroduz jogo encerrado — que é literalmente o defeito que a #86 existe para medir. Se aparecer resíduo no D+7, não dá para atribuir (foi o expurgo ou o flip?), e a #86 manda o resíduo para a #78 **com número**.

O A7-3 não tem relógio e nada depende dele, então segurar custa zero. Se concordar, eu emendo a D13 na ADR.

## Ordem depois deste merge

#85 (expurgo, hoje) → #88/#38 no mesmo deploy → #95 e #96 durante a espera → #86 (~D+7) → **#97** → #91 (+#71) → #82 → remedição a partir de 30/09.

Refs #94 — a spec-mãe fica aberta enquanto #95, #96 e #97 executam.
