### PR TITLE
feat(futebol): o board para de emitir jogo encerrado, com as duas guardas (#85)

### DIFF
--- a/dbt_futebol/dbt_project.yml
+++ b/dbt_futebol/dbt_project.yml
@@ -18,6 +18,20 @@ clean-targets:
   - "dbt_packages"
 
 
+# A carência do expurgo do board (#85, ADR 0009): quantas horas depois do kickoff uma linha
+# sem status final ainda pode ficar no `fact_value_opportunities`. É a rede de segurança para
+# o jogo que passou do apito e nunca recebeu status — falha de COLETA DE PLACAR, não de
+# modelagem —, e por isso ela é parâmetro: a qualidade dessa coleta é a task [C] e vai mudar.
+#
+# ⚠️ Nenhum workflow passa esta var (nem o `workflow_futebol.yml` nem o
+# `workflow_futebol_odds.yml`). Mudar a carência é mudar este arquivo e redeployar a imagem,
+# de propósito: a fronteira do board não é knob de execução.
+#
+# A carência NÃO se aplica a PST/SUSP/INT — ver `macros/futebol_expurgo.sql`.
+vars:
+  expurgo_carencia_horas: 24
+
+
 models:
   dbt_futebol:
     staging:

--- a/dbt_futebol/docs/contrato-serving-rpcs.md
+++ b/dbt_futebol/docs/contrato-serving-rpcs.md
@@ -26,13 +26,20 @@ aplicação não os consulta" (falso, ver abaixo) e a **C5** não a mencionou.
 
 ## A matriz
 
-20 das 22 tabelas da allowlist são lidas por alguma RPC. **`dim_leagues` e
-`fact_value_opportunities_hist` não são lidas por nenhuma** — mudança de grão nelas não alcança o
-app (o `hist` é consumido só por análise).
+21 das 22 tabelas da allowlist são lidas por alguma RPC. **Só `dim_leagues` não é lida por
+nenhuma** — mudança de grão nela não alcança o app.
 
-⚠️ **A segunda metade dessa frase morre com a ADR 0009.** Quando o board passar a expurgar jogo
-encerrado, o passado do app passa a ser servido pelo `hist`, em leitura point-in-time no apito —
-e ele deixa de ser tabela de análise para virar fonte de duas telas.
+✅ **A frase que estava aqui morreu, como previsto** (ADR 0009). Até 19/08/2026 este parágrafo
+dizia que o `fact_value_opportunities_hist` também não era lido por RPC nenhuma e era "consumido
+só por análise", com um aviso de que a segunda metade da frase morreria com o expurgo. Morreu: o
+release #271 pôs no PRD as migrations 092–105, e **o `hist` virou fonte de duas telas** —
+`get_futebol_value_history` (aba Histórico) e `get_futebol_fixture_value` (que cai no snapshot
+quando o kickoff já passou). O passado do app é servido em leitura point-in-time no apito.
+
+**O grão do `hist` é contrato de serving a partir daqui.** Ele deixou de ser tabela de análise, e
+a consequência é a regra desta página inteira: mudar o grão dele — ou o `check_cols` do snapshot,
+que é o que decide quando nasce versão nova — muda o que duas telas mostram. Não é mais mudança
+interna.
 
 | Tabela sincronizada | RPCs que leem | Suposição de grão | Estado |
 |---|---|---|---|
@@ -45,7 +52,7 @@ e ele deixa de ser tabela de análise para virar fonte de duas telas.
 | `fact_injuries_snapshot` | 1 | `distinct on (player_id)` + `order by snapshot_date desc` | ✅ desempate correto e semântico |
 | 5 × `int_futebol_premissas_*` | 2 cada | join por (fixture, outcome[, line]) | ✅ hoje; ⚠️ #41 pode adicionar coluna |
 | `fact_h2h`, `fact_predictions_api`, `fact_standings_snapshot`, `fact_team_season_stats`, `fact_fixture_stats`, `fact_fixture_events`, `fact_fixture_player_stats` | 1–2 cada | leitura direta, sem suposição de unicidade além da chave natural | ✅ |
-| `fact_value_opportunities_hist` | **nenhuma hoje**; passa a ter 1 (`get_futebol_value_history`) | leitura **point-in-time no apito**: 1 linha por `opportunity_key`, a versão viva quando o jogo começou | ⚠️ o grão dele vira **contrato de serving** com o expurgo do board (ADR 0009) |
+| `fact_value_opportunities_hist` | **2** (`get_futebol_value_history`, `get_futebol_fixture_value`) | leitura **point-in-time no apito**: 1 linha por `opportunity_key`, a versão viva quando o jogo começou | ⚠️ **tabela de serving** desde o release #271 (ADR 0009). O grão É contrato: mexer nele, ou no `check_cols` do snapshot, muda o que a aba Histórico e o bloco pós-jogo da tela do jogo mostram |
 | `dim_leagues` | **nenhuma** | — | ✅ fora do alcance do app |
 
 ## ⛔ Defeito vivo: o desempate de janela das RPCs de odds não conhece a `daily`
@@ -94,4 +101,4 @@ Antes de mudar **grão** ou **colunas** de qualquer tabela da allowlist:
 | **#87** | Quatro flags de penalidade (`pen_odd_outlier`, `pen_poucas_casas`, `pen_odd_longshot`, `pen_odd_juice`) como `BOOLEAN` no mart | Colunas novas → mesmo caminho da #40: `ALTER TABLE ... ADD COLUMN <flag> boolean;` nas **duas** tabelas (`fact_value_opportunities` e `_hist`) × **dois** bancos, antes do deploy da imagem. **Nenhuma RPC quebra** — verificado no prd em 19/08: as duas que leem o mart o aliasam como `v` e enumeram coluna a coluna, sem `v.*`. E a #87 é o pré-requisito do conserto do lado do app: só com estas colunas no prd o CTE `d` de `get_futebol_fixture_value` (linha ⛔ da tabela acima) vira leitura direta e morre |
 | **A1** | Remove `pts_valor`/`pts_corroboracao`/`penalidades` do mart | Colunas removidas **e** declaradas no `RETURNS TABLE` das duas RPCs → `DROP FUNCTION` + recriar |
 | **A7** | Tabela nova de funil | Livre — fora da allowlist |
-| **Expurgo do board** (ADR 0009) | Mart para de emitir linha de jogo encerrado; passado vem do `hist` | **Nenhuma coluna muda** — o filtro é por join com `fact_fixtures`, de propósito. O risco aqui é o outro: o parity passa, as RPCs devolvem 200 e o Histórico esvazia em silêncio. Por isso a RPC nova (`get_futebol_value_history`) e o front vão **antes** do expurgo, e `get_futebol_value_board` **não é alterada**. `get_futebol_fixture_value` muda só o corpo (assinatura idêntica → `CREATE OR REPLACE`) |
+| **Expurgo do board** (ADR 0009, #85) | Mart para de emitir linha de jogo encerrado; passado vem do `hist` | ✅ **ENTREGUE.** **Nenhuma coluna muda** — o filtro é por join com `fact_fixtures`, de propósito, e por isso este passo não precisou de migration nenhuma. O risco aqui era o outro: o parity passa, as RPCs devolvem 200 e o Histórico esvazia em silêncio. Foi por isso que a RPC nova (`get_futebol_value_history`) e o front foram **antes** — os dois no PRD pelo release #271, em 19/08 — e `get_futebol_value_board` **não foi alterada**. `get_futebol_fixture_value` mudou só o corpo (assinatura idêntica → `CREATE OR REPLACE`) |

--- a/dbt_futebol/macros/futebol_expurgo.sql
+++ b/dbt_futebol/macros/futebol_expurgo.sql
@@ -1,0 +1,86 @@
+{#-
+  A FRONTEIRA DO EXPURGO DO BOARD, declarada num lugar só (issue #85, ADR 0009).
+
+  O `fact_value_opportunities` não tinha filtro de data nem de status: a linha de um jogo
+  que já terminou continuava sendo reavaliada e reemitida enquanto os modelos de premissa e
+  o de-vig continuassem produzindo-a. Medido em 17/08/2026 no PRD, o board tinha 121 linhas
+  e apenas 2 de jogo futuro, a mais velha de 19/06.
+
+  A ADR 0009 decidiu que **o board é a janela do que ainda dá para apostar**. Este macro é
+  essa janela, escrita como predicado.
+
+  ⚠️ Por que macro e não SQL no modelo: a **guarda 1** (`assert_board_sem_jogo_encerrado`)
+  espelha exatamente este predicado para provar que o expurgo aconteceu. Predicado copiado
+  em dois arquivos é predicado que diverge no primeiro refactor — e a divergência aqui é
+  muda nos dois sentidos: guarda mais frouxa que o mart nunca acende, guarda mais estrita
+  que o mart acende sem defeito. Com um macro só, mart e guarda não têm como discordar.
+
+  A fronteira é o STATUS, não o relógio:
+
+    · expurgam os TERMINAIS — o jogo acabou (ou nunca vai acontecer): FT, AET, PEN, CANC,
+      ABD, AWD, WO;
+    · expurgam os AO VIVO — não se aposta pré-jogo com a bola rolando;
+    · SOBREVIVEM `PST`, `SUSP` e `INT`. Kickoff no passado com jogo ainda por acontecer é
+      oportunidade legítima, e um corte por relógio a mataria.
+
+  A rede de segurança (kickoff + carência) existe para o jogo que passou do apito e **nunca
+  recebeu status final** — falha de coleta de placar, não de modelagem. Ela é parametrizada
+  em `var expurgo_carencia_horas` (default 24, declarado no `dbt_project.yml`) porque é um
+  parâmetro da QUALIDADE DA COLETA, que é a task [C] e vai mudar. Nenhum workflow passa a
+  var: mudar o default é mudar o arquivo, e isso é de propósito.
+
+  ⚠️ A CARÊNCIA NÃO SE APLICA A `PST`/`SUSP`/`INT` (ambiguidade da spec-mãe, resolvida no
+  fatiamento da #85). Sem essa exceção a rede de 24 h expurgaria exatamente a linha que a
+  decisão manda preservar — jogo adiado fica adiado por semanas — e a guarda 1, que espelha
+  o predicado, acenderia vermelha nela sem que houvesse defeito nenhum.
+
+  ⚠️ NULL É FAIL-OPEN, DE PROPÓSITO. Se o fixture não existir em `fact_fixtures`, tanto o
+  `IN` quanto o `NOT IN` devolvem NULL e o predicado inteiro vira NULL — a linha NÃO é
+  expurgada. É a ADR 0003 aplicada aqui (dado faltante diagnostica, não elimina): sumir com
+  a linha por falta do lado direito do join seria a perda silenciosa que a ADR 0009 existe
+  para impedir. Quem grita nesse caso é a guarda 1, que trata fixture ausente como vermelho
+  próprio, com diagnóstico próprio. Por isso o consumidor deste macro escreve
+  `NOT COALESCE(<predicado>, FALSE)` — explícito, nunca `NOT <predicado>`.
+-#}
+
+{#- Terminais: o jogo acabou, ou foi decidido fora de campo, ou não vai acontecer. -#}
+{% macro futebol_status_terminais() -%}
+    'FT', 'AET', 'PEN', 'CANC', 'ABD', 'AWD', 'WO'
+{%- endmacro %}
+
+
+{#-
+  Ao vivo: a bola está rolando. `SUSP` e `INT` são estados de jogo interrompido e ficam
+  FORA desta lista de propósito — eles sobrevivem, porque o jogo ainda pode ser retomado.
+-#}
+{% macro futebol_status_ao_vivo() -%}
+    '1H', 'HT', '2H', 'ET', 'BT', 'P', 'LIVE'
+{%- endmacro %}
+
+
+{#-
+  Os que sobrevivem mesmo com o kickoff no passado: adiado, suspenso, interrompido.
+  Kickoff velho aqui não é sintoma de coleta ruim — é o estado real do jogo.
+-#}
+{% macro futebol_status_sobrevivem() -%}
+    'PST', 'SUSP', 'INT'
+{%- endmacro %}
+
+
+{#-
+  O predicado. TRUE = a linha sai do board.
+
+  `status_col` e `kickoff_col` são expressões já qualificadas pelo chamador (ex.:
+  `fx.status_short`, `fx.kickoff_utc`), porque os dois consumidores juntam `fact_fixtures`
+  com aliases diferentes.
+-#}
+{% macro futebol_expurga_do_board(status_col, kickoff_col) -%}
+    (
+        {{ status_col }} IN ({{ futebol_status_terminais() }}, {{ futebol_status_ao_vivo() }})
+        OR (
+            TIMESTAMP_ADD({{ kickoff_col }}, INTERVAL {{ var('expurgo_carencia_horas') }} HOUR)
+                < CURRENT_TIMESTAMP()
+            AND {{ status_col }} NOT IN ({{ futebol_status_sobrevivem() }})
+        )
+    )
+{%- endmacro %}

--- a/dbt_futebol/macros/futebol_expurgo.sql
+++ b/dbt_futebol/macros/futebol_expurgo.sql
@@ -34,13 +34,27 @@
   decisão manda preservar — jogo adiado fica adiado por semanas — e a guarda 1, que espelha
   o predicado, acenderia vermelha nela sem que houvesse defeito nenhum.
 
-  ⚠️ NULL É FAIL-OPEN, DE PROPÓSITO. Se o fixture não existir em `fact_fixtures`, tanto o
-  `IN` quanto o `NOT IN` devolvem NULL e o predicado inteiro vira NULL — a linha NÃO é
-  expurgada. É a ADR 0003 aplicada aqui (dado faltante diagnostica, não elimina): sumir com
-  a linha por falta do lado direito do join seria a perda silenciosa que a ADR 0009 existe
-  para impedir. Quem grita nesse caso é a guarda 1, que trata fixture ausente como vermelho
-  próprio, com diagnóstico próprio. Por isso o consumidor deste macro escreve
+  ⚠️ FIXTURE AUSENTE É FAIL-OPEN, DE PROPÓSITO. Se o fixture não existir em `fact_fixtures`,
+  o `kickoff` é NULL, a comparação de relógio vira NULL e o predicado inteiro vira NULL — a
+  linha NÃO é expurgada. É a ADR 0003 aplicada aqui (dado faltante diagnostica, não elimina):
+  sumir com a linha por falta do lado direito do join seria a perda silenciosa que a ADR 0009
+  existe para impedir. Quem grita nesse caso é a guarda 1, que trata fixture ausente como
+  vermelho próprio, com diagnóstico próprio. Por isso o consumidor deste macro escreve
   `NOT COALESCE(<predicado>, FALSE)` — explícito, nunca `NOT <predicado>`.
+
+  ⚠️ STATUS NULO NUM FIXTURE QUE EXISTE É COISA DIFERENTE, e por isso o `COALESCE` no braço
+  do relógio. Sem ele o buraco caía exatamente onde a rede de segurança deveria pegar: com
+  `status_short` NULL, `NULL NOT IN ('PST','SUSP','INT')` devolve NULL, o braço inteiro vira
+  NULL, o `COALESCE(..., FALSE)` do consumidor deixa a linha passar — e a guarda 1, que
+  espelha o mesmo predicado, também não acende. Jogo com o apito dado há dias, sem status
+  nenhum, ficaria no board para sempre e em silêncio: o caso literal que a rede existe para
+  cobrir ("passou do kickoff e NUNCA recebeu status final"). Com `COALESCE(status, '')`, um
+  status nulo não é nenhum dos três que sobrevivem, então a carência o alcança.
+
+  A diferença entre os dois NULLs é deliberada: fixture ausente é defeito A MONTANTE e a
+  linha fica (com a guarda gritando); status nulo é a AUSÊNCIA DE PLACAR que a carência
+  existe para cobrir, e a linha sai. Um é "não sei o que é este jogo", o outro é "sei qual é
+  o jogo e ninguém carimbou o fim dele".
 -#}
 
 {#- Terminais: o jogo acabou, ou foi decidido fora de campo, ou não vai acontecer. -#}
@@ -80,7 +94,9 @@
         OR (
             TIMESTAMP_ADD({{ kickoff_col }}, INTERVAL {{ var('expurgo_carencia_horas') }} HOUR)
                 < CURRENT_TIMESTAMP()
-            AND {{ status_col }} NOT IN ({{ futebol_status_sobrevivem() }})
+            -- COALESCE, e não `{{ status_col }} NOT IN (...)` direto: status nulo tem de
+            -- ser alcançado pela carência, não escapar dela por NULL. Ver o cabeçalho.
+            AND COALESCE({{ status_col }}, '') NOT IN ({{ futebol_status_sobrevivem() }})
         )
     )
 {%- endmacro %}

--- a/dbt_futebol/models/marts/_fact_value_opportunities.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities.yml
@@ -15,6 +15,19 @@ models:
       ⚠️ Desde a #40 o gate é avaliado em TODAS as janelas coletadas e só depois reduzido a uma
       linha: é o que permite dizer, em `janela_deteccao`, há quanto tempo a oportunidade está no
       board. O grão não muda; o custo por build sim (os joins abrem ~4x antes do filtro final).
+      ⚠️ EXPURGO (#85, ADR 0009): passar no gate deixou de bastar. O mart é a JANELA DO QUE AINDA
+      DÁ PARA APOSTAR — junta `fact_fixtures` e não emite linha de jogo com status terminal
+      (FT/AET/PEN/CANC/ABD/AWD/WO) nem ao vivo, com rede de segurança em kickoff +
+      `var expurgo_carencia_horas` (24) para o jogo que passou do apito e nunca recebeu status.
+      `PST`, `SUSP` e `INT` SOBREVIVEM, inclusive além da carência: kickoff no passado com jogo
+      por acontecer é oportunidade legítima. Antes disso o mart não tinha filtro de data nem de
+      status e reemitia jogo encerrado a cada run — 133 linhas no PRD em 20/08, só 6 de jogo
+      futuro, a mais velha de 19/06. NENHUMA COLUNA NOVA saiu daqui por causa disso (coluna nova
+      em tabela sincronizada exigiria migration no Postgres antes do deploy da imagem; o filtro
+      por join não exige nada). Nada é apagado: o `fact_value_opportunities_hist` fecha e guarda
+      a versão, e é dele que o app serve o passado em leitura point-in-time no apito. O predicado
+      mora em `macros/futebol_expurgo.sql`, num lugar só, porque a guarda
+      `assert_board_sem_jogo_encerrado` o espelha.
     columns:
       - name: fixture_id
         tests: [not_null]

--- a/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
@@ -88,6 +88,20 @@ unit_tests:
       - input: ref('int_futebol_corroboracao')
         rows: []
 
+      # #85: o mart ganhou um ref novo (`fact_fixtures`, para o expurgo) e todo ref
+      # precisa de mock — sem este bloco o unit test não roda. Os quatro jogos entram
+      # como futuros e 'NS' de propósito: aqui se mede a JANELA DE DETECÇÃO, e nenhuma
+      # linha pode morrer pela fronteira do board sem que a asserção acima mude de
+      # significado em silêncio. A fronteira tem teste próprio, logo abaixo.
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          SELECT 1 AS fixture_id, 'NS' AS status_short,
+                 TIMESTAMP '2099-01-01 00:00:00+00' AS kickoff_utc
+          UNION ALL SELECT 2, 'NS', TIMESTAMP '2099-01-01 00:00:00+00'
+          UNION ALL SELECT 3, 'NS', TIMESTAMP '2099-01-01 00:00:00+00'
+          UNION ALL SELECT 4, 'NS', TIMESTAMP '2099-01-01 00:00:00+00'
+
     expect:
       rows:
         # fixture 1: publica a t15m (o preço que dá para pegar) e conta que a
@@ -97,3 +111,83 @@ unit_tests:
         - {fixture_id: 3, market: 'match_winner', outcome: 'Home', janela_usada: 't15m', janela_deteccao: 't15m', score: 45, penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
         # As fixtures 2 e 4 não aparecem. São as duas formas de morrer na janela
         # corrente: a 2 por preço, a 4 por conjunto incompleto.
+
+  - name: value_opportunities_expurgo_a_fronteira_do_board
+    model: fact_value_opportunities
+    description: >
+      A fronteira do expurgo (#85, ADR 0009) é o STATUS, não o relógio. Cobre as cinco
+      formas de sair ou ficar, e a que mais importa é a terceira: PST/SUSP/INT sobrevivem
+      INCLUSIVE além da carência — sem essa exceção a rede de 24 h expurgaria exatamente
+      a linha que a decisão manda preservar.
+    given:
+      # Seis jogos idênticos em tudo que não seja a fronteira: mesmos pontos, mesmo
+      # preço, uma janela só. O que os separa é só o par (status, kickoff), então
+      # qualquer diferença no resultado é atribuível ao expurgo e a mais nada.
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 10 AS fixture_id, 'Home' AS outcome, 'brasileirao' AS competition,
+                 2026 AS season, 15 AS pts_premissas, 0 AS premissas_sem_dado,
+                 0 AS penalidades_1x2_pts,
+                 CAST([] AS ARRAY<STRING>) AS evidencias,
+                 CAST([] AS ARRAY<STRING>) AS avisos
+          UNION ALL SELECT 11, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 12, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 13, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 14, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 15, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          - {fixture_id: 10, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 11, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 12, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 13, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 14, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 15, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      # A FIXTURE 15 NÃO ESTÁ AQUI, e é de propósito: é o fail-open do LEFT JOIN
+      # (ADR 0003). Fixture ausente não expurga a linha — quem grita nesse caso é a
+      # guarda 1, com diagnóstico próprio, e não o sumiço silencioso da oportunidade.
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          -- 10: jogo futuro, não começou. FICA.
+          SELECT 10 AS fixture_id, 'NS' AS status_short,
+                 TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 6 HOUR) AS kickoff_utc
+          -- 11: terminou. SAI por status terminal.
+          UNION ALL SELECT 11, 'FT', TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR)
+          -- 12: bola rolando. SAI — não se aposta pré-jogo com o jogo em curso.
+          UNION ALL SELECT 12, '1H', TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
+          -- 13: ADIADO há 10 dias. FICA, apesar de o kickoff ter passado MUITO da
+          --     carência de 24 h. É a asserção central deste teste.
+          UNION ALL SELECT 13, 'PST', TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 240 HOUR)
+          -- 14: passou do apito há 48 h e nunca recebeu status final. SAI pela rede de
+          --     segurança — é o sintoma de coleta de placar falha (task [C]).
+          UNION ALL SELECT 14, 'NS', TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 48 HOUR)
+
+      - input: ref('int_futebol_premissas_ou')
+        rows: []
+      - input: ref('int_futebol_premissas_ah')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+
+    expect:
+      rows:
+        # 10 — jogo por acontecer.
+        - {fixture_id: 10, market: 'match_winner', outcome: 'Home', score: 45}
+        # 13 — adiado há 10 dias: sobrevive INCLUSIVE além da carência.
+        - {fixture_id: 13, market: 'match_winner', outcome: 'Home', score: 45}
+        # 15 — sem fixture: o fail-open deixa passar (ADR 0003), a guarda 1 acusa.
+        - {fixture_id: 15, market: 'match_winner', outcome: 'Home', score: 45}
+        # Não aparecem: 11 (terminal), 12 (ao vivo), 14 (carência).

--- a/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
@@ -141,6 +141,8 @@ unit_tests:
                  CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
           UNION ALL SELECT 15, 'Home', 'brasileirao', 2026, 15, 0, 0,
                  CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 16, 'Home', 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
 
       - input: ref('int_futebol_odds_devig')
         rows:
@@ -150,6 +152,7 @@ unit_tests:
           - {fixture_id: 13, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
           - {fixture_id: 14, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
           - {fixture_id: 15, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 16, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
 
       # A FIXTURE 15 NÃO ESTÁ AQUI, e é de propósito: é o fail-open do LEFT JOIN
       # (ADR 0003). Fixture ausente não expurga a linha — quem grita nesse caso é a
@@ -170,6 +173,13 @@ unit_tests:
           -- 14: passou do apito há 48 h e nunca recebeu status final. SAI pela rede de
           --     segurança — é o sintoma de coleta de placar falha (task [C]).
           UNION ALL SELECT 14, 'NS', TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 48 HOUR)
+          -- 16: o fixture EXISTE mas o status é NULL, e o apito foi há 48 h. SAI.
+          --     Sem o COALESCE no braço do relógio, `NULL NOT IN (...)` devolveria NULL, o
+          --     predicado inteiro viraria NULL e a linha ficaria no board PARA SEMPRE — e a
+          --     guarda 1, que espelha o predicado, também não acenderia. É o caso literal
+          --     que a rede de segurança existe para cobrir, e ele escapava por NULL.
+          UNION ALL SELECT 16, CAST(NULL AS STRING),
+                 TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 48 HOUR)
 
       - input: ref('int_futebol_premissas_ou')
         rows: []
@@ -190,4 +200,12 @@ unit_tests:
         - {fixture_id: 13, market: 'match_winner', outcome: 'Home', score: 45}
         # 15 — sem fixture: o fail-open deixa passar (ADR 0003), a guarda 1 acusa.
         - {fixture_id: 15, market: 'match_winner', outcome: 'Home', score: 45}
-        # Não aparecem: 11 (terminal), 12 (ao vivo), 14 (carência).
+        # Não aparecem: 11 (terminal), 12 (ao vivo), 14 (carência) e 16 (status NULL
+        # além da carência — o caso que escapava por NULL antes do COALESCE).
+        #
+        # A 15 e a 16 são o par que dá o desenho: as duas têm informação faltando, e
+        # elas vão para lados OPOSTOS de propósito. Na 15 falta o jogo inteiro — é
+        # defeito a montante, a linha fica e a guarda grita. Na 16 falta só o carimbo
+        # do fim — é a ausência de placar que a carência existe para cobrir, e a linha
+        # sai. "Não sei que jogo é este" e "sei qual é e ninguém carimbou o fim" não
+        # podem ter o mesmo destino.

--- a/dbt_futebol/models/marts/fact_value_opportunities.sql
+++ b/dbt_futebol/models/marts/fact_value_opportunities.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='table',
     cluster_by=['competition', 'fixture_id'],
-    description='Mart de saída do Motor de Score de Confiabilidade (value bet futebol). 1 linha por (fixture_id, market, outcome, line_value) que PASSA no gate (edge>0 E n_casas>=3 E de-vig válido E conjunto da Pinnacle completo pro mercado E score>=40 E — p/ Handicap asiático/Gols O/U — linha meia .5, sem push). Score 0-100 = clamp(PTS_VALOR + PTS_PREMISSAS + PTS_CORROBORACAO − PENALIDADES). faixa Alta(>=60)/Média(40-59); abaixo de 40 não vira oportunidade. evidencias[] = o "por quê" (premissas + corroboração); avisos[] = red flags. Long por `market` — v5 liga 1X2 (market_id=1) + Gols O/U (market_id=5) + Handicap asiático (market_id=4) + Ambos Marcam/BTTS (market_id=8) + Dupla Chance (market_id=12, saídas 1X/X2). Junta int_futebol_premissas_1x2/_ou/_ah/_btts/_dc + int_futebol_odds_devig + int_futebol_corroboracao. line_value é NULL no 1X2/BTTS/DC, a linha L no O/U e o handicap (ótica do mandante, mesmo p/ Home e Away) no AH. valor_fonte = pinnacle (de-vig da Pinnacle, mercados 1/4/5; e DC, derivada do 1X2 da Pinnacle) ou consenso (de-vig da mediana das casas — BTTS, pois a Pinnacle não precifica; rotular como estimativa no front). A DC tem GATE PRÓPRIO (melhor_odd >=1,25, sem odd_juice) — aplicado no ramo joined_dc; o gate >=1,25 já garante o retorno mínimo (sem penalidade específica de odd baixa). Contador de cegueira (#41, ADR 0003): premissas_sem_dado diz QUANTAS premissas aplicáveis àquela linha não puderam ser avaliadas por falta de insumo — gerado do mapa futebol_insumos_premissa(), nunca escrito à mão. QUAIS foram fica nos modelos de premissas (premissas_cegas[]), de onde este número vem: o mart carrega a contagem, que é o que o board exibe. O score NÃO muda: a premissa cega já não acendia e continua não acendendo; o que muda é o board passar a dizer o que não levou em conta. premissas_sem_dado é propagado dos cinco modelos de premissas e sai também como aviso em avisos[], SEM pontos entre parênteses: ele não desconta nada, diz que a nota está incompleta e não contrária (#41, ADR 0003). JANELA DE DETECÇÃO (#40, ADR 0004): janela_deteccao é a janela mais cedo (daily<t24h<t1h<t15m) em que ESTA linha passou no gate; janela_usada continua sendo a janela corrente, a que dá o preço publicado. Nunca posterior a janela_usada (guarda assert_janela_deteccao_nao_posterior). O grão NÃO muda — segue 1 linha por (fixture, mercado, saída, linha) —, mas o CUSTO muda: achar a janela mais cedo exige rodar o gate (nota inclusa) em TODAS as janelas coletadas e só depois reduzir, então os joins deste mart abrem ~4x antes do WHERE final. Linha que passou numa janela cedo e não passa na corrente NÃO aparece no board: preço que o usuário não consegue mais pegar não é oportunidade, e o histórico do que já foi anunciado vive no snapshot fact_value_opportunities_hist. PARCELAS DA PENALIDADE GLOBAL (#87): além do agregado penalidades_globais_pts, o mart publica as quatro flags que o compõem — pen_odd_outlier/pen_poucas_casas/pen_odd_longshot/pen_odd_juice, BOOLEAN —, as MESMAS que montam o avisos[]. Antes só o agregado saía, e o consumidor tinha de readivinhar as parcelas a partir do int_futebol_odds_devig por uma chave sem market_id e sem janela: a soma sobrevivia e as parcelas se perdiam. Publicá-las não muda score, avisos nem grão; muda que a parcela é lida em vez de reconstruída, e que ela entra no snapshot _hist (vira point-in-time). Identidade garantida em todo ramo: 30*outlier + 12*poucas + 15*longshot + 10*juice = penalidades_globais_pts (na Dupla Chance o juice é FALSE de propósito — o gate de odd >=1,25 já cobre o retorno mínimo).'
+    description='Mart de saída do Motor de Score de Confiabilidade (value bet futebol). 1 linha por (fixture_id, market, outcome, line_value) que PASSA no gate (edge>0 E n_casas>=3 E de-vig válido E conjunto da Pinnacle completo pro mercado E score>=40 E — p/ Handicap asiático/Gols O/U — linha meia .5, sem push). Score 0-100 = clamp(PTS_VALOR + PTS_PREMISSAS + PTS_CORROBORACAO − PENALIDADES). faixa Alta(>=60)/Média(40-59); abaixo de 40 não vira oportunidade. evidencias[] = o "por quê" (premissas + corroboração); avisos[] = red flags. Long por `market` — v5 liga 1X2 (market_id=1) + Gols O/U (market_id=5) + Handicap asiático (market_id=4) + Ambos Marcam/BTTS (market_id=8) + Dupla Chance (market_id=12, saídas 1X/X2). Junta int_futebol_premissas_1x2/_ou/_ah/_btts/_dc + int_futebol_odds_devig + int_futebol_corroboracao. line_value é NULL no 1X2/BTTS/DC, a linha L no O/U e o handicap (ótica do mandante, mesmo p/ Home e Away) no AH. valor_fonte = pinnacle (de-vig da Pinnacle, mercados 1/4/5; e DC, derivada do 1X2 da Pinnacle) ou consenso (de-vig da mediana das casas — BTTS, pois a Pinnacle não precifica; rotular como estimativa no front). A DC tem GATE PRÓPRIO (melhor_odd >=1,25, sem odd_juice) — aplicado no ramo joined_dc; o gate >=1,25 já garante o retorno mínimo (sem penalidade específica de odd baixa). Contador de cegueira (#41, ADR 0003): premissas_sem_dado diz QUANTAS premissas aplicáveis àquela linha não puderam ser avaliadas por falta de insumo — gerado do mapa futebol_insumos_premissa(), nunca escrito à mão. QUAIS foram fica nos modelos de premissas (premissas_cegas[]), de onde este número vem: o mart carrega a contagem, que é o que o board exibe. O score NÃO muda: a premissa cega já não acendia e continua não acendendo; o que muda é o board passar a dizer o que não levou em conta. premissas_sem_dado é propagado dos cinco modelos de premissas e sai também como aviso em avisos[], SEM pontos entre parênteses: ele não desconta nada, diz que a nota está incompleta e não contrária (#41, ADR 0003). JANELA DE DETECÇÃO (#40, ADR 0004): janela_deteccao é a janela mais cedo (daily<t24h<t1h<t15m) em que ESTA linha passou no gate; janela_usada continua sendo a janela corrente, a que dá o preço publicado. Nunca posterior a janela_usada (guarda assert_janela_deteccao_nao_posterior). O grão NÃO muda — segue 1 linha por (fixture, mercado, saída, linha) —, mas o CUSTO muda: achar a janela mais cedo exige rodar o gate (nota inclusa) em TODAS as janelas coletadas e só depois reduzir, então os joins deste mart abrem ~4x antes do WHERE final. Linha que passou numa janela cedo e não passa na corrente NÃO aparece no board: preço que o usuário não consegue mais pegar não é oportunidade, e o histórico do que já foi anunciado vive no snapshot fact_value_opportunities_hist. PARCELAS DA PENALIDADE GLOBAL (#87): além do agregado penalidades_globais_pts, o mart publica as quatro flags que o compõem — pen_odd_outlier/pen_poucas_casas/pen_odd_longshot/pen_odd_juice, BOOLEAN —, as MESMAS que montam o avisos[]. Antes só o agregado saía, e o consumidor tinha de readivinhar as parcelas a partir do int_futebol_odds_devig por uma chave sem market_id e sem janela: a soma sobrevivia e as parcelas se perdiam. Publicá-las não muda score, avisos nem grão; muda que a parcela é lida em vez de reconstruída, e que ela entra no snapshot _hist (vira point-in-time). Identidade garantida em todo ramo: 30*outlier + 12*poucas + 15*longshot + 10*juice = penalidades_globais_pts (na Dupla Chance o juice é FALSE de propósito — o gate de odd >=1,25 já cobre o retorno mínimo). EXPURGO DO BOARD (#85, ADR 0009): o mart é a janela do que AINDA DÁ PARA APOSTAR — junta fact_fixtures e não emite linha de jogo com status terminal (FT/AET/PEN/CANC/ABD/AWD/WO) nem ao vivo, com rede de segurança em kickoff + var expurgo_carencia_horas (24) para o jogo que passou do apito e nunca recebeu status. PST/SUSP/INT SOBREVIVEM, inclusive além da carência: kickoff no passado com jogo por acontecer é oportunidade legítima. Antes do expurgo o mart não tinha filtro de data nem de status e reemitia jogo encerrado a cada run (121 linhas no PRD em 17/08, só 2 de jogo futuro, a mais velha de 19/06). NENHUMA COLUNA NOVA sai daqui por causa disso — coluna nova em tabela sincronizada exigiria migration no Postgres antes do deploy da imagem, e o filtro por join não exige nada. Nada é apagado: o fact_value_opportunities_hist fecha e guarda a versão (invalidate_hard_deletes), e é dele que o app serve o passado em leitura point-in-time no apito. O predicado mora em macros/futebol_expurgo.sql, num lugar só, porque a guarda assert_board_sem_jogo_encerrado o espelha.'
 ) }}
 
 WITH prem_1x2 AS (
@@ -42,6 +42,27 @@ devig AS (
 corro AS (
     SELECT *, COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
     FROM {{ ref('int_futebol_corroboracao') }}
+),
+
+-- O EXPURGO DO BOARD (#85, ADR 0009): o único uso de `fact_fixtures` neste mart, e ele
+-- serve só ao filtro final. Até aqui o mart não tinha filtro de data nem de status, e a
+-- linha de jogo encerrado seguia sendo reavaliada e reemitida a cada run — 121 linhas no
+-- PRD em 17/08, só 2 de jogo futuro, a mais velha de 19/06.
+--
+-- As duas colunas vêm com prefixo `_fx_` por necessidade, não por estilo: `fact_fixtures`
+-- também tem `competition` e `season`, e a lista final deste modelo referencia as duas sem
+-- qualificar. Trazer o `*` (ou os nomes originais) tornaria as referências ambíguas e o
+-- modelo pararia de compilar.
+--
+-- NENHUMA COLUNA NOVA SAI DAQUI, e isso é decisão, não descuido: coluna nova em tabela
+-- sincronizada exige migração no Postgres ANTES do deploy da imagem, senão o parity aborta
+-- as 21 tabelas. O filtro por join não exige nada — por isso ele é o mecanismo escolhido.
+fixtures AS (
+    SELECT
+        fixture_id,
+        status_short AS _fx_status_short,
+        kickoff_utc  AS _fx_kickoff_utc
+    FROM {{ ref('fact_fixtures') }}
 ),
 
 -- ============================================================================
@@ -508,6 +529,12 @@ SELECT
 
     CURRENT_TIMESTAMP() AS dbt_loaded_at
 FROM com_deteccao
+-- LEFT, nunca INNER (#85, ADR 0009 + ADR 0003). Fixture que não existe em `fact_fixtures`
+-- não deve sumir do board: sumir seria a perda silenciosa que a ADR 0009 existe para
+-- impedir. O predicado do expurgo devolve NULL nesse caso e o `COALESCE(..., FALSE)` abaixo
+-- deixa a linha passar — e a guarda 1 acende vermelho com diagnóstico próprio, que é o
+-- caminho certo para dado faltante: diagnosticar, não eliminar.
+LEFT JOIN fixtures USING (fixture_id)
 -- A REDUÇÃO A UMA LINHA POR (fixture, mercado, saída, linha) (#40). O grão do mart não
 -- mudou; o que mudou é que a redução agora é explícita aqui, em vez de vir pronta do
 -- macro futebol_devig_janela_corrente(). As duas condições respondem coisas diferentes
@@ -520,3 +547,17 @@ FROM com_deteccao
 --                       para ficar nele com carimbo antigo (ADR 0004).
 WHERE janela_e_corrente
   AND passou_no_gate
+  -- O BOARD É A JANELA DO QUE AINDA DÁ PARA APOSTAR (#85, ADR 0009). O predicado mora em
+  -- `macros/futebol_expurgo.sql`, num lugar só, porque a guarda 1 o espelha para provar que
+  -- o expurgo aconteceu — e predicado copiado é predicado que diverge.
+  --
+  -- Nada é apagado: o mart é reconstruído do zero e o `fact_value_opportunities_hist` fecha
+  -- e guarda a versão pelo `invalidate_hard_deletes` do snapshot, sem nenhuma mudança lá.
+  -- Sair do board é deixar de ser emitida, não deixar de ter existido.
+  --
+  -- O `COALESCE(..., FALSE)` é o fail-open explicado no join e no macro: fixture ausente
+  -- não expurga a linha, acende a guarda.
+  AND NOT COALESCE(
+        {{ futebol_expurga_do_board('_fx_status_short', '_fx_kickoff_utc') }},
+        FALSE
+      )

--- a/dbt_futebol/tests/assert_board_sem_jogo_encerrado.sql
+++ b/dbt_futebol/tests/assert_board_sem_jogo_encerrado.sql
@@ -27,6 +27,14 @@
 -- ⚠️ PST/SUSP/INT sobrevivem inclusive além da carência, e é por isso que a exceção está
 -- dentro do macro e não aqui: jogo adiado fica adiado por semanas, e uma guarda que a
 -- ignorasse acenderia vermelha em cima da linha que a decisão manda preservar.
+--
+-- ⚠️ PONTO CEGO DECLARADO: esta guarda reavalia `CURRENT_TIMESTAMP()` na fase 4, minutos
+-- depois de o mart tê-lo avaliado na fase 2. Uma linha que cruzar a fronteira da carência
+-- DENTRO dessa janela acende vermelho uma vez sem defeito nenhum de código, e se cura
+-- sozinha no run seguinte (o mart a expurga). Não vale sincronizar relógio entre as fases
+-- para evitar isso: o custo seria carimbar um "agora" no mart — coluna nova em tabela
+-- sincronizada, que é exatamente o que a ADR 0009 recusou —, e o falso positivo é raro,
+-- transitório e legível pelo diagnóstico, que aponta a carência e não o status.
 
 SELECT
     o.fixture_id,

--- a/dbt_futebol/tests/assert_board_sem_jogo_encerrado.sql
+++ b/dbt_futebol/tests/assert_board_sem_jogo_encerrado.sql
@@ -1,0 +1,55 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA 1 DO EXPURGO DO BOARD (#85, ADR 0009): o `fact_value_opportunities` não emite
+-- linha de jogo que já saiu da janela do que dá para apostar.
+--
+-- Ela existe porque o aceite da ADR 0009 é MEDIDO, não afirmado. O defeito que a decisão
+-- corrige é exatamente do tipo que volta sozinho: basta alguém reescrever o filtro final
+-- do mart, ou trocar o LEFT JOIN de lugar, e o board recomeça a reemitir jogo de junho —
+-- sem erro, sem linha vermelha, com o app continuando a servir 200.
+--
+-- ⚠️ O PREDICADO NÃO É COPIADO. Ele vem de `macros/futebol_expurgo.sql`, o mesmo que o
+-- mart usa. Guarda que reescreve à mão a regra que fiscaliza tem dois modos de falha e os
+-- dois são mudos: mais frouxa que o mart, nunca acende; mais estrita, acende sem defeito.
+--
+-- TRÊS DIAGNÓSTICOS, e eles não são a mesma falha:
+--
+--   · status terminal ou ao vivo — o expurgo por status parou de acontecer. É a regressão
+--     direta da ADR 0009;
+--   · kickoff + carência sem status final — o expurgo por status está de pé, mas a rede de
+--     segurança não. Aqui o dedo aponta para a COLETA DE PLACAR (task [C]), não para este
+--     mart: o jogo aconteceu e ninguém carimbou o status;
+--   · fixture ausente em `fact_fixtures` — a linha passou pelo fail-open do mart. Não é
+--     defeito do expurgo (a ADR 0003 manda mesmo deixar passar), é defeito a montante, e
+--     esta guarda é o único lugar onde ele grita. Sem este ramo o fail-open seria um buraco
+--     por onde jogo encerrado voltaria ao board em silêncio, que é o oposto do que a
+--     decisão quer.
+--
+-- ⚠️ PST/SUSP/INT sobrevivem inclusive além da carência, e é por isso que a exceção está
+-- dentro do macro e não aqui: jogo adiado fica adiado por semanas, e uma guarda que a
+-- ignorasse acenderia vermelha em cima da linha que a decisão manda preservar.
+
+SELECT
+    o.fixture_id,
+    o.market,
+    o.outcome,
+    o.line_value,
+    f.status_short,
+    f.kickoff_utc,
+    CASE
+        WHEN f.fixture_id IS NULL
+            THEN 'fixture ausente em fact_fixtures — a linha entrou pelo fail-open do mart (ADR 0003). Defeito a montante, não do expurgo, mas o board está publicando linha que ninguém consegue validar'
+        WHEN f.status_short IN ({{ futebol_status_terminais() }})
+            THEN 'jogo com status terminal ainda no board — o expurgo por status parou de acontecer (regressão da ADR 0009)'
+        WHEN f.status_short IN ({{ futebol_status_ao_vivo() }})
+            THEN 'jogo ao vivo ainda no board — não se aposta pré-jogo com a bola rolando (regressão da ADR 0009)'
+        ELSE FORMAT(
+            'kickoff passou de %d h e o jogo nunca recebeu status final (está em %s) — a rede de segurança do expurgo não pegou. O dedo aponta para a coleta de placar (task [C]), não para este mart',
+            {{ var('expurgo_carencia_horas') }},
+            COALESCE(f.status_short, 'NULL')
+        )
+    END AS diagnostico
+FROM {{ ref('fact_value_opportunities') }} o
+LEFT JOIN {{ ref('fact_fixtures') }} f
+       ON f.fixture_id = o.fixture_id
+WHERE f.fixture_id IS NULL
+   OR {{ futebol_expurga_do_board('f.status_short', 'f.kickoff_utc') }}

--- a/dbt_futebol/tests/assert_hist_aberto_existe_no_board.sql
+++ b/dbt_futebol/tests/assert_hist_aberto_existe_no_board.sql
@@ -1,0 +1,57 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA 2 DO EXPURGO DO BOARD (#85, ADR 0009): nada sai do `fact_value_opportunities` sem
+-- ficar com a versão FECHADA no `fact_value_opportunities_hist`.
+--
+-- Uma chave "aberta" no histórico (`dbt_valid_to IS NULL`) diz: *esta oportunidade está no
+-- board agora*. Se ela não está mais no mart, o histórico está mentindo — e a mentira é do
+-- tipo que ninguém vê, porque o app lê o `hist` e recebe 200 com uma linha que já não
+-- existe.
+--
+-- POR QUE A GUARDA 1 NÃO BASTA. A guarda 1 prova que o expurgo ACONTECE. Esta prova que ele
+-- não vira PERDA. São as duas metades da mesma decisão: a ADR 0009 aceita apagar do board
+-- justamente porque o histórico guarda — se o carimbo falhar, o expurgo deixa de ser uma
+-- mudança de janela e passa a ser destruição de evidência. É a diferença entre "a linha
+-- saiu de cartaz" e "a linha nunca existiu".
+--
+-- ⚠️ ELA DEPENDE DA ORDEM, e a ordem já está certa — foi verificada, não presumida. No
+-- `workflow_futebol_odds.yml` a fase 3 é o `dbt snapshot` e a fase 4 é o
+-- `dbt test --select tag:guarda`. O snapshot fecha (`invalidate_hard_deletes`) as chaves
+-- que sumiram do mart, e só depois a guarda lê. Rodada ANTES do snapshot ela acusaria
+-- vermelho em cima do funcionamento normal: entre o `dbt run` e o `dbt snapshot` toda linha
+-- expurgada está legitimamente aberta no `hist` e ausente do mart.
+--
+-- Isso é o que faz esta guarda entrar sem tocar em YAML nenhum: a fase que ela precisa já
+-- existe, com status próprio (`guardas_status`), e nenhum workflow precisa de redeploy.
+--
+-- ⚠️ Consequência para quem roda na mão: `dbt test --select tag:guarda` sem ter rodado o
+-- `dbt snapshot` depois do `dbt run` acende vermelho aqui, e é vermelho legítimo — está
+-- descrevendo o estado real do banco, não um defeito do código.
+--
+-- A chave é reconstruída com o MESMO `CONCAT` NULL-safe do snapshot (`line_value` é NULL em
+-- match_winner/btts/double_chance). Se as duas expressões divergirem, esta guarda acende —
+-- o que também é o comportamento certo: chave que não casa entre mart e histórico é
+-- exatamente o defeito que ela procura.
+
+WITH board AS (
+    SELECT
+        CONCAT(
+          CAST(fixture_id AS STRING), '|', market, '|', outcome, '|',
+          COALESCE(CAST(line_value AS STRING), 'NONE')
+        ) AS opportunity_key
+    FROM {{ ref('fact_value_opportunities') }}
+)
+
+SELECT
+    h.opportunity_key,
+    h.fixture_id,
+    h.market,
+    h.outcome,
+    h.line_value,
+    h.janela_usada,
+    h.dbt_valid_from,
+    'chave aberta no hist (dbt_valid_to IS NULL) sem par no board — o histórico está dizendo que a oportunidade está no ar e ela não está. Ou o snapshot não rodou depois do run, ou a linha evaporou do mart sem carimbo' AS diagnostico
+FROM {{ ref('fact_value_opportunities_hist') }} h
+LEFT JOIN board b
+       ON b.opportunity_key = h.opportunity_key
+WHERE h.dbt_valid_to IS NULL
+  AND b.opportunity_key IS NULL


### PR DESCRIPTION
Passo 3+4 da ordem de entrega da ADR 0009. Os passos 1 e 2 (RPC point-in-time + front) subiram no PRD em 19/08 pelo release #271 do prop-play-predictor — o gatilho que destravou este ticket.

## O defeito

O `fact_value_opportunities` não tinha filtro de data nem de status. A linha de um jogo que já terminou seguia sendo reavaliada e reemitida a cada run, enquanto os modelos de premissa e o de-vig continuassem produzindo-a.

**Medido no PRD hoje (20/08), re-medido no dia como o aceite manda:** 133 linhas no board, **6 de jogo futuro**, a mais velha de **19/06**. Sob o mart novo sobram exatamente essas 6.

## A fronteira, e por que ela é o status

`macros/futebol_expurgo.sql` — o predicado num lugar só, porque a guarda 1 o espelha para provar que o expurgo aconteceu. Predicado copiado é predicado que diverge, e a divergência é muda nos dois sentidos: guarda mais frouxa nunca acende, guarda mais estrita acende sem defeito.

- expurgam os **terminais** (`FT`, `AET`, `PEN`, `CANC`, `ABD`, `AWD`, `WO`) e os **ao vivo**;
- **sobrevivem `PST`, `SUSP`, `INT`** — inclusive além da carência. Kickoff no passado com jogo por acontecer é oportunidade legítima, e um corte por relógio a mataria;
- rede de segurança em kickoff + `var expurgo_carencia_horas` (24), para o jogo que passou do apito e nunca recebeu status. É var porque é parâmetro da **qualidade da coleta de placar**, que é a task [C] e vai mudar. Nenhum workflow a passa.

**Nenhuma coluna nova.** Coluna nova em tabela sincronizada exigiria migration no Postgres antes do deploy da imagem, senão o parity aborta as 21 tabelas. O filtro por join não exige nada — é por isso que ele é o mecanismo.

## Os dois NULLs vão para lados opostos, e é decisão

| | Destino | Por quê |
|---|---|---|
| **Fixture ausente** em `fact_fixtures` | a linha **fica**, e a guarda 1 grita | Defeito a montante. ADR 0003: dado faltante diagnostica, não elimina. Sumir com a linha por falta do lado direito de um join é a perda silenciosa que a ADR 0009 existe para impedir |
| **`status_short` NULO** num fixture que existe | a linha **sai** pela carência | É a ausência de placar que a rede de segurança existe para cobrir |

*"Não sei que jogo é este"* e *"sei qual é e ninguém carimbou o fim dele"* não podem ter o mesmo destino.

O segundo caso era um **defeito real, achado na revisão** (`e6f2d88`): `NULL NOT IN ('PST','SUSP','INT')` devolve NULL, o braço do relógio virava NULL, a linha passava — e a guarda, espelhando o mesmo predicado, também não acendia. Jogo com apito dado há dias ficaria no board para sempre, em silêncio. Medido: 0 status nulo nos 10.529 fixtures do prd, então era **latente**. Corrigido mesmo assim, porque a rede só é exercitada quando a coleta se comporta mal — que é exatamente quando o NULL aparece.

## As duas guardas, falsificadas nos dois sentidos

| Guarda | Estado defeituoso | Estado correto |
|---|---|---|
| 1 — `assert_board_sem_jogo_encerrado` | **127 vermelhas** contra o prd de hoje, com o diagnóstico certo | **0** sobre o SQL do mart novo |
| 2 — `assert_hist_aberto_existe_no_board` | **1 vermelha** ao remover do board uma chave aberta no `hist` | **0** contra o prd real |

A guarda 1 não precisou de defeito forjado: **o prd de hoje já é o estado do defeito**. Depois do deploy essa falsificação ficaria cara, então foi feita agora.

**Nenhum YAML de workflow mudou.** A fase 3 do `workflow_futebol_odds.yml` é o `dbt snapshot` e a fase 4 é o `dbt test --select tag:guarda`, com seleção **por tag** — guarda nova entra sem redeploy de workflow. A ordem importa para a guarda 2 e já estava correta; foi verificada, não presumida.

## Testes

- Unit test novo com os **seis** casos da fronteira. Vermelho-verde conferido duas vezes: falha ao neutralizar o filtro, e falha ao remover o `COALESCE` do status nulo
- O unit test que já existia **não mockava o ref novo** — `dbt parse` não valida isso, então teria quebrado no primeiro `dbt test`
- `dbt test --select tag:guarda test_type:unit` → **PASS=33, ERROR=1**. A única vermelha é a guarda 1 lendo o mart ainda não reconstruído; ela vira verde com o deploy
- Validado por `dbt compile` + `bq query`, **sem `dbt run` contra `futebol`** — dev e prod apontam para o mesmo dataset

## ⚠️ Achado que muda o alvo da #86

**`fact_fixtures` é reconstruída uma vez por dia** (`workflow-futebol-daily`, `0 9 * * *`). O board roda a cada 15 min e não a toca. Entre o apito e as 09:00 UTC a linha continua no board.

Fatiando as 17.719 versões pós-apito do `hist`: o expurgo mata **17.390 (98,1%)**; sobram **329 (1,9%)** que ele estruturalmente não alcança — 121 na latência do status e 208 no valor da carência.

Ou seja, **o alvo da #86 ("zero versão nova pós-apito") não será atingido ao pé da letra**, e agora ela sabe atribuir em vez de investigar. É a dependência [A]→[C] que a ADR 0009 pré-declarou; o que não existia era o tamanho dela. Números completos no comentário da #85.

## Duas escolhas que registro por serem discutíveis

1. **A guarda 1 é estritamente mais estrita que o mart**, por causa do ramo de fixture ausente — a spec pedia "o mesmo predicado, espelhado". É deliberado: sem esse ramo, o fail-open vira um buraco por onde jogo encerrado volta ao board em silêncio. 0 linhas em prd hoje.
2. **A expressão da `opportunity_key` continua duplicada** entre a guarda 2 e o snapshot, apesar de este PR extrair o outro predicado para macro. Extrair esta exigiria mexer no `unique_key` do snapshot, e uma diferença de um byte na renderização **muda toda chave e transforma o histórico inteiro em churn**. O risco é alto e o benefício é nulo: divergência de chave falha **alto** (as chaves param de casar e a guarda 2 acende), ao contrário da divergência de predicado, que é muda.

## Depois do merge

Este PR **não** entrega sozinho — mergear não é deployar. A ordem é: tirar o #88 do draft e mergear, um `./build-and-push.sh dbt_futebol` para os dois, `checa_deriva.sh` **do checkout principal** (do worktree ele mente), e **registrar a data do deploy** — é ela que inicia o D+7 da #86, não o merge.

Closes #85
