### PR TITLE
Futebol: o funil nasce — um booleano por porta, e nada filtrado (#95)

### DIFF
--- a/dbt_futebol/macros/futebol_funil.sql
+++ b/dbt_futebol/macros/futebol_funil.sql
@@ -1,0 +1,46 @@
+{#-
+  O UNIVERSO DO FUNIL, declarado num lugar só (issue #95, ADR 0011).
+
+  São os **cinco mercados pontuados** — os que têm modelo de premissa — e o nome público
+  de cada um, que é o `market` que sai no `fact_value_funnel` e no
+  `fact_value_opportunities`.
+
+  ⚠️ O mercado **6** (Gols O/U do 1º tempo) está FORA de propósito, e não por esquecimento.
+  O de-vig o emite (22.363 linhas na foto de 19/08) porque ele está declarado em
+  `futebol_conjunto_saidas()` — lá a lista responde "qual conjunto de saídas este mercado
+  precisa ter para o de-vig poder emitir", que é outra pergunta. Aqui a lista responde
+  "quais mercados o Motor pontua". Gravar o 6 como *rejeitado* registraria como decisão
+  nossa a ausência de um modelo que nunca escrevemos.
+
+  Por que macro e não literal nos dois arquivos: a guarda `assert_funil_reconcilia_com_devig`
+  precisa mapear `market_id` -> `market` exatamente como o modelo mapeia, senão ela acende
+  vermelha (ou, pior, fica muda) por divergência de vocabulário e não por defeito. É a mesma
+  razão que pôs o predicado do expurgo em `futebol_expurgo.sql`.
+-#}
+{% macro futebol_mercados_pontuados() %}
+    {{ return({
+        1:  'match_winner',
+        4:  'asian_handicap',
+        5:  'goals_over_under',
+        8:  'btts',
+        12: 'double_chance'
+    }) }}
+{% endmacro %}
+
+
+{#- Os ids, prontos para um `IN (...)`. -#}
+{% macro futebol_mercados_pontuados_ids() -%}
+    {{ futebol_mercados_pontuados().keys() | join(', ') }}
+{%- endmacro %}
+
+
+{#- `market_id` -> o nome público do mercado. Mercado fora da lista resolve para NULL
+    (fail-closed): ele não é candidato do funil, e um NULL numa chave de reconciliação
+    acende vermelho em vez de casar por acidente. -#}
+{% macro futebol_market_slug(coluna) -%}
+    CASE {{ coluna }}
+        {%- for mid, slug in futebol_mercados_pontuados().items() %}
+        WHEN {{ mid }} THEN '{{ slug }}'
+        {%- endfor %}
+    END
+{%- endmacro %}

--- a/dbt_futebol/models/marts/_fact_value_funnel.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel.yml
@@ -1,0 +1,186 @@
+version: 2
+
+models:
+  - name: fact_value_funnel
+    description: >
+      O FUNIL DE AVALIAÇÃO (#95, ADR 0011 + ADR 0006). 1 linha por
+      (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos
+      cinco mercados pontuados — e NADA filtrado. Onde o `fact_value_opportunities` guarda
+      só o que passa, este guarda todo candidato com o veredito de cada porta em coluna
+      própria, e é dele que sai a pergunta que a task [A] inteira precisa responder:
+      quantas linhas cada porta remove SOZINHA, e quantas ela ainda remove DEPOIS das
+      anteriores.
+
+      Duas rejeições que hoje são SUMIÇO passam a ser linha com carimbo: o conjunto de
+      saídas incompleto (a maior do sistema, ~49% do universo), que vivia num `WHERE`
+      dentro do join de cada ramo do board; e a saída "12" da Dupla Chance — precificada,
+      não pontuada —, que o `INNER JOIN` com as premissas engolia.
+
+      O board NÃO muda nesta entrega. Quem prova que o funil o descreve de verdade é
+      `assert_funil_paridade_com_board`; quem prova que o universo está inteiro é
+      `assert_funil_reconcilia_com_devig`, que lê a FONTE (o de-vig) e nunca o próprio
+      funil.
+
+      ⚠️ Materialização TABELA nesta entrega: como ela nasce cobrindo desde a primeira odd
+      coletada, o backfill sai de graça. O append-only com congelamento no apito (ADR 0011)
+      é a próxima entrega — e é ela que impede o rebuild de reescrever o passado quando as
+      portas mudarem (A1/A2/A3/A5).
+
+      ⚠️ NÃO VAI PARA O SUPABASE (ADR 0006/0011): o app não lê funil. Sem migração no
+      Postgres, sem RPC, sem tocar `check_schema_parity`.
+
+      ⚠️ Quem for CONTAR o funil precisa fixar UMA janela por candidato antes de contar
+      (`janela_e_corrente`, ou a janela que a análise escolher). Contando as quatro, todo
+      número infla até 4×.
+    columns:
+      # ------------------------------------------------------------------ chave e grão
+      - name: fixture_id
+        description: "Jogo. Vem do de-vig, não de `fact_fixtures` — o funil não perde linha por fixture ausente."
+        tests: [not_null]
+      - name: market
+        description: "Os cinco mercados pontuados. O mercado 6 (Gols O/U do 1º tempo) fica FORA do universo: não existe modelo de premissa para ele (ADR 0011). A lista mora em `macros/futebol_funil.sql`."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['match_winner', 'goals_over_under', 'asian_handicap', 'btts', 'double_chance']
+      - name: outcome
+        description: >
+          A saída precificada. Inclui a "12" da Dupla Chance, que o Motor NÃO pontua — ela
+          entra com `porta_saida_catalogada = FALSE`, porque teve preço e a decisão de não
+          pontuá-la é nossa (ADR 0011). Por isso a lista aqui é MAIOR que a do board.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Home', 'Draw', 'Away', 'Over', 'Under', 'Yes', 'No', '1X', '12', 'X2']
+      - name: line_value
+        description: "NULL no 1X2, BTTS e Dupla Chance; a linha L (1.5/2.5/...) no Gols O/U; o handicap na ótica do mandante (o mesmo p/ Home e Away) no Handicap asiático."
+      - name: janela
+        description: "A janela de coleta que originou esta avaliação. São QUATRO por candidato (daily < t24h < t1h < t15m), não três — a `daily` entrou em 07/08/2026. É a quarta coluna do grão."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['daily', 't24h', 't1h', 't15m']
+      - name: janela_prioridade
+        description: "A ordem declarada das janelas (`futebol_janela_prioridade()`), 1=daily .. 4=t15m. Ordenar pelo NOME diria que 'daily' < 't15m' < 't1h' < 't24h'."
+      - name: janela_e_corrente
+        description: >
+          TRUE na janela mais recente coletada deste (fixture, mercado, linha) — a que o
+          board publicaria. É REDUÇÃO, não veredito: fica FORA de `passou_no_gate` de
+          propósito (ADR 0011, D8), senão toda taxa de rejeição do funil passaria a incluir
+          três janelas que ninguém rejeitou.
+        tests: [not_null]
+
+      # ------------------------------------------------------------------- as oito portas
+      - name: porta_saida_catalogada
+        description: "TRUE = a saída é pontuada pelo Motor. FALSE só na \"12\" da Dupla Chance, hoje. É a porta que existe para que uma saída precificada e não modelada seja um DESCARTE registrado, e não um sumiço."
+        tests: [not_null]
+      - name: porta_conjunto_completo
+        description: >
+          TRUE = o conjunto de saídas do de-vig tem o tamanho declarado (ADR 0002): 1X2
+          exige 3 saídas da Pinnacle, Handicap e Gols exigem o par, BTTS exige o par no
+          consenso, Dupla Chance exige o conjunto 1X2 DE ORIGEM completo. É a maior
+          rejeição do sistema (~49% do universo) e até esta entrega ela não existia em
+          lugar nenhum — saía num `WHERE` dentro do join, antes de qualquer nota.
+        tests: [not_null]
+      - name: porta_valor_estimavel
+        description: >
+          TRUE = há `prob_justa_fechamento`. ⚠️ ANINHADA com `porta_conjunto_completo`:
+          pela ADR 0002, conjunto incompleto implica prob justa ausente. As duas ficam
+          porque a leitura marginal é o produto da tabela — mas quem as somar como
+          independentes conta a mesma linha duas vezes.
+        tests: [not_null]
+      - name: porta_liquidez
+        description: "TRUE = `n_casas >= 3`. (A A3 vai mexer neste número; é para medir o antes/depois que esta tabela existe.)"
+        tests: [not_null]
+      - name: porta_edge
+        description: "TRUE = `edge > 0`, ou `> consensus_min_edge` (3%) quando o valor vem do consenso — o edge de consenso é enviesado p/ cima (best_odd é o MÁXIMO das casas contra a prob da MEDIANA). (A A2 tira o edge do gate.)"
+        tests: [not_null]
+      - name: porta_nota
+        description: "TRUE = `score >= 40`. Nota NULL (saída sem premissa a avaliar) reprova aqui — é a porta que absorve o que o `INNER JOIN` do board descartava."
+        tests: [not_null]
+      - name: porta_linha_meia
+        description: "TRUE = a linha é meia (.5, sem push/meio-push). Só se aplica a Handicap asiático e Gols O/U; nos outros três passa trivialmente, porque a porta não se aplica — não porque a linha foi isentada."
+        tests: [not_null]
+      - name: porta_odd_dc
+        description: "TRUE = `best_odd >= 1,25`. Gate de odd PRÓPRIO da Dupla Chance (que por isso não aplica a penalidade de juice). Trivialmente TRUE nos outros quatro mercados."
+        tests: [not_null]
+      - name: passou_no_gate
+        description: >
+          A CONJUNÇÃO das oito portas, DERIVADA e nunca escrita à mão (ADR 0006). Não
+          inclui `janela_e_corrente` (redução, não veredito) nem o expurgo do board
+          (o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a
+          faixa descartada).
+        tests: [not_null]
+      - name: motivo_primario
+        description: >
+          CONVENIÊNCIA DE LEITURA, NÃO FONTE (ADR 0006). A primeira porta reprovada na
+          ordem de leitura declarada; NULL quando a linha passou. Uma linha reprova em
+          várias portas ao mesmo tempo, e é justamente a leitura marginal — isolada vs.
+          depois das anteriores — que dá valor à tabela: quem for medir porta lê os oito
+          booleanos, nunca esta coluna.
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['saida_nao_catalogada', 'conjunto_incompleto', 'valor_nao_estimavel',
+                         'sem_liquidez', 'sem_edge', 'nota_abaixo_da_regua', 'sem_lado_apostado',
+                         'linha_nao_meia', 'odd_dc_abaixo_do_minimo']
+      - name: sem_lado_apostado
+        description: >
+          O empate do 1X2 (ADR 0005/0006). Marca ESTRUTURAL — o mercado e a saída —, nunca
+          "a nota deu zero": sem lado apostado nenhuma premissa dispara, e um terço do
+          universo do 1X2 está em zero POR CONSTRUÇÃO. Sob o motivo genérico esse terço
+          apareceria como "nota abaixo da régua" e a régua pareceria mais severa no 1X2 do
+          que é.
+        tests: [not_null]
+
+      # --------------------------------------------------------------------- o payload
+      - name: kickoff_utc
+        description: >
+          O apito, em UTC. Eixo de toda análise por horizonte e — na próxima entrega — a
+          fronteira do congelamento (ADR 0011). NULL quando o fixture não existe em
+          `fact_fixtures`: o join é LEFT de propósito, porque perder a linha seria a perda
+          silenciosa que a tabela existe para impedir.
+      - name: score
+        description: "A MESMA nota do board: clamp(pts_valor + pts_premissas + pts_corroboracao − penalidades, 0, 100). NULL onde não houve premissa a avaliar (a \"12\" da DC) — e o NULL morre na `porta_nota`, que é NULL-safe."
+      - name: pts_premissas
+        description: "NULL, e não zero, onde não houve premissa a avaliar. Zero seria \"foi avaliada e tirou zero\", que é outra coisa (ADR 0003)."
+      - name: premissas_sem_dado
+        description: "Quantas premissas aplicáveis à linha não puderam ser avaliadas por falta de insumo (#41, ADR 0003). Não entra na nota: é o que a nota NÃO pôde levar em conta. NULL onde não houve premissa nenhuma."
+      - name: edge
+        description: "EV/edge = best_odd * prob_justa − 1. Ao contrário do board, aqui ele NÃO é garantidamente positivo: o funil guarda o que a porta de edge rejeitou."
+      - name: valor_fonte
+        description: "'pinnacle' (mercados 1/4/5; e Dupla Chance, derivada do 1X2 da Pinnacle) ou 'consenso' (mediana das casas — BTTS). NULL em linha cujo conjunto de saídas veio incompleto: sem conjunto não há estimativa (ADR 0002)."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['pinnacle', 'consenso']
+      - name: is_half_line
+        description: "TRUE se a linha é meia (.5); FALSE p/ cheia/quarter; NULL onde não há linha. Insumo cru da `porta_linha_meia`."
+      - name: pen_odd_outlier
+        description: "Parcela da penalidade global: best_odd >= 1,10 × média das OUTRAS casas (−30)."
+      - name: pen_poucas_casas
+        description: "Parcela da penalidade global: n_casas < 4 (−12)."
+      - name: pen_odd_longshot
+        description: "Parcela da penalidade global: best_odd > 4,5 (−15)."
+      - name: pen_odd_juice
+        description: "Parcela da penalidade global: best_odd < 1,40 (−10). FALSE na Dupla Chance de propósito — o gate de odd próprio (>= 1,25) já cobre o retorno mínimo."
+    tests:
+      # O GRÃO — e aqui ele inclui a JANELA, ao contrário do board (ADR 0004/0011).
+      #
+      # `tag:guarda` porque esta é a única propriedade da tabela que nenhuma outra guarda
+      # cobre: a `assert_funil_reconcilia_com_devig` compara CONJUNTOS de chaves com
+      # `EXCEPT DISTINCT`, que é insensível a duplicata — um fan-out que duplicasse toda
+      # linha passaria por ela nos dois sentidos e só apareceria aqui.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - fixture_id
+              - market
+              - outcome
+              - line_value
+              - janela
+          config:
+            tags: ['guarda']

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -1,0 +1,267 @@
+version: 2
+
+# ==============================================================================
+# Unit tests do FUNIL DE AVALIAÇÃO (#95, ADR 0011 + ADR 0006).
+#
+# Por que unit test e não data test: o produto desta tabela é a DISTINÇÃO entre as
+# portas — quantas linhas cada uma remove sozinha, e quantas ela ainda remove depois
+# das anteriores. Numa contagem sobre produção essa distinção é indistinguível de
+# muitas outras coisas: um funil em que toda linha reprovada tem
+# `porta_conjunto_completo = FALSE` é compatível tanto com "a coluna está certa e o
+# conjunto incompleto é mesmo 49% do universo" quanto com "todas as portas estão
+# copiando a mesma expressão". Só linha construída separa as duas.
+#
+# Regra de construção: cada fixture isola UM caso e muda UMA COISA SÓ em relação ao
+# caso base (fixture 1). Os valores do caso base são deliberadamente folgados —
+# pts_valor 30 + pts_premissas 15 = score 45, folga de 5 sobre a régua de 40. Se
+# alguém mexer nos pesos e o teste ficar vermelho por score, é o número daqui que se
+# ajusta; não é o caso de teste que está errado.
+#
+# ⚠️ As linhas do de-vig são MOCKS, não amostras: algumas combinações não ocorrem em
+# produção de propósito, porque isolar uma porta às vezes exige quebrar a implicação
+# que a liga a outra. Onde isso acontece está dito na linha.
+# ==============================================================================
+unit_tests:
+
+  # ---------------------------------------------------------------------------
+  # 1. CADA PORTA REPROVANDO SOZINHA — as outras sete TRUE.
+  #
+  # É o caso que a coluna única de motivo não conseguiria provar, e é a razão da
+  # ADR 0006 ter escolhido oito booleanos: sob um campo único, sete destes nove
+  # fixtures seriam indistinguíveis de qualquer outro que reprovasse antes deles na
+  # fila.
+  # ---------------------------------------------------------------------------
+  - name: funil_cada_porta_reprova_sozinha
+    model: fact_value_funnel
+    description: >
+      Nove candidatos idênticos fora de uma coisa cada: o base (passa em tudo) e um por
+      porta. Prova que as oito portas são independentes entre si e que
+      `passou_no_gate` é a conjunção delas — nunca uma segunda cópia do gate do board.
+    given:
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # -- 1: o CASO BASE. 1X2 Home, tudo em ordem. -------------------------------
+          - {fixture_id: 1, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 2: porta_saida_catalogada. A "12" da Dupla Chance — precificada, e o Motor
+          # pontua só 1X e X2. ⚠️ MOCK DELIBERADAMENTE IRREAL: em produção a "12" não tem
+          # linha nenhuma em `int_futebol_premissas_dc` (é exatamente por isso que ela é
+          # não-catalogada), então ela reprova em DUAS portas ao mesmo tempo. Aqui a
+          # premissa é fabricada para isolar a porta; o caso realista está no teste
+          # `funil_duas_portas_o_empate_e_o_insumo_nulo`.
+          - {fixture_id: 2, competition: 'brasileirao', season: 2026, market_id: 12, outcome_side: '12', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 1.50, best_book: 'Bet365', avg_odd: 1.45, n_casas: 5, prob_justa_fechamento: 0.60, pin_n_outcomes: , n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 3: porta_conjunto_completo. O 1X2 exige as três saídas da Pinnacle; vieram
+          # duas. É a MAIOR rejeição do sistema (~49% do universo) e até esta entrega ela
+          # não existia em lugar nenhum — saía num `WHERE` dentro do join. ⚠️ O de-vig
+          # real anularia prob_justa junto (ADR 0002); aqui ela fica para isolar a porta.
+          - {fixture_id: 3, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 4: porta_valor_estimavel. Sem prob justa não há estimativa. --------------
+          - {fixture_id: 4, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: , pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 5: porta_liquidez. Duas casas cobrindo o mercado. -----------------------
+          - {fixture_id: 5, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 2, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 6: porta_edge. O mercado corrigiu e a vantagem virou negativa. ----------
+          - {fixture_id: 6, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: -0.05, pts_valor: 30, best_odd: 1.90, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 7: porta_nota. Idêntico ao base; o que muda está nas premissas (0 pontos),
+          # então o score cai para 30 e não alcança a régua de 40.
+          - {fixture_id: 7, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 8: porta_linha_meia. Gols O/U na linha CHEIA 2.0 — pode dar push, e o
+          # de-vig 2-way superdimensiona o edge nela.
+          - {fixture_id: 8, competition: 'brasileirao', season: 2026, market_id: 5, outcome_side: 'Over', line_value: 2.0, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 9: porta_odd_dc. Dupla Chance com odd abaixo do mínimo próprio (1,25). ---
+          - {fixture_id: 9, competition: 'brasileirao', season: 2026, market_id: 12, outcome_side: '1X', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 1.20, best_book: 'Bet365', avg_odd: 1.18, n_casas: 5, prob_justa_fechamento: 0.85, pin_n_outcomes: , n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      # format: sql porque `evidencias`/`avisos` são ARRAY<STRING> nos modelos de
+      # premissa, e o formato de dicionário entrega todo valor como escalar. O funil não
+      # lê esses arrays, então o mock traz só as colunas que ele lê.
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 1 AS fixture_id, 'Home' AS outcome, 15 AS pts_premissas,
+                 0 AS premissas_sem_dado, 0 AS penalidades_1x2_pts
+          UNION ALL SELECT 3, 'Home', 15, 0, 0
+          UNION ALL SELECT 4, 'Home', 15, 0, 0
+          UNION ALL SELECT 5, 'Home', 15, 0, 0
+          UNION ALL SELECT 6, 'Home', 15, 0, 0
+          -- fixture 7: a premissa não acendeu nada. É a ÚNICA diferença dele para o base.
+          UNION ALL SELECT 7, 'Home', 0, 0, 0
+
+      - input: ref('int_futebol_premissas_ou')
+        format: sql
+        rows: |
+          SELECT 8 AS fixture_id, 'Over' AS outcome, 2.0 AS line_value,
+                 15 AS pts_premissas, 0 AS premissas_sem_dado, 0 AS penalidades_ou_pts
+
+      - input: ref('int_futebol_premissas_dc')
+        format: sql
+        rows: |
+          SELECT 2 AS fixture_id, '12' AS outcome, 15 AS pts_premissas, 0 AS premissas_sem_dado
+          UNION ALL SELECT 9, '1X', 15, 0
+
+      - input: ref('int_futebol_premissas_ah')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+
+      # O funil junta `fact_fixtures` SÓ pelo kickoff (ADR 0011, D10 — o status muda
+      # depois do apito e uma linha congelada com o status de antes mentiria).
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          SELECT id AS fixture_id, TIMESTAMP '2099-01-01 00:00:00+00' AS kickoff_utc
+          FROM UNNEST([1,2,3,4,5,6,7,8,9]) AS id
+
+    expect:
+      rows:
+        - {fixture_id: 1, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: true,  motivo_primario: , sem_lado_apostado: false}
+        - {fixture_id: 2, market: 'double_chance',    outcome: '12',   score: 45, porta_saida_catalogada: false, porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'saida_nao_catalogada', sem_lado_apostado: false}
+        - {fixture_id: 3, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: false, porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'conjunto_incompleto', sem_lado_apostado: false}
+        - {fixture_id: 4, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: false, porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'valor_nao_estimavel', sem_lado_apostado: false}
+        - {fixture_id: 5, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: false, porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'sem_liquidez', sem_lado_apostado: false}
+        - {fixture_id: 6, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: false, porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'sem_edge', sem_lado_apostado: false}
+        - {fixture_id: 7, market: 'match_winner',     outcome: 'Home', score: 30, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'nota_abaixo_da_regua', sem_lado_apostado: false}
+        - {fixture_id: 8, market: 'goals_over_under', outcome: 'Over', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: false, porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'linha_nao_meia', sem_lado_apostado: false}
+        - {fixture_id: 9, market: 'double_chance',    outcome: '1X',   score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: false, passou_no_gate: false, motivo_primario: 'odd_dc_abaixo_do_minimo', sem_lado_apostado: false}
+
+  # ---------------------------------------------------------------------------
+  # 2. OS CASOS QUE A TABELA EXISTE PARA REGISTRAR.
+  #
+  # Três coisas diferentes que a estrutura de hoje perde: a linha que reprova em duas
+  # portas ao mesmo tempo (que um campo único de motivo achataria), o empate do 1X2
+  # (que sob motivo genérico faria a régua parecer mais severa no 1X2 do que é) e o
+  # insumo ausente (que sem NULL-safety por porta apagaria a linha em silêncio).
+  # ---------------------------------------------------------------------------
+  - name: funil_duas_portas_o_empate_e_o_insumo_nulo
+    model: fact_value_funnel
+    description: >
+      Uma linha reprovando em duas portas ao mesmo tempo — as DUAS colunas FALSE, que é a
+      propriedade que a coluna única de motivo destruiria; a "12" da Dupla Chance na sua
+      forma real (sem premissa nenhuma); o empate do 1X2 com marca própria e nota
+      explícita, nunca NULL; e insumo ausente reprovando a porta sem propagar NULL para
+      dentro da conjunção.
+    given:
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # -- 10: DUAS portas ao mesmo tempo — sem liquidez E sem edge. O `motivo_primario`
+          # elege a primeira da ordem de leitura, e é justamente por isso que ele não pode
+          # ser a fonte: sob ele, esta linha seria contada só como "sem liquidez".
+          - {fixture_id: 10, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: -0.05, pts_valor: 30, best_odd: 1.90, best_book: 'Bet365', avg_odd: 2.00, n_casas: 2, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 11: a "12" da DC COMO ELA É em produção — precificada e sem nenhuma linha em
+          # `int_futebol_premissas_dc`. O LEFT JOIN traz pts_premissas NULL, a nota fica NULL,
+          # e a linha reprova em duas: saída não catalogada e nota. Sob o INNER JOIN do board
+          # ela não existiria em lugar nenhum — nem como oportunidade, nem como descarte.
+          - {fixture_id: 11, competition: 'brasileirao', season: 2026, market_id: 12, outcome_side: '12', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 1.50, best_book: 'Bet365', avg_odd: 1.45, n_casas: 5, prob_justa_fechamento: 0.60, pin_n_outcomes: , n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 12: o EMPATE do 1X2. Sem lado apostado nenhuma premissa dispara e a penalidade
+          # de pick_empate (−10) pesa: 30 + 0 − 10 = 20. A nota é um NÚMERO, não NULL — o
+          # zero é explícito (ADR 0005) e a linha sai marcada, não descartada em silêncio.
+          - {fixture_id: 12, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Draw', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 3.40, best_book: 'Bet365', avg_odd: 3.20, n_casas: 5, prob_justa_fechamento: 0.32, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 13: INSUMO AUSENTE numa porta — `n_casas` chega NULL. A porta reprova
+          # (COALESCE(..., FALSE)) e `passou_no_gate` sai FALSE, nunca NULL. Sem a
+          # NULL-safety por porta, o NULL atravessaria a conjunção e a linha sumiria do
+          # recorte de quem filtrasse `passou_no_gate = FALSE` — descarte silencioso pela
+          # porta dos fundos, que é o que a ADR 0006 proíbe.
+          - {fixture_id: 13, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: , prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 10 AS fixture_id, 'Home' AS outcome, 15 AS pts_premissas,
+                 0 AS premissas_sem_dado, 0 AS penalidades_1x2_pts
+          -- O empate: zero ponto de premissa e os −10 do pick_empate.
+          UNION ALL SELECT 12, 'Draw', 0, 0, 10
+          UNION ALL SELECT 13, 'Home', 15, 0, 0
+
+      # A "12" da fixture 11 NÃO tem linha aqui — de propósito. É o estado real.
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_premissas_ou')
+        rows: []
+      - input: ref('int_futebol_premissas_ah')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          SELECT id AS fixture_id, TIMESTAMP '2099-01-01 00:00:00+00' AS kickoff_utc
+          FROM UNNEST([10,11,12,13]) AS id
+
+    expect:
+      rows:
+        # duas portas FALSE na mesma linha, e o motivo elege só a primeira.
+        - {fixture_id: 10, market: 'match_winner',  outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: false, porta_edge: false, porta_nota: true,  porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_liquidez',         sem_lado_apostado: false, pts_premissas: 15}
+        # a "12" real: sem premissa -> nota NULL -> porta_nota FALSE, e a saída não catalogada.
+        - {fixture_id: 11, market: 'double_chance', outcome: '12',   score: ,   porta_saida_catalogada: false, porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'saida_nao_catalogada', sem_lado_apostado: false, pts_premissas: }
+        # o empate: nota 20 (um número), marca própria e motivo próprio.
+        - {fixture_id: 12, market: 'match_winner',  outcome: 'Draw', score: 20, porta_saida_catalogada: true,  porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_lado_apostado',   sem_lado_apostado: true,  pts_premissas: 0}
+        # insumo NULL: porta FALSE, gate FALSE — nunca NULL.
+        - {fixture_id: 13, market: 'match_winner',  outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: false, porta_edge: true,  porta_nota: true,  porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_liquidez',         sem_lado_apostado: false, pts_premissas: 15}
+
+  # ---------------------------------------------------------------------------
+  # 3. AS QUATRO JANELAS.
+  #
+  # O grão do funil inclui a janela (ADR 0004/0011): são QUATRO registros por
+  # candidato, não três — a `daily` entrou em 07/08/2026. `janela_e_corrente` marca
+  # exatamente um deles, e fica FORA de `passou_no_gate`: ela é redução, não veredito.
+  #
+  # É o teste que protege o número de todo mundo que for contar esta tabela. Contando
+  # as quatro janelas sem fixar uma, toda taxa de rejeição infla até 4×.
+  # ---------------------------------------------------------------------------
+  - name: funil_quatro_janelas_um_candidato_uma_corrente
+    model: fact_value_funnel
+    description: >
+      O mesmo candidato coletado nas quatro janelas vira quatro linhas, e só a mais
+      recente tem `janela_e_corrente`. O veredito das portas varia entre elas (é isso
+      que muda entre janelas depois que o preço sai da nota), e a redução não interfere
+      no gate.
+    given:
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # daily: o mercado ainda não estava líquido — reprova na liquidez.
+          - {fixture_id: 20, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 'daily', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 2, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 20, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't24h', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 20, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't1h',  edge: 0.08, pts_valor: 30, best_odd: 2.15, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # t15m: a janela corrente. O mercado corrigiu e o edge virou negativo — a linha
+          # não publicaria, e continua registrada, que é o ponto da tabela inteira.
+          - {fixture_id: 20, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: -0.02, pts_valor: 30, best_odd: 1.95, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 20 AS fixture_id, 'Home' AS outcome, 15 AS pts_premissas,
+                 0 AS premissas_sem_dado, 0 AS penalidades_1x2_pts
+
+      - input: ref('int_futebol_premissas_ou')
+        rows: []
+      - input: ref('int_futebol_premissas_ah')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          SELECT 20 AS fixture_id, TIMESTAMP '2099-01-01 00:00:00+00' AS kickoff_utc
+
+    expect:
+      rows:
+        - {fixture_id: 20, janela: 'daily', janela_e_corrente: false, porta_liquidez: false, porta_edge: true,  passou_no_gate: false}
+        - {fixture_id: 20, janela: 't24h',  janela_e_corrente: false, porta_liquidez: true,  porta_edge: true,  passou_no_gate: true}
+        - {fixture_id: 20, janela: 't1h',   janela_e_corrente: false, porta_liquidez: true,  porta_edge: true,  passou_no_gate: true}
+        - {fixture_id: 20, janela: 't15m',  janela_e_corrente: true,  porta_liquidez: true,  porta_edge: false, passou_no_gate: false}

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -1,0 +1,574 @@
+{{ config(
+    materialized='table',
+    cluster_by=['competition', 'fixture_id'],
+    description='O FUNIL DE AVALIAÇÃO (#95, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). MATERIALIZAÇÃO TABELA nesta entrega (#95): a tabela nasce cobrindo desde a primeira odd coletada (16/06), então o backfill sai de graça. O append-only com congelamento no apito (ADR 0011) é a próxima entrega. NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil).'
+) }}
+
+-- ============================================================================
+-- O UNIVERSO SAI DO DE-VIG, NÃO DAS PREMISSAS — e essa é a inversão da entrega.
+--
+-- O `fact_value_opportunities` parte das premissas e faz `INNER JOIN` com o de-vig.
+-- Sob essa direção a saída "12" da Dupla Chance (precificada, não pontuada) some antes
+-- de qualquer porta, e o mesmo vale para toda saída sem modelo. Aqui o de-vig é o lado
+-- de FORA: candidato é linha que teve preço (ADR 0006), e o que falta do lado das
+-- premissas vira porta FALSE, não ausência.
+--
+-- A guarda `assert_funil_reconcilia_com_devig` amarra isso: linhas do funil = candidatos
+-- do de-vig nos cinco mercados. Nenhum join abaixo pode acrescentar nem tirar linha.
+-- ============================================================================
+WITH devig AS (
+    SELECT
+        *,
+        COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
+    FROM ({{ futebol_devig_todas_janelas() }})
+    -- OS CINCO MERCADOS PONTUADOS. O 6 (Gols O/U do 1º tempo) é coletado e passa pelo
+    -- de-vig, mas não tem modelo de premissa: gravá-lo como "rejeitado" registraria como
+    -- decisão nossa a ausência de um modelo que nunca escrevemos (ADR 0011).
+    WHERE market_id IN ({{ futebol_mercados_pontuados_ids() }})
+),
+
+-- A corroboração já vem reduzida à janela corrente e com grão (fixture, mercado, saída,
+-- linha) — sem janela. O join abaixo, portanto, é o MESMO do board: a linha de t24h e a
+-- de t15m recebem a mesma corroboração. Não é descuido do funil, é o grão do modelo a
+-- montante, e mudá-lo aqui quebraria a paridade.
+corro AS (
+    SELECT
+        *,
+        COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key
+    FROM {{ ref('int_futebol_corroboracao') }}
+),
+
+prem_1x2 AS (
+    SELECT * FROM {{ ref('int_futebol_premissas_1x2') }}
+),
+
+prem_ou AS (
+    SELECT * FROM {{ ref('int_futebol_premissas_ou') }}
+),
+
+prem_ah AS (
+    SELECT * FROM {{ ref('int_futebol_premissas_ah') }}
+),
+
+prem_btts AS (
+    SELECT * FROM {{ ref('int_futebol_premissas_btts') }}
+),
+
+prem_dc AS (
+    SELECT * FROM {{ ref('int_futebol_premissas_dc') }}
+),
+
+-- SÓ O KICKOFF, e o status DE PROPÓSITO fora (ADR 0011, D10). O kickoff é o que o
+-- congelamento da próxima entrega vai usar e o que toda análise por horizonte precisa;
+-- o status muda DEPOIS do apito, e uma linha congelada carregando o status de antes
+-- mentiria. Quem quiser status junta `fact_fixtures` — que é onde ele está certo.
+fixtures AS (
+    SELECT
+        fixture_id,
+        kickoff_utc AS _fx_kickoff_utc
+    FROM {{ ref('fact_fixtures') }}
+),
+
+-- ============================================================================
+-- Ramo 1X2 (market_id=1). Saídas catalogadas: Home / Draw / Away.
+-- Completude do conjunto = 1X2 inteiro na Pinnacle (pin_n_outcomes >= 3) — o MESMO
+-- predicado que hoje é `WHERE d.pin_n_outcomes >= 3` no ramo do board, virado coluna.
+-- ============================================================================
+cand_1x2 AS (
+    SELECT
+        d.fixture_id,
+        '{{ futebol_mercados_pontuados()[1] }}'         AS market,
+        d.outcome_side                                  AS outcome,
+        CAST(NULL AS FLOAT64)                           AS line_value,
+        d.line_key,
+        d.competition,
+        d.season,
+        d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
+
+        d.edge,
+        COALESCE(d.pts_valor, 0)                        AS pts_valor,
+        d.best_odd,
+        d.best_book,
+        d.avg_odd,
+        d.n_casas,
+        d.prob_justa_fechamento,
+        d.pin_n_outcomes,
+        d.n_outcomes_valor,
+        d.valor_fonte,
+        COALESCE(d.penalidades_globais_pts, 0)          AS penalidades_globais_pts,
+        d.pen_odd_outlier,
+        d.pen_poucas_casas,
+        d.pen_odd_longshot,
+        d.pen_odd_juice,
+
+        p.pts_premissas,
+        p.premissas_sem_dado,
+        p.penalidades_1x2_pts                           AS penalidades_especificas_pts,
+
+        COALESCE(c.pts_corroboracao, 0)                 AS pts_corroboracao,
+        COALESCE(c.modelo_api_concorda, FALSE)          AS modelo_api_concorda,
+        COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
+
+        COALESCE(d.outcome_side IN ('Home', 'Draw', 'Away'), FALSE) AS porta_saida_catalogada,
+        COALESCE(d.pin_n_outcomes >= 3, FALSE)          AS porta_conjunto_completo,
+        -- O EMPATE (ADR 0005/0006). Não tem lado apostado: nenhuma premissa do 1X2 se
+        -- aplica, o teto de premissa é zero e — quando a A6 introduzir o denominador —
+        -- ele também será zero, explicitamente antes da divisão. A marca é ESTRUTURAL
+        -- (o mercado e a saída), nunca "a nota deu zero": é ela que impede que um terço
+        -- do universo do 1X2, que está em zero por construção, seja lido como
+        -- severidade da régua.
+        COALESCE(d.outcome_side = 'Draw', FALSE)        AS sem_lado_apostado
+    FROM devig d
+    LEFT JOIN prem_1x2 p
+        ON  p.fixture_id = d.fixture_id
+       AND  p.outcome    = d.outcome_side
+    LEFT JOIN corro c
+        ON  c.market_id    = d.market_id
+       AND  c.fixture_id   = d.fixture_id
+       AND  c.outcome_side = d.outcome_side
+    WHERE d.market_id = 1
+),
+
+-- ============================================================================
+-- Ramo Gols O/U (market_id=5). Saídas catalogadas: Over / Under.
+-- Completude = par Over+Under da Pinnacle na linha (pin_n_outcomes >= 2).
+-- ============================================================================
+cand_ou AS (
+    SELECT
+        d.fixture_id,
+        '{{ futebol_mercados_pontuados()[5] }}'         AS market,
+        d.outcome_side                                  AS outcome,
+        d.line_value,
+        d.line_key,
+        d.competition,
+        d.season,
+        d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
+
+        d.edge,
+        COALESCE(d.pts_valor, 0)                        AS pts_valor,
+        d.best_odd,
+        d.best_book,
+        d.avg_odd,
+        d.n_casas,
+        d.prob_justa_fechamento,
+        d.pin_n_outcomes,
+        d.n_outcomes_valor,
+        d.valor_fonte,
+        COALESCE(d.penalidades_globais_pts, 0)          AS penalidades_globais_pts,
+        d.pen_odd_outlier,
+        d.pen_poucas_casas,
+        d.pen_odd_longshot,
+        d.pen_odd_juice,
+
+        p.pts_premissas,
+        p.premissas_sem_dado,
+        p.penalidades_ou_pts                            AS penalidades_especificas_pts,
+
+        COALESCE(c.pts_corroboracao, 0)                 AS pts_corroboracao,
+        COALESCE(c.modelo_api_concorda, FALSE)          AS modelo_api_concorda,
+        COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
+
+        COALESCE(d.outcome_side IN ('Over', 'Under'), FALSE) AS porta_saida_catalogada,
+        COALESCE(d.pin_n_outcomes >= 2, FALSE)          AS porta_conjunto_completo,
+        FALSE                                           AS sem_lado_apostado
+    FROM devig d
+    LEFT JOIN prem_ou p
+        ON  p.fixture_id = d.fixture_id
+       AND  p.outcome    = d.outcome_side
+       AND  COALESCE(CAST(p.line_value AS STRING), 'NONE') = d.line_key
+    LEFT JOIN corro c
+        ON  c.market_id    = d.market_id
+       AND  c.fixture_id   = d.fixture_id
+       AND  c.outcome_side = d.outcome_side
+       AND  c.line_key     = d.line_key
+    WHERE d.market_id = 5
+),
+
+-- ============================================================================
+-- Ramo Handicap asiático (market_id=4). Saídas catalogadas: Home / Away.
+-- `line_value` é o handicap na ótica do MANDANTE e é o MESMO para Home e Away (par
+-- complementar). Completude = par da Pinnacle (pin_n_outcomes >= 2).
+-- ============================================================================
+cand_ah AS (
+    SELECT
+        d.fixture_id,
+        '{{ futebol_mercados_pontuados()[4] }}'         AS market,
+        d.outcome_side                                  AS outcome,
+        d.line_value,
+        d.line_key,
+        d.competition,
+        d.season,
+        d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
+
+        d.edge,
+        COALESCE(d.pts_valor, 0)                        AS pts_valor,
+        d.best_odd,
+        d.best_book,
+        d.avg_odd,
+        d.n_casas,
+        d.prob_justa_fechamento,
+        d.pin_n_outcomes,
+        d.n_outcomes_valor,
+        d.valor_fonte,
+        COALESCE(d.penalidades_globais_pts, 0)          AS penalidades_globais_pts,
+        d.pen_odd_outlier,
+        d.pen_poucas_casas,
+        d.pen_odd_longshot,
+        d.pen_odd_juice,
+
+        p.pts_premissas,
+        p.premissas_sem_dado,
+        p.penalidades_ah_pts                            AS penalidades_especificas_pts,
+
+        COALESCE(c.pts_corroboracao, 0)                 AS pts_corroboracao,
+        COALESCE(c.modelo_api_concorda, FALSE)          AS modelo_api_concorda,
+        COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
+
+        COALESCE(d.outcome_side IN ('Home', 'Away'), FALSE) AS porta_saida_catalogada,
+        COALESCE(d.pin_n_outcomes >= 2, FALSE)          AS porta_conjunto_completo,
+        FALSE                                           AS sem_lado_apostado
+    FROM devig d
+    LEFT JOIN prem_ah p
+        ON  p.fixture_id = d.fixture_id
+       AND  p.outcome    = d.outcome_side
+       AND  COALESCE(CAST(p.line_value AS STRING), 'NONE') = d.line_key
+    LEFT JOIN corro c
+        ON  c.market_id    = d.market_id
+       AND  c.fixture_id   = d.fixture_id
+       AND  c.outcome_side = d.outcome_side
+       AND  c.line_key     = d.line_key
+    WHERE d.market_id = 4
+),
+
+-- ============================================================================
+-- Ramo Ambos Marcam / BTTS (market_id=8). Saídas catalogadas: Yes / No.
+-- A Pinnacle NÃO precifica BTTS -> o valor vem do CONSENSO, e a completude é medida
+-- por `n_outcomes_valor >= 2` (o par Yes+No da mediana), não por pin_n_outcomes —
+-- que fica NULL aqui, honestamente.
+-- ============================================================================
+cand_btts AS (
+    SELECT
+        d.fixture_id,
+        '{{ futebol_mercados_pontuados()[8] }}'         AS market,
+        d.outcome_side                                  AS outcome,
+        CAST(NULL AS FLOAT64)                           AS line_value,
+        d.line_key,
+        d.competition,
+        d.season,
+        d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
+
+        d.edge,
+        COALESCE(d.pts_valor, 0)                        AS pts_valor,
+        d.best_odd,
+        d.best_book,
+        d.avg_odd,
+        d.n_casas,
+        d.prob_justa_fechamento,
+        d.pin_n_outcomes,
+        d.n_outcomes_valor,
+        d.valor_fonte,
+        COALESCE(d.penalidades_globais_pts, 0)          AS penalidades_globais_pts,
+        d.pen_odd_outlier,
+        d.pen_poucas_casas,
+        d.pen_odd_longshot,
+        d.pen_odd_juice,
+
+        p.pts_premissas,
+        p.premissas_sem_dado,
+        p.penalidades_btts_pts                          AS penalidades_especificas_pts,
+
+        COALESCE(c.pts_corroboracao, 0)                 AS pts_corroboracao,
+        COALESCE(c.modelo_api_concorda, FALSE)          AS modelo_api_concorda,
+        COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
+
+        COALESCE(d.outcome_side IN ('Yes', 'No'), FALSE) AS porta_saida_catalogada,
+        COALESCE(d.n_outcomes_valor >= 2, FALSE)        AS porta_conjunto_completo,
+        FALSE                                           AS sem_lado_apostado
+    FROM devig d
+    LEFT JOIN prem_btts p
+        ON  p.fixture_id = d.fixture_id
+       AND  p.outcome    = d.outcome_side
+    LEFT JOIN corro c
+        ON  c.market_id    = d.market_id
+       AND  c.fixture_id   = d.fixture_id
+       AND  c.outcome_side = d.outcome_side
+    WHERE d.market_id = 8
+),
+
+-- ============================================================================
+-- Ramo Dupla Chance (market_id=12). Saídas catalogadas: 1X / X2 — a "12" NÃO.
+--
+-- É AQUI que a segunda rejeição invisível vira linha. A DC é cotada em três saídas e o
+-- Motor pontua duas; o `INNER JOIN` com as premissas engolia a "12" (1.059 linhas, um
+-- terço exato do universo de DC, na foto de 19/08) antes de qualquer porta. Com o LEFT
+-- JOIN ela entra com `porta_saida_catalogada = FALSE`, que é o que ela é: uma decisão
+-- nossa de não pontuar, não uma ausência de mercado.
+--
+-- Completude = conjunto 1X2 DE ORIGEM completo (n_outcomes_valor >= 3): a prob justa da
+-- DC é derivada do de-vig 1X2 da Pinnacle. E a DC tem GATE DE ODD PRÓPRIO
+-- (best_odd >= 1,25), que hoje mora no `WHERE` do ramo do board e aqui é a
+-- `porta_odd_dc`.
+-- ============================================================================
+cand_dc AS (
+    SELECT
+        d.fixture_id,
+        '{{ futebol_mercados_pontuados()[12] }}'        AS market,
+        d.outcome_side                                  AS outcome,
+        CAST(NULL AS FLOAT64)                           AS line_value,
+        d.line_key,
+        d.competition,
+        d.season,
+        d.janela_usada,
+        d.janela_prioridade,
+        d.janela_e_corrente,
+
+        d.edge,
+        COALESCE(d.pts_valor, 0)                        AS pts_valor,
+        d.best_odd,
+        d.best_book,
+        d.avg_odd,
+        d.n_casas,
+        d.prob_justa_fechamento,
+        d.pin_n_outcomes,
+        d.n_outcomes_valor,
+        d.valor_fonte,
+        -- penalidades globais SEM o juice: o gate de odd próprio da DC (>= 1,25) já
+        -- garante o retorno mínimo. Idêntico ao ramo `joined_dc` do board — a paridade
+        -- exige a nota byte a byte, e o juice vale −10 pontos.
+        ( 30 * CAST(d.pen_odd_outlier  AS INT64)
+        + 12 * CAST(d.pen_poucas_casas AS INT64)
+        + 15 * CAST(d.pen_odd_longshot AS INT64) )      AS penalidades_globais_pts,
+        d.pen_odd_outlier,
+        d.pen_poucas_casas,
+        d.pen_odd_longshot,
+        FALSE                                           AS pen_odd_juice,
+
+        p.pts_premissas,
+        p.premissas_sem_dado,
+        -- A DC não tem penalidade específica (o gate de odd próprio já barra o retorno
+        -- baixo). É constante no board e é constante aqui — inclusive na "12", onde não
+        -- há premissa nenhuma para o LEFT JOIN trazer.
+        CAST(0 AS INT64)                                AS penalidades_especificas_pts,
+
+        COALESCE(c.pts_corroboracao, 0)                 AS pts_corroboracao,
+        COALESCE(c.modelo_api_concorda, FALSE)          AS modelo_api_concorda,
+        COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
+
+        COALESCE(d.outcome_side IN ('1X', 'X2'), FALSE) AS porta_saida_catalogada,
+        COALESCE(d.n_outcomes_valor >= 3, FALSE)        AS porta_conjunto_completo,
+        FALSE                                           AS sem_lado_apostado
+    FROM devig d
+    LEFT JOIN prem_dc p
+        ON  p.fixture_id = d.fixture_id
+       AND  p.outcome    = d.outcome_side
+    LEFT JOIN corro c
+        ON  c.market_id    = d.market_id
+       AND  c.fixture_id   = d.fixture_id
+       AND  c.outcome_side = d.outcome_side
+    WHERE d.market_id = 12
+),
+
+unioned AS (
+    SELECT * FROM cand_1x2
+    UNION ALL
+    SELECT * FROM cand_ou
+    UNION ALL
+    SELECT * FROM cand_ah
+    UNION ALL
+    SELECT * FROM cand_btts
+    UNION ALL
+    SELECT * FROM cand_dc
+),
+
+-- ============================================================================
+-- A NOTA, na mesma aritmética do board — de propósito, e essa é a decisão de risco
+-- desta entrega: a fórmula existe em dois lugares até o flip (passo 2), e é a guarda
+-- de paridade que impede as duas cópias de divergirem em silêncio.
+--
+-- `pts_premissas` e `penalidades_especificas_pts` NÃO levam COALESCE. Saída sem
+-- premissa (a "12" da DC) resolve a nota para NULL, e o NULL morre na `porta_nota`,
+-- que é NULL-safe. Somar zero no lugar diria que a linha foi avaliada e tirou zero —
+-- que é diferente de não ter sido avaliada, e é a distinção que a ADR 0003 preserva.
+-- ============================================================================
+scored AS (
+    SELECT
+        *,
+        (penalidades_globais_pts + penalidades_especificas_pts) AS penalidades,
+        LEAST(GREATEST(
+            pts_valor + pts_premissas + pts_corroboracao
+            - (penalidades_globais_pts + penalidades_especificas_pts), 0), 100) AS score,
+        -- linha "meia" (.5) é a única SEM push/meio-push. NULL onde não há linha.
+        (MOD(CAST(ROUND(ABS(line_value) * 2) AS INT64), 2) = 1) AS is_half_line
+    FROM unioned
+),
+
+-- ============================================================================
+-- AS OITO PORTAS. TRUE = passou. Cada uma é NULL-safe SOZINHA — insumo ausente
+-- reprova a porta em vez de propagar NULL para dentro da conjunção. É a degradação
+-- graciosa do Motor, e é o que impede o descarte silencioso que a ADR 0006 proíbe.
+--
+-- ⚠️ `porta_conjunto_completo` e `porta_valor_estimavel` são ANINHADAS: pela ADR 0002,
+-- conjunto incompleto implica prob justa ausente. As duas ficam mesmo assim, porque a
+-- leitura marginal é o produto da tabela — mas quem somar as duas como se fossem
+-- independentes conta a mesma linha duas vezes.
+-- ============================================================================
+com_portas AS (
+    SELECT
+        *,
+        (prob_justa_fechamento IS NOT NULL)                 AS porta_valor_estimavel,
+        COALESCE(n_casas >= 3, FALSE)                       AS porta_liquidez,
+        COALESCE(
+            edge > CASE
+                     -- edge de CONSENSO (o BTTS, que a Pinnacle não precifica) é
+                     -- enviesado p/ cima — best_odd é o MÁXIMO das casas contra a prob
+                     -- da MEDIANA — e por isso exige piso maior.
+                     WHEN valor_fonte = 'consenso' THEN {{ var('consensus_min_edge', 0.03) }}
+                     ELSE 0
+                   END,
+            FALSE)                                          AS porta_edge,
+        COALESCE(score >= 40, FALSE)                        AS porta_nota,
+        -- Handicap e Gols exigem linha meia (.5): nas outras o resultado pode dar
+        -- push/meio-push e o de-vig 2-way superdimensiona o edge. Mercado sem linha
+        -- passa trivialmente — não é isenção, é que a porta não se aplica.
+        COALESCE(
+            market NOT IN ('{{ futebol_mercados_pontuados()[4] }}',
+                           '{{ futebol_mercados_pontuados()[5] }}') OR is_half_line,
+            FALSE)                                          AS porta_linha_meia,
+        -- Gate de odd próprio da Dupla Chance. Trivialmente TRUE nos outros quatro.
+        COALESCE(
+            market <> '{{ futebol_mercados_pontuados()[12] }}' OR best_odd >= 1.25,
+            FALSE)                                          AS porta_odd_dc
+    FROM scored
+),
+
+-- ============================================================================
+-- A CONJUNÇÃO, e só ela. `passou_no_gate` é DERIVADO das oito colunas acima — nunca
+-- escrito à mão, nunca uma segunda cópia do gate do board. Se uma porta nova entrar,
+-- ela entra aqui e a conjunção a absorve.
+--
+-- `janela_e_corrente` NÃO está na conjunção (ADR 0011, D8): ela responde "qual janela
+-- publica", que é redução, não veredito de qualidade. Somá-la ao gate sujaria a
+-- aritmética do funil — toda taxa de rejeição passaria a incluir três janelas que
+-- ninguém rejeitou.
+--
+-- O EXPURGO também não está (ADR 0011): o funil guarda jogo encerrado de propósito.
+-- Quem filtra por status é o board.
+-- ============================================================================
+com_gate AS (
+    SELECT
+        *,
+        (   porta_saida_catalogada
+        AND porta_conjunto_completo
+        AND porta_valor_estimavel
+        AND porta_liquidez
+        AND porta_edge
+        AND porta_nota
+        AND porta_linha_meia
+        AND porta_odd_dc ) AS passou_no_gate
+    FROM com_portas
+)
+
+SELECT
+    fixture_id,
+    market,
+    outcome,
+    line_value,
+    janela_usada                AS janela,
+    janela_prioridade,
+    -- redução, não veredito: diz qual das quatro janelas o board publicaria. Quem for
+    -- contar o funil precisa FIXAR uma janela por candidato antes de contar — contando
+    -- as quatro, todo número infla até 4×.
+    janela_e_corrente,
+
+    competition,
+    season,
+    -- o kickoff é o eixo de todo horizonte, e é o que a próxima entrega usa para
+    -- congelar a linha no apito.
+    _fx_kickoff_utc             AS kickoff_utc,
+
+    -- ---------------------------------------------------------------- as oito portas
+    porta_saida_catalogada,
+    porta_conjunto_completo,
+    porta_valor_estimavel,
+    porta_liquidez,
+    porta_edge,
+    porta_nota,
+    porta_linha_meia,
+    porta_odd_dc,
+    passou_no_gate,
+
+    -- CONVENIÊNCIA DE LEITURA, NÃO FONTE (ADR 0006). Uma linha reprova em várias portas
+    -- ao mesmo tempo, e um campo único de motivo é vitória do primeiro da fila: ele
+    -- destrói exatamente a distinção que dá valor à tabela — quantas linhas a porta
+    -- remove SOZINHA contra quantas ela ainda remove DEPOIS das anteriores. Quem for
+    -- medir porta lê os booleanos; isto aqui serve para olhar uma linha e entender.
+    --
+    -- A ordem é a de leitura declarada na ADR 0011 (D5), e o empate tem lugar próprio
+    -- dentro da porta de nota: sem ele, um terço do universo do 1X2 apareceria como
+    -- "nota abaixo da régua" e a régua pareceria mais severa no 1X2 do que é.
+    CASE
+        WHEN NOT porta_saida_catalogada  THEN 'saida_nao_catalogada'
+        WHEN NOT porta_conjunto_completo THEN 'conjunto_incompleto'
+        WHEN NOT porta_valor_estimavel   THEN 'valor_nao_estimavel'
+        WHEN NOT porta_liquidez          THEN 'sem_liquidez'
+        WHEN NOT porta_edge              THEN 'sem_edge'
+        WHEN NOT porta_nota
+            THEN IF(sem_lado_apostado, 'sem_lado_apostado', 'nota_abaixo_da_regua')
+        WHEN NOT porta_linha_meia        THEN 'linha_nao_meia'
+        WHEN NOT porta_odd_dc            THEN 'odd_dc_abaixo_do_minimo'
+        ELSE NULL
+    END AS motivo_primario,
+
+    -- O empate do 1X2 — marca ESTRUTURAL, e não "a nota deu zero" (ADR 0005/0006).
+    sem_lado_apostado,
+
+    -- ------------------------------------------------------- componentes numéricos
+    edge,
+    pts_valor,
+    -- NULL onde não houve premissa a avaliar (a "12" da DC). Zero seria "foi avaliada e
+    -- tirou zero", que é outra coisa — ADR 0003.
+    pts_premissas,
+    pts_corroboracao,
+    penalidades_globais_pts,
+    penalidades_especificas_pts,
+    penalidades,
+    score,
+    -- quantas premissas aplicáveis à linha não puderam ser avaliadas por falta de
+    -- insumo (#41). Não entra na nota: é o que a nota NÃO pôde levar em conta.
+    premissas_sem_dado,
+
+    -- as quatro parcelas da penalidade global (#87). Na DC o juice é FALSE de propósito.
+    pen_odd_outlier,
+    pen_poucas_casas,
+    pen_odd_longshot,
+    pen_odd_juice,
+    -- as duas parcelas da corroboração — mesma lição da #87: parcela publicada é
+    -- parcela lida, em vez de readivinhada por uma chave que não desempata.
+    modelo_api_concorda,
+    linha_sharp_confirma,
+
+    -- ------------------------------------------------------------ contexto de odds
+    best_odd,
+    best_book,
+    avg_odd,
+    n_casas,
+    prob_justa_fechamento,
+    valor_fonte,
+    pin_n_outcomes,
+    n_outcomes_valor,
+    is_half_line,
+
+    CURRENT_TIMESTAMP() AS dbt_loaded_at
+FROM com_gate
+-- LEFT, nunca INNER: fixture ausente em `fact_fixtures` não pode sumir do funil — sumir
+-- seria a perda silenciosa que a tabela inteira existe para impedir, e quebraria a
+-- reconciliação contra o de-vig. O kickoff vem NULL e diz isso de si mesmo.
+LEFT JOIN fixtures USING (fixture_id)

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -80,7 +80,6 @@ cand_1x2 AS (
         '{{ futebol_mercados_pontuados()[1] }}'         AS market,
         d.outcome_side                                  AS outcome,
         CAST(NULL AS FLOAT64)                           AS line_value,
-        d.line_key,
         d.competition,
         d.season,
         d.janela_usada,
@@ -141,7 +140,6 @@ cand_ou AS (
         '{{ futebol_mercados_pontuados()[5] }}'         AS market,
         d.outcome_side                                  AS outcome,
         d.line_value,
-        d.line_key,
         d.competition,
         d.season,
         d.janela_usada,
@@ -199,7 +197,6 @@ cand_ah AS (
         '{{ futebol_mercados_pontuados()[4] }}'         AS market,
         d.outcome_side                                  AS outcome,
         d.line_value,
-        d.line_key,
         d.competition,
         d.season,
         d.janela_usada,
@@ -258,7 +255,6 @@ cand_btts AS (
         '{{ futebol_mercados_pontuados()[8] }}'         AS market,
         d.outcome_side                                  AS outcome,
         CAST(NULL AS FLOAT64)                           AS line_value,
-        d.line_key,
         d.competition,
         d.season,
         d.janela_usada,
@@ -323,7 +319,6 @@ cand_dc AS (
         '{{ futebol_mercados_pontuados()[12] }}'        AS market,
         d.outcome_side                                  AS outcome,
         CAST(NULL AS FLOAT64)                           AS line_value,
-        d.line_key,
         d.competition,
         d.season,
         d.janela_usada,
@@ -397,6 +392,15 @@ unioned AS (
 -- premissa (a "12" da DC) resolve a nota para NULL, e o NULL morre na `porta_nota`,
 -- que é NULL-safe. Somar zero no lugar diria que a linha foi avaliada e tirou zero —
 -- que é diferente de não ter sido avaliada, e é a distinção que a ADR 0003 preserva.
+--
+-- ⚠️ Isto NÃO contraria a regra do CODING_STANDARDS.md ("missing data must resolve to
+-- FALSE, never a NULL propagated into the Score"). Aquela regra é sobre INSUMO de
+-- premissa — degradação graciosa: dado ausente não acende a premissa, e é ela que
+-- resolve para FALSE. Aqui não falta insumo: falta a AVALIAÇÃO inteira, porque a saída
+-- não é catalogada. E o NULL não se propaga para dentro de veredito nenhum — todas as
+-- oito portas o absorvem individualmente, que é o que a regra existe para garantir.
+-- No board esta linha nem existia; só aqui ela precisa de um valor, e nenhum número
+-- seria honesto.
 -- ============================================================================
 scored AS (
     SELECT

--- a/dbt_futebol/tests/assert_funil_paridade_com_board.sql
+++ b/dbt_futebol/tests/assert_funil_paridade_com_board.sql
@@ -1,0 +1,98 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DE PARIDADE FUNIL x BOARD (#95, ADR 0011): a prova de que o funil descreve o
+-- board de verdade — tirada ANTES de qualquer um passar a depender dele.
+--
+-- Enquanto o passo 2 (o flip) não acontece, a nota e as portas existem em DOIS lugares: no
+-- `fact_value_opportunities`, onde são `WHERE`, e no `fact_value_funnel`, onde são coluna.
+-- Duas cópias da mesma aritmética divergem — é o que cópias fazem. Esta guarda é o que
+-- torna a divergência barulhenta em vez de muda, e ela é o motivo pelo qual a duplicação é
+-- aceitável nesta entrega.
+--
+-- Ela é **ASSIMÉTRICA DE PROPÓSITO**, e as duas direções valem coisas diferentes:
+--
+--   · DIREÇÃO 1 (vale sempre) — toda linha do board existe idêntica no funil, com a MESMA
+--     janela e a MESMA nota. Se o funil perder uma linha que o board publica, ou pontuá-la
+--     diferente, a leitura de "quanto rendeu a faixa descartada" está sendo feita sobre
+--     outra tabela que não a que o assinante viu;
+--
+--   · DIREÇÃO 2 (restrita) — o funil filtrado por `janela_e_corrente AND passou_no_gate`
+--     não tem linha fora do board **entre os fixtures que ainda não foram expurgados**.
+--     A restrição não é conveniência: o funil guarda jogo encerrado DE PROPÓSITO (ADR
+--     0011) e o board não (ADR 0009, #85). Sem ela, a guarda ficaria vermelha para sempre
+--     por acerto das duas tabelas, e guarda permanentemente vermelha morre ignorada.
+--
+-- O predicado do expurgo vem do macro `futebol_expurgo.sql`, o mesmo que o board usa —
+-- nunca copiado. Predicado copiado diverge, e aqui a divergência seria muda nos dois
+-- sentidos: mais frouxo e a guarda não acende, mais estrito e ela acende sem defeito.
+--
+-- ⚠️ O expurgo é função de `CURRENT_TIMESTAMP()`, e a guarda roda DEPOIS do build. Um jogo
+-- que cruzou a carência de 24 h entre o build do board e esta execução sai do lado do
+-- expurgo aqui e a linha é (corretamente) ignorada. A janela oposta — jogo que era
+-- expurgável no build e deixou de ser — só existe via PST/SUSP reabrindo, e nela a guarda
+-- acusa uma diferença real de conteúdo entre as duas tabelas.
+--
+-- ⚠️ ESTA GUARDA TEM DATA DE VALIDADE. No passo 2 o board passa a ser o funil filtrado, a
+-- paridade vira tautologia e ela é APOSENTADA no mesmo commit. Guarda que não pode falhar
+-- é ruído com cara de cobertura.
+
+WITH board AS (
+    SELECT
+        fixture_id,
+        market,
+        outcome,
+        COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
+        janela_usada                                    AS janela,
+        score
+    FROM {{ ref('fact_value_opportunities') }}
+),
+
+fixtures AS (
+    SELECT
+        fixture_id,
+        status_short AS _fx_status_short,
+        kickoff_utc  AS _fx_kickoff_utc
+    FROM {{ ref('fact_fixtures') }}
+),
+
+-- O funil na leitura que o board faria: janela corrente, gate aprovado, e — só para a
+-- direção 2 — sem os fixtures que o board expurga.
+funil_publicavel AS (
+    SELECT
+        f.fixture_id,
+        f.market,
+        f.outcome,
+        COALESCE(CAST(f.line_value AS STRING), 'NONE')  AS line_key,
+        f.janela,
+        f.score
+    FROM {{ ref('fact_value_funnel') }} f
+    -- LEFT + COALESCE(..., FALSE): fixture ausente é fail-open aqui pelo mesmo motivo que
+    -- é fail-open no board — a linha fica, e quem grita sobre fixture ausente é a
+    -- assert_board_sem_jogo_encerrado, que tem diagnóstico próprio para isso.
+    LEFT JOIN fixtures fx USING (fixture_id)
+    WHERE f.janela_e_corrente
+      AND f.passou_no_gate
+      AND NOT COALESCE(
+            {{ futebol_expurga_do_board('fx._fx_status_short', 'fx._fx_kickoff_utc') }},
+            FALSE
+          )
+)
+
+SELECT
+    *,
+    'linha publicada no board que o funil não reproduz (ausente, ou com janela/nota diferente) — as duas cópias da aritmética divergiram' AS diagnostico
+FROM (
+    SELECT * FROM board
+    EXCEPT DISTINCT
+    SELECT * FROM funil_publicavel
+)
+
+UNION ALL
+
+SELECT
+    *,
+    'linha que o funil publicaria e o board não publica, em fixture NÃO expurgado — o funil está mais frouxo que o board (porta virada coluna com predicado diferente?)' AS diagnostico
+FROM (
+    SELECT * FROM funil_publicavel
+    EXCEPT DISTINCT
+    SELECT * FROM board
+)

--- a/dbt_futebol/tests/assert_funil_paridade_com_board.sql
+++ b/dbt_futebol/tests/assert_funil_paridade_com_board.sql
@@ -31,9 +31,41 @@
 -- expurgável no build e deixou de ser — só existe via PST/SUSP reabrindo, e nela a guarda
 -- acusa uma diferença real de conteúdo entre as duas tabelas.
 --
+-- ⚠️ O QUE ELA NÃO COBRE, e é preciso dizer em voz alta: as duas direções comparam só o
+-- conjunto PUBLICÁVEL. Uma divergência de fórmula confinada às linhas REJEITADAS — que são
+-- justamente o produto novo desta tabela — passa por aqui em silêncio nas duas direções,
+-- porque nenhum dos dois lados as contém. Quem alcança essa região são os unit tests do
+-- `fact_value_funnel`, com linha construída. A guarda impede as duas cópias de divergirem
+-- onde o assinante enxerga; não onde a análise da [A] vai olhar.
+--
 -- ⚠️ ESTA GUARDA TEM DATA DE VALIDADE. No passo 2 o board passa a ser o funil filtrado, a
 -- paridade vira tautologia e ela é APOSENTADA no mesmo commit. Guarda que não pode falhar
 -- é ruído com cara de cobertura.
+
+-- "IDÊNTICA" É A PALAVRA DO ACEITE, ENTÃO A COMPARAÇÃO É O PAYLOAD INTEIRO, não só a
+-- chave e a nota. A nota agrega os componentes: `edge`, o contexto de odds e as quatro
+-- parcelas da penalidade podem divergir sem mover um ponto sequer — `pts_valor` é o edge
+-- passado por um `ROUND` de faixa, e três das quatro penalidades não mudam a soma se duas
+-- trocarem de lugar. Comparar a nota sozinha seria confiar num proxy que perde exatamente
+-- as parcelas que a #87 acabou de publicar para não serem readivinhadas.
+--
+-- ⚠️ `competition` e `season` entram, e têm PROVENIÊNCIA DIFERENTE nos dois lados: o board
+-- as tira das premissas, o funil do de-vig. Medido em 20/08, os dois concordam nos 391
+-- fixtures — zero divergência —, então incluí-las não custa nada hoje e o dia em que elas
+-- discordarem é um dia sobre o qual se quer saber (jogo cuja competição mudou entre a
+-- coleta da odd e o registro do fixture).
+--
+-- Ficam de fora as colunas que só existem de um lado: `faixa`, `evidencias`, `avisos` e
+-- `janela_deteccao` são do board (derivados ou de outra pergunta), `n_outcomes_valor`,
+-- `janela_prioridade` e as oito portas são do funil.
+{%- set payload = [
+    'edge', 'pts_valor', 'pts_premissas', 'premissas_sem_dado', 'pts_corroboracao',
+    'penalidades', 'penalidades_globais_pts', 'penalidades_especificas_pts',
+    'pen_odd_outlier', 'pen_poucas_casas', 'pen_odd_longshot', 'pen_odd_juice',
+    'modelo_api_concorda', 'linha_sharp_confirma',
+    'best_odd', 'best_book', 'avg_odd', 'n_casas', 'prob_justa_fechamento',
+    'valor_fonte', 'pin_n_outcomes', 'is_half_line', 'competition', 'season'
+] %}
 
 WITH board AS (
     SELECT
@@ -42,7 +74,8 @@ WITH board AS (
         outcome,
         COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
         janela_usada                                    AS janela,
-        score
+        score,
+        {{ payload | join(',\n        ') }}
     FROM {{ ref('fact_value_opportunities') }}
 ),
 
@@ -63,7 +96,8 @@ funil_publicavel AS (
         f.outcome,
         COALESCE(CAST(f.line_value AS STRING), 'NONE')  AS line_key,
         f.janela,
-        f.score
+        f.score,
+        f.{{ payload | join(',\n        f.') }}
     FROM {{ ref('fact_value_funnel') }} f
     -- LEFT + COALESCE(..., FALSE): fixture ausente é fail-open aqui pelo mesmo motivo que
     -- é fail-open no board — a linha fica, e quem grita sobre fixture ausente é a

--- a/dbt_futebol/tests/assert_funil_reconcilia_com_devig.sql
+++ b/dbt_futebol/tests/assert_funil_reconcilia_com_devig.sql
@@ -1,0 +1,70 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DE RECONCILIAÇÃO DO FUNIL (#95, ADR 0011): o universo do `fact_value_funnel` é
+-- exatamente o conjunto de candidatos do `int_futebol_odds_devig` nos cinco mercados
+-- pontuados, nas quatro janelas. Nem uma linha a mais, nem uma a menos.
+--
+-- ⚠️ ELA LÊ A FONTE, NUNCA O PRÓPRIO FUNIL — e essa é a decisão inteira desta guarda.
+-- A versão tentadora seria somar as rejeições do funil e comparar com o total do funil:
+-- ela FECHA SEMPRE, porque as duas parcelas saem da mesma tabela. É a armadilha que a
+-- costura B da task [F] já pagou uma vez: guarda que lê o próprio produto não é guarda,
+-- é uma segunda cópia da exclusão.
+--
+-- O que ela pega, em cada direção:
+--
+--   · candidato do de-vig SEM linha no funil — algum join do modelo virou INNER sem
+--     querer, ou um `WHERE` voltou a existir dentro de um ramo. É o modo de falha que a
+--     tabela existe para impedir: a rejeição vira sumiço de novo, e o número publicado
+--     parece certo;
+--   · linha no funil SEM candidato no de-vig — fan-out. Os joins com as premissas e com
+--     a corroboração são um-para-um por construção; se um deles duplicar (grão a montante
+--     mudou, chave nova apareceu), toda taxa de rejeição do funil passa a ter denominador
+--     inflado, e em silêncio.
+--
+-- A comparação é por CHAVE (EXCEPT DISTINCT nos dois sentidos), não por contagem: duas
+-- contagens iguais convivem confortavelmente com um erro que tira uma linha de um lado e
+-- põe outra do outro.
+--
+-- ⚠️ Ponto cego declarado, o de sempre (ADR 0005, subtask C4): até a C4 fechar, o job do
+-- agendado devolve sucesso mesmo com esta guarda vermelha. Ela encurta o tempo até alguém
+-- saber; não impede a tabela errada de ser publicada.
+
+WITH fonte AS (
+    SELECT
+        fixture_id,
+        {{ futebol_market_slug('market_id') }}          AS market,
+        outcome_side                                    AS outcome,
+        COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
+        janela_usada                                    AS janela
+    FROM {{ ref('int_futebol_odds_devig') }}
+    WHERE market_id IN ({{ futebol_mercados_pontuados_ids() }})
+),
+
+funil AS (
+    SELECT
+        fixture_id,
+        market,
+        outcome,
+        COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
+        janela
+    FROM {{ ref('fact_value_funnel') }}
+)
+
+SELECT
+    *,
+    'candidato do de-vig que não virou linha no funil — algum ramo voltou a filtrar (INNER JOIN ou WHERE), e a rejeição virou sumiço de novo' AS diagnostico
+FROM (
+    SELECT * FROM fonte
+    EXCEPT DISTINCT
+    SELECT * FROM funil
+)
+
+UNION ALL
+
+SELECT
+    *,
+    'linha no funil sem candidato correspondente no de-vig — fan-out num dos joins do modelo; o denominador de toda taxa de rejeição está inflado' AS diagnostico
+FROM (
+    SELECT * FROM funil
+    EXCEPT DISTINCT
+    SELECT * FROM fonte
+)


### PR DESCRIPTION
O `fact_value_opportunities` guarda só o que passa, e por isso as duas maiores rejeições do
sistema hoje não são rejeição — são **sumiço**. O conjunto de saídas incompleto sai num
`WHERE` dentro do join de cada ramo, antes de qualquer nota; e a saída **"12"** da Dupla
Chance, precificada e não pontuada, é engolida pelo `INNER JOIN` com as premissas. Sem elas
gravadas não existe linha de base contra a qual medir as portas que a [A] vai mudar.

Entra o **`fact_value_funnel`**: uma linha por `(fixture, mercado, saída, linha, janela)` que
teve preço, nos cinco mercados pontuados, com **uma coluna booleana por porta** e nada
filtrado. Os `WHERE` de completude viram coluna e o `INNER JOIN` com as premissas vira `LEFT
JOIN` — é essa inversão que faz as duas rejeições existirem como linha carimbada.

**O board não muda nesta entrega.** `fact_value_opportunities.sql` não foi tocado; o que a
entrega acrescenta é a tabela **mais a prova** de que ela descreve o board de verdade, antes
de qualquer um passar a depender dela.

## O que tem dentro

| arquivo | o que é |
|---|---|
| `models/marts/fact_value_funnel.sql` | o funil |
| `macros/futebol_funil.sql` | os 5 mercados pontuados e o mapa `market_id → market`, num lugar só |
| `models/marts/_fact_value_funnel.yml` | descrição, colunas, `accepted_values`, grão de 5 colunas com `tag:guarda` |
| `models/marts/_fact_value_funnel__unit_tests.yml` | 3 unit tests, 17 linhas construídas |
| `tests/assert_funil_reconcilia_com_devig.sql` | universo = candidatos do de-vig, lendo a **fonte** |
| `tests/assert_funil_paridade_com_board.sql` | board ≡ funil filtrado, assimétrica de propósito |

`passou_no_gate` é a **conjunção derivada** das oito portas, nunca escrita à mão.
`motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte.
Cada porta é NULL-safe **individualmente** — insumo ausente reprova a porta em vez de propagar
`NULL` para dentro da conjunção.

Ficam **fora** da conjunção, de propósito: `janela_e_corrente` (redução, não veredito — ADR
0011 D8) e o expurgo do board (o funil guarda jogo encerrado; é ele que responde quanto rendeu
a faixa descartada). O empate do 1X2 carrega marca própria (`sem_lado_apostado`) para que o
terço do universo do 1X2 que está em zero **por construção** não seja lido como severidade da
régua.

## O que foi medido, contra produção

Sem materializar nada — `dbt compile` + `bq query` sobre o SQL compilado, porque `dev` e `prod`
apontam para o mesmo dataset e rodar o mart na máquina **é** produção (ADR 0007).

| | |
|---|---|
| universo | **94.699 linhas / 391 fixtures** |
| conjunto incompleto | **46.463 (49,1%)** — a spec media 49% em 19/08 |
| saída "12" da DC | **1.098** — um terço exato do universo de DC |
| empates do 1X2 | **1.098** |
| `passou_no_gate` NULL | **0** |
| reconciliação com o de-vig | **0 e 0** (`EXCEPT DISTINCT` nos dois sentidos) |
| paridade com o board | **0 e 0**, sobre a chave, a janela, a nota e 24 colunas de payload |

## Falsificado antes de ficar verde

Guarda que nunca ficou vermelha não está provada. Os 3 unit tests foram falsificados um a um
(tirar o `COALESCE` de uma porta, pôr `janela_e_corrente` na conjunção, catalogar a "12"), e as
duas guardas levaram quatro defeitos injetados:

| defeito injetado no modelo | guarda | linhas |
|---|---|---|
| funil perde o mercado 12 inteiro | reconciliação | 3.294 |
| nota do funil diverge do board em 1 ponto | paridade | 13 |
| porta de nota mais frouxa (30 em vez de 40) | paridade | 12 |
| `UPPER(best_book)` só no funil — payload diverge, **nota não se move** | paridade | 12 |

O quarto é a razão de a paridade comparar o payload inteiro e não só a nota: sob a comparação
por `(chave, janela, nota)` ele passava verde.

## Duas coisas declaradas, para não serem lidas como esquecimento

- **Materialização `table`, não incremental.** O append-only com congelamento no apito (ADR
  0011) é a **próxima** entrega, como o próprio #95 diz. Como a tabela nasce cobrindo desde a
  primeira odd coletada (16/06), o backfill sai de graça. Pelo mesmo motivo, os carimbos
  `gravado_em`/`origem` (D11) vão com o append-only: numa tabela reconstruída eles mentiriam.
- **"Denominador zero explícito antes da divisão"** — não existe divisão nenhuma nesta entrega;
  o denominador chega com a **A6**. O que o critério pede hoje é a metade que existe: a marca
  estrutural `sem_lado_apostado` e uma nota do empate que é **número, nunca `NULL`** (unit test
  fixture 12, nota 20).

## ⚠️ Depois do merge, nesta ordem

1. **Redeployar os workflows** — tech-lamjav/data-engineering#46, e depois `gcloud workflows deploy`. Editar
   o YML não muda o workflow vivo.
2. **`./build-and-push.sh dbt_futebol`** — mergear não é deployar.

**A ordem importa e é o contrário do que parece.** As guardas viajam na imagem e o agendado as
roda por `tag:guarda`; o modelo só é construído se estiver no selector do workflow **vivo**.
Imagem nova + workflow velho = as duas guardas vermelhas sobre uma tabela que não existe. A
ordem inversa é inócua: selector que nomeia modelo ausente da imagem é aviso do dbt, exit 0
(verificado). Entre o merge e o `build-and-push` também está limpo — a imagem velha não tem nem
o modelo nem as guardas.

O CI não roda `dbt test` (só `dbt docs generate`), então nada aqui o afeta.

## Fora de escopo, mas achado no caminho

`is_half_line` usa `ROUND(ABS(line_value) * 2)`, e o BigQuery arredonda meio para longe do
zero: **linha `.25` sai como `TRUE`**. São **18.809 linhas** de Handicap/Gols em `.25` no
de-vig, que o board trata como se não tivessem meio-push — o oposto do que a #2 diz
(*"FALSE p/ linha cheia (2.0) e quarter"*). A expressão foi copiada **verbatim** de propósito:
consertá-la aqui seria mudar uma porta, que é não-objetivo declarado da A7, e quebraria a
paridade. Vale issue própria — ela afeta os dois marts igualmente, então a paridade fica verde
de qualquer jeito.

## Não toca

Supabase: sem migração, sem RPC, sem `check_schema_parity`. O app não lê funil (ADR 0006/0011).

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
