### PR TITLE
fix(futebol): a linha de quarto deixa de ser classificada como meia

### DIFF
--- a/dbt_futebol/analyses/taskA_linha_de_base.sql
+++ b/dbt_futebol/analyses/taskA_linha_de_base.sql
@@ -25,6 +25,15 @@
     que leem movimento de odd. É a decisão D1 da spec, ainda pendente de confirmação —
     por isso as duas notas saem lado a lado em vez de uma escolhida.
 
+    ⚠ `passa_meia_linha` MUDOU na #101 e os números da entrega original não se reproduzem.
+    Ela tinha uma cópia da expressão do board, que classificava linha de QUARTO (.25) como
+    meia; hoje chama `futebol_e_linha_meia()`, o mesmo predicado que os dois marts. Esta
+    análise declara, na primeira linha, que "reproduz os 5 ramos do
+    `fact_value_opportunities`" — se o board conserta e ela não, ela para de cumprir o
+    próprio contrato. Consequência: a leitura de "quantas linhas a porta de meia linha
+    remove" era subestimada, e rerodar agora dá número maior. É o mesmo tipo de
+    rebaselinamento da #82.
+
     Rodar com:
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_linha_de_base
       bq query --use_legacy_sql=false < ../target/compiled/dbt_futebol/analyses/taskA_linha_de_base.sql
@@ -97,7 +106,7 @@ ramo_ou AS (
         d.best_odd, d.n_casas, d.prob_justa_fechamento, d.valor_fonte, d.edge,
         COALESCE(c.pts_corroboracao, 0) AS pts_corroboracao,
         COALESCE(d.pin_n_outcomes >= 2, FALSE)            AS passa_completude,
-        COALESCE(MOD(CAST(ROUND(ABS(p.line_value) * 2) AS INT64), 2) = 1, FALSE) AS passa_meia_linha
+        COALESCE({{ futebol_e_linha_meia('p.line_value') }}, FALSE) AS passa_meia_linha
     FROM {{ ref('int_futebol_premissas_ou') }} p
     JOIN board b        ON b.fixture_id = p.fixture_id
     JOIN devig d        ON d.market_id = 5 AND d.fixture_id = p.fixture_id AND d.outcome_side = p.outcome
@@ -129,7 +138,7 @@ ramo_ah AS (
         d.best_odd, d.n_casas, d.prob_justa_fechamento, d.valor_fonte, d.edge,
         COALESCE(c.pts_corroboracao, 0) AS pts_corroboracao,
         COALESCE(d.pin_n_outcomes >= 2, FALSE)            AS passa_completude,
-        COALESCE(MOD(CAST(ROUND(ABS(p.line_value) * 2) AS INT64), 2) = 1, FALSE) AS passa_meia_linha
+        COALESCE({{ futebol_e_linha_meia('p.line_value') }}, FALSE) AS passa_meia_linha
     FROM {{ ref('int_futebol_premissas_ah') }} p
     JOIN board b        ON b.fixture_id = p.fixture_id
     JOIN devig d        ON d.market_id = 4 AND d.fixture_id = p.fixture_id AND d.outcome_side = p.outcome

--- a/dbt_futebol/macros/futebol_linha_meia.sql
+++ b/dbt_futebol/macros/futebol_linha_meia.sql
@@ -1,0 +1,70 @@
+{#-
+  A PORTA DA LINHA MEIA, declarada num lugar só (issue #101).
+
+  Handicap asiático e Gols O/U têm LINHA, e o quarto da linha decide o que acontece com a
+  aposta quando o placar bate nela:
+
+    · x.0   linha cheia  — o placar pode bater exatamente: PUSH, a aposta inteira volta.
+    · x.25  linha de quarto — metade em x.0 e metade em x.5: MEIO-PUSH.
+    · x.5   linha meia   — o placar não pode bater: a aposta ganha ou perde, nunca volta.
+    · x.75  linha de quarto — metade em x.5 e metade em x1.0: MEIO-PUSH.
+
+  Só a **meia** é resolvida em duas saídas exaustivas. É por isso que a porta existe: o
+  de-vig é 2-way e normaliza as probabilidades sobre Over/Under (ou Home/Away) como se
+  fossem as únicas saídas possíveis. Quando parte da aposta pode voltar como push, essa
+  normalização superdimensiona o edge — o número publicado descreve uma aposta que não é
+  a que o usuário faria.
+
+  ⚠️ O DEFEITO QUE ESTE MACRO CONSERTA (#101). A expressão anterior comparava em MEIOS:
+
+      MOD(CAST(ROUND(ABS(line_value) * 2) AS INT64), 2) = 1
+
+  e o BigQuery arredonda **meio para longe do zero** (`ROUND(0.5) = 1`). Então:
+
+      | line_value | ABS*2 | ROUND | MOD 2 | resultado | correto? |
+      |------------|-------|-------|-------|-----------|----------|
+      | x.0        | 0.0   | 0     | 0     | false     | ✅       |
+      | x.25       | 0.5   | 1     | 1     | TRUE      | ❌       |
+      | x.5        | 1.0   | 1     | 1     | true      | ✅       |
+      | x.75       | 1.5   | 2     | 0     | false     | ✅ (por sorte) |
+
+  A linha de quarto `.25` era classificada como meia e entrava no gate como se não
+  tivesse push. Medido no `int_futebol_odds_devig` em 20/08/2026, mercados 4 e 5:
+  **18.809 linhas** de `.25` contra 29.260 de `.5`. E no histórico já publicado,
+  **78 das 234 chaves (33,3%)** do `fact_value_opportunities_hist` estão numa linha de
+  quarto. O `.75` acertava por acidente aritmético, não por construção.
+
+  ⚠️ E O DEFEITO NÃO SE VÊ NO NÚMERO. As linhas de quarto aparecem com edge publicado
+  ligeiramente MENOR que as de meia (3,47% vs 4,33% em Gols; 3,44% vs 3,77% em Handicap).
+  A inflação é do edge publicado contra o valor VERDADEIRO, nunca contra o edge das `.5` —
+  as duas populações são indistinguíveis na tela, e nada no número denuncia que numa delas
+  parte do risco pode voltar como push.
+
+  Comparar em QUARTOS em vez de meios torna o `.75` correto por construção, e não por
+  sorte: em quartos, `resto 2` é a definição de meia, e nenhum dos outros três restos
+  ({0, 1, 3}) pode ser alcançado por arredondamento a partir dela.
+
+  ⚠️ POR QUE MACRO E NÃO SQL NO MODELO — e esta é a lição que o próprio defeito ensinou:
+  a expressão tinha TRÊS cópias (`fact_value_opportunities`, `fact_value_funnel` e a
+  análise `taskA_linha_de_base`), e o funil nasceu com o defeito porque copiou a
+  expressão do board **byte a byte**, de propósito, para que a guarda
+  `assert_funil_paridade_com_board` pudesse provar que o funil descreve o board. Predicado
+  copiado é predicado que diverge no primeiro refactor — e aqui a divergência seria muda:
+  a paridade continuaria verde comparando dois erros iguais. Com um macro só, os três não
+  têm como discordar. É a mesma razão de `futebol_expurgo.sql`.
+
+  ⚠️ NULL É NULL, DE PROPÓSITO. Mercado sem linha (1X2 / BTTS / Dupla Chance) tem
+  `line_value` NULL e o predicado resolve para NULL — não para FALSE. A porta não se
+  aplica a esses mercados; quem a consome escreve `market NOT IN (...) OR is_half_line`,
+  e o `COALESCE(..., FALSE)` fica no CONSUMIDOR, onde a degradação graciosa do Motor
+  pertence. Resolver aqui para FALSE apagaria a diferença entre "esta linha pode dar push"
+  e "este mercado não tem linha".
+-#}
+
+{#-
+  TRUE = a linha é meia (.5) e não pode dar push nem meio-push.
+  NULL onde não há linha. `coluna` é a expressão já qualificada pelo chamador.
+-#}
+{% macro futebol_e_linha_meia(coluna) -%}
+    (MOD(CAST(ROUND(ABS({{ coluna }}) * 4) AS INT64), 4) = 2)
+{%- endmacro %}

--- a/dbt_futebol/models/marts/_fact_value_funnel.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel.yml
@@ -158,7 +158,7 @@ models:
               arguments:
                 values: ['pinnacle', 'consenso']
       - name: is_half_line
-        description: "TRUE se a linha é meia (.5); FALSE p/ cheia/quarter; NULL onde não há linha. Insumo cru da `porta_linha_meia`."
+        description: "TRUE só se a linha é meia (.5); FALSE p/ cheia (x.0) e p/ os DOIS quartos (.25 e .75); NULL onde não há linha. Insumo cru da `porta_linha_meia`. Predicado em `futebol_e_linha_meia()`; até a #101 a linha de quarto .25 saía TRUE aqui."
       - name: pen_odd_outlier
         description: "Parcela da penalidade global: best_odd >= 1,10 × média das OUTRAS casas (−30)."
       - name: pen_poucas_casas

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -265,3 +265,94 @@ unit_tests:
         - {fixture_id: 20, janela: 't24h',  janela_e_corrente: false, porta_liquidez: true,  porta_edge: true,  passou_no_gate: true}
         - {fixture_id: 20, janela: 't1h',   janela_e_corrente: false, porta_liquidez: true,  porta_edge: true,  passou_no_gate: true}
         - {fixture_id: 20, janela: 't15m',  janela_e_corrente: true,  porta_liquidez: true,  porta_edge: false, passou_no_gate: false}
+
+  # ---------------------------------------------------------------------------
+  # 4. A PORTA DA LINHA MEIA, QUARTO A QUARTO (#101).
+  #
+  # O teste 1 cobre a porta com UM caso (a linha cheia 2.0) e ela passa. Isso não
+  # prova a porta: `is_half_line` era `MOD(ROUND(ABS(line_value) * 2), 2) = 1`, e o
+  # BigQuery arredonda **meio para longe do zero** — então `.25` virava `0.5 -> 1` e a
+  # linha de QUARTO era classificada como meia. Medido em 20/08/2026 no de-vig,
+  # mercados 4 e 5: 18.809 linhas de `.25` entravam no gate como se não tivessem push.
+  # O `.75` escapava por sorte (arredonda para cima e cai no par).
+  #
+  # A porta existe porque em linha não-meia parte da aposta pode voltar como push e o
+  # de-vig 2-way normaliza sobre duas saídas que NÃO são exaustivas. Na linha de quarto
+  # isso vale igual — ela é metade da aposta em cada uma das duas linhas vizinhas.
+  #
+  # Por isso o caso de teste é a TABELA INTEIRA, e não mais um caso: só os quatro
+  # quartos juntos separam "a porta está certa" de "a porta acerta o .5 e o 2.0". A
+  # linha negativa está aqui porque é assim que se escreve Handicap asiático, e o `ABS`
+  # é a única razão de ela funcionar.
+  # ---------------------------------------------------------------------------
+  - name: funil_linha_meia_e_por_quarto_de_linha
+    model: fact_value_funnel
+    description: >
+      Os quatro quartos de linha (.0, .25, .5, .75) em Gols O/U, uma linha de quarto
+      NEGATIVA em Handicap, e um mercado sem linha. Só `.5` é meia; linha de quarto pode
+      dar push e reprova. Antes da #101 o `.25` passava.
+    given:
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # -- 30: linha CHEIA. Push inteiro possível. ---------------------------------
+          - {fixture_id: 30, competition: 'brasileirao', season: 2026, market_id: 5, outcome_side: 'Over', line_value: 2.0, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 31: linha de QUARTO. É O CASO DA #101 — passava como se fosse meia. -----
+          - {fixture_id: 31, competition: 'brasileirao', season: 2026, market_id: 5, outcome_side: 'Over', line_value: 2.25, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 32: linha MEIA. A única sem push nem meio-push — a que a porta deixa passar.
+          - {fixture_id: 32, competition: 'brasileirao', season: 2026, market_id: 5, outcome_side: 'Over', line_value: 2.5, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 33: o outro QUARTO. Já reprovava — mas por sorte do arredondamento, não por
+          # construção. Fica no teste para continuar reprovando pelo motivo certo.
+          - {fixture_id: 33, competition: 'brasileirao', season: 2026, market_id: 5, outcome_side: 'Over', line_value: 2.75, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 34: quarto NEGATIVO, em Handicap. É a forma normal de escrever handicap, e
+          # a única coisa que a faz funcionar é o `ABS`.
+          - {fixture_id: 34, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Home', line_value: -0.25, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+          # -- 35: mercado SEM linha. `is_half_line` tem de continuar NULL (não FALSE): a
+          # porta não se aplica e passa trivialmente. Não é isenção.
+          - {fixture_id: 35, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      - input: ref('int_futebol_premissas_ou')
+        format: sql
+        rows: |
+          SELECT 30 AS fixture_id, 'Over' AS outcome, 2.0 AS line_value,
+                 15 AS pts_premissas, 0 AS premissas_sem_dado, 0 AS penalidades_ou_pts
+          UNION ALL SELECT 31, 'Over', 2.25, 15, 0, 0
+          UNION ALL SELECT 32, 'Over', 2.5,  15, 0, 0
+          UNION ALL SELECT 33, 'Over', 2.75, 15, 0, 0
+
+      - input: ref('int_futebol_premissas_ah')
+        format: sql
+        rows: |
+          SELECT 34 AS fixture_id, 'Home' AS outcome, -0.25 AS line_value,
+                 15 AS pts_premissas, 0 AS premissas_sem_dado, 0 AS penalidades_ah_pts
+
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 35 AS fixture_id, 'Home' AS outcome, 15 AS pts_premissas,
+                 0 AS premissas_sem_dado, 0 AS penalidades_1x2_pts
+
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          SELECT id AS fixture_id, TIMESTAMP '2099-01-01 00:00:00+00' AS kickoff_utc
+          FROM UNNEST([30,31,32,33,34,35]) AS id
+
+    expect:
+      rows:
+        - {fixture_id: 30, market: 'goals_over_under', is_half_line: false, porta_linha_meia: false, passou_no_gate: false, motivo_primario: 'linha_nao_meia'}
+        - {fixture_id: 31, market: 'goals_over_under', is_half_line: false, porta_linha_meia: false, passou_no_gate: false, motivo_primario: 'linha_nao_meia'}
+        - {fixture_id: 32, market: 'goals_over_under', is_half_line: true,  porta_linha_meia: true,  passou_no_gate: true,  motivo_primario: }
+        - {fixture_id: 33, market: 'goals_over_under', is_half_line: false, porta_linha_meia: false, passou_no_gate: false, motivo_primario: 'linha_nao_meia'}
+        - {fixture_id: 34, market: 'asian_handicap',   is_half_line: false, porta_linha_meia: false, passou_no_gate: false, motivo_primario: 'linha_nao_meia'}
+        - {fixture_id: 35, market: 'match_winner',     is_half_line: ,      porta_linha_meia: true,  passou_no_gate: true,  motivo_primario: }

--- a/dbt_futebol/models/marts/_fact_value_opportunities.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities.yml
@@ -46,7 +46,7 @@ models:
       - name: line_value
         description: "NULL no 1X2, BTTS e Dupla Chance; a linha L (1.5/2.5/3.5/...) no Gols O/U; o handicap (ótica do mandante, mesmo p/ Home e Away) no Handicap asiático."
       - name: is_half_line
-        description: "TRUE se a linha é meia (.5, sem push/meio-push); FALSE p/ linha cheia/quarter; NULL onde não há linha (1X2/BTTS/DC). O gate só materializa asian_handicap/goals_over_under quando is_half_line (#2 — evita edge superdimensionado por push ignorado)."
+        description: "TRUE só se a linha é meia (.5, a única sem push nem meio-push); FALSE p/ linha cheia (x.0) e p/ os DOIS quartos (.25 e .75, que dão meio-push); NULL onde não há linha (1X2/BTTS/DC). O gate só materializa asian_handicap/goals_over_under quando is_half_line (#2 — evita edge superdimensionado por push ignorado). Predicado em `futebol_e_linha_meia()`; até a #101 a linha de quarto .25 saía TRUE aqui."
       - name: valor_fonte
         description: "Fonte do de-vig/edge: 'pinnacle' (mercados 1/4/5 da Pinnacle; e Dupla Chance, derivada do 1X2 da Pinnacle) ou 'consenso' (mediana das casas — BTTS, pois a Pinnacle não precifica; rotular como estimativa no front; exige edge>=consensus_min_edge no gate). #1"
         tests:

--- a/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities__unit_tests.yml
@@ -209,3 +209,76 @@ unit_tests:
         # do fim — é a ausência de placar que a carência existe para cobrir, e a linha
         # sai. "Não sei que jogo é este" e "sei qual é e ninguém carimbou o fim" não
         # podem ter o mesmo destino.
+
+  # ---------------------------------------------------------------------------
+  # A PORTA DA LINHA MEIA, NO BOARD (#101).
+  #
+  # O gêmeo deste caso vive no funil (`funil_linha_meia_e_por_quarto_de_linha`), e
+  # até aqui era o ÚNICO: os dois unit tests do board são 100% 1X2, com `line_value`
+  # vazio em toda linha mockada, então o modelo que serve o usuário não tinha
+  # nenhuma linha construída exercitando esta porta.
+  #
+  # Hoje os dois marts não têm como divergir — chamam o mesmo
+  # `futebol_e_linha_meia()` —, e `assert_funil_paridade_com_board` pegaria a
+  # divergência nas linhas publicadas. Mas a paridade é declaradamente temporária: o
+  # plano é o board passar a LER do funil, e nesse dia a guarda se aposenta e o funil
+  # deixa de ser um segundo cálculo. Este teste é o que sobra quando isso acontecer.
+  #
+  # E a asserção aqui é diferente da do funil, de propósito. O funil grava o veredito
+  # de cada porta e responde "por que reprovou"; o board só responde "aparece ou
+  # não". A linha de quarto SUMIR do board é a consequência que o usuário vê, e é ela
+  # que precisa estar presa.
+  # ---------------------------------------------------------------------------
+  - name: value_opportunities_linha_de_quarto_nao_chega_ao_board
+    model: fact_value_opportunities
+    description: >
+      Três candidatos de Gols O/U idênticos fora da linha — cheia (2.0), de quarto
+      (2.25) e meia (2.5). Só a meia é publicada. Antes da #101 a de quarto entrava no
+      board como se não pudesse dar push.
+    given:
+      - input: ref('int_futebol_premissas_ou')
+        format: sql
+        rows: |
+          SELECT 20 AS fixture_id, 'Over' AS outcome, 2.0 AS line_value,
+                 'brasileirao' AS competition, 2026 AS season,
+                 15 AS pts_premissas, 0 AS premissas_sem_dado,
+                 0 AS penalidades_ou_pts,
+                 CAST([] AS ARRAY<STRING>) AS evidencias,
+                 CAST([] AS ARRAY<STRING>) AS avisos
+          UNION ALL SELECT 21, 'Over', 2.25, 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+          UNION ALL SELECT 22, 'Over', 2.5, 'brasileirao', 2026, 15, 0, 0,
+                 CAST([] AS ARRAY<STRING>), CAST([] AS ARRAY<STRING>)
+
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          - {fixture_id: 20, market_id: 5, outcome_side: 'Over', line_value: 2.0, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 21, market_id: 5, outcome_side: 'Over', line_value: 2.25, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 22, market_id: 5, outcome_side: 'Over', line_value: 2.5, janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      - input: ref('int_futebol_premissas_1x2')
+        rows: []
+      - input: ref('int_futebol_premissas_ah')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+
+      # Os três futuros e 'NS': ninguém pode morrer pela fronteira do expurgo sem que
+      # a asserção abaixo mude de significado em silêncio.
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          SELECT id AS fixture_id, 'NS' AS status_short,
+                 TIMESTAMP '2099-01-01 00:00:00+00' AS kickoff_utc
+          FROM UNNEST([20,21,22]) AS id
+
+    expect:
+      rows:
+        # Só a linha MEIA. A cheia (20) e a de quarto (21) não aparecem — nas duas
+        # parte da aposta pode voltar como push, e o de-vig 2-way superdimensiona o
+        # edge. A 21 é a que passava antes da #101.
+        - {fixture_id: 22, market: 'goals_over_under', outcome: 'Over', line_value: 2.5, is_half_line: true, score: 45}

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -410,7 +410,9 @@ scored AS (
             pts_valor + pts_premissas + pts_corroboracao
             - (penalidades_globais_pts + penalidades_especificas_pts), 0), 100) AS score,
         -- linha "meia" (.5) é a única SEM push/meio-push. NULL onde não há linha.
-        (MOD(CAST(ROUND(ABS(line_value) * 2) AS INT64), 2) = 1) AS is_half_line
+        -- O predicado mora em `futebol_linha_meia.sql`, e não aqui, porque foi copiá-lo
+        -- byte a byte do board que trouxe o defeito do `.25` para esta tabela (#101).
+        {{ futebol_e_linha_meia('line_value') }} AS is_half_line
     FROM unioned
 ),
 

--- a/dbt_futebol/models/marts/fact_value_opportunities.sql
+++ b/dbt_futebol/models/marts/fact_value_opportunities.sql
@@ -363,9 +363,12 @@ scored AS (
         LEAST(GREATEST(
             pts_valor + pts_premissas + pts_corroboracao
             - (penalidades_globais_pts + penalidades_especificas_pts), 0), 100) AS score,
-        -- #2: linha "meia" (.5) é a única SEM push/meio-push. line_value*2 ímpar => meia.
-        -- TRUE só p/ .5; FALSE p/ linha cheia (2.0) e quarter; NULL onde não há linha (1X2/BTTS/DC).
-        (MOD(CAST(ROUND(ABS(line_value) * 2) AS INT64), 2) = 1) AS is_half_line
+        -- #2: linha "meia" (.5) é a única SEM push/meio-push.
+        -- TRUE só p/ .5; FALSE p/ linha cheia (2.0) e p/ os dois quartos (.25/.75);
+        -- NULL onde não há linha (1X2/BTTS/DC). O predicado mora em
+        -- `futebol_linha_meia.sql` desde a #101 — até lá ele era comparado em MEIOS aqui,
+        -- e o `.25` passava como meia porque o BigQuery arredonda 0.5 para longe do zero.
+        {{ futebol_e_linha_meia('line_value') }} AS is_half_line
     FROM unioned
 ),
 


### PR DESCRIPTION
## O defeito

`is_half_line` decide se a linha de Handicap asiático / Gols O/U é **meia** (`.5`) — a única sem
push nem meio-push. Ela comparava em **meios**:

```sql
MOD(CAST(ROUND(ABS(line_value) * 2) AS INT64), 2) = 1
```

O BigQuery arredonda **meio para longe do zero**, então `.25` virava `0.5 → 1 → ímpar` e a linha de
**quarto** passava como meia. O `.75` escapava por sorte (arredonda para cima e cai no par), não por
construção. O comentário ao lado do código dizia o oposto do que o código fazia.

A porta existe porque em linha não-meia parte da aposta pode voltar como push, e o de-vig 2-way
normaliza sobre duas saídas que **não** são exaustivas — o edge publicado descreve uma aposta que
não é a que o usuário faria. Na linha de quarto isso vale igual: ela é metade da aposta em cada uma
das duas linhas vizinhas.

⚠️ **E o defeito não se vê no número.** As linhas de quarto aparecem com edge publicado
ligeiramente **menor** que as de meia (3,47% vs 4,33% em Gols). As duas populações são
indistinguíveis na tela, e nada denuncia que numa delas parte do risco pode voltar como push.

## O conserto

```sql
MOD(CAST(ROUND(ABS(line_value) * 4) AS INT64), 4) = 2
```

Comparar em **quartos** torna o `.75` correto por construção e não por sorte: em quartos, `resto 2`
é a definição de meia, e nenhum dos outros três restos pode ser alcançado por arredondamento a
partir dela.

## Tamanho, medido antes do deploy

No `fact_value_funnel` de produção (que ainda roda o predicado antigo), **uma janela fixada por
candidato**, kickoff de 16/06 a 27/08:

| mercado | candidatos c/ linha | deixam de ser "meia" | oportunidades hoje | **deixam de ser oportunidade** |
|---|---|---|---|---|
| `asian_handicap` | 15.323 | 3.643 | 41 | **15 (36,6%)** |
| `goals_over_under` | 16.073 | 3.194 | 65 | **25 (38,5%)** |
| **total** | **31.396** | **6.837 (21,8%)** | **106** | **40 (37,7%)** |

**O board perde 37,7% das oportunidades de Handicap e Gols.**

O conserto é **monotônico**: `COUNTIF(NOT is_half_line AND <predicado novo>)` = **0**. Nada anda no
sentido contrário — só aperta, nunca afrouxa.

**Os quatro quartos particionam a população**: `.0` 20.650 + `.25` 19.246 + `.5` 30.027 + `.75`
18.084 = **88.007**, exatamente o total de linhas com `line_value`. Nenhum valor exótico (`.1`,
`.33`) fora dos quartos, então o predicado novo não tem caso não coberto em produção.

**Efeito no snapshot:** `is_half_line` está no `check_cols` do `fact_value_opportunities_hist`, que
usa `invalidate_hard_deletes=True`. Hoje o hist tem **3 versões abertas**, das quais **1** é linha de
quarto — ela será fechada no primeiro build pós-deploy. Sem tempestade de churn: o expurgo da #85 já
tinha reduzido o board.

## Eram TRÊS cópias, não duas

Quatro ocorrências em três arquivos: `fact_value_opportunities`, `fact_value_funnel` e **duas vezes**
em `analyses/taskA_linha_de_base.sql`. O funil nasceu com o defeito porque copiou a expressão do
board **byte a byte**, de propósito, para que `assert_funil_paridade_com_board` pudesse provar que
ele descreve o board — e por isso a paridade ficava verde comparando dois erros iguais.

As quatro passam a ler o macro `futebol_e_linha_meia()`, pela mesma razão que o expurgo virou macro
na #85: predicado copiado é predicado que diverge, e aqui a divergência seria **muda**.

A análise entra junto porque o cabeçalho dela **declara** que ela "reproduz os 5 ramos do
`fact_value_opportunities`". Consequência registrada no cabeçalho dela: os números da linha de base
da [A] foram medidos sob a regra velha e não se reproduzem — mesma família da #82.

## O teste

`funil_linha_meia_e_por_quarto_de_linha`: a **tabela inteira** (`.0`/`.25`/`.5`/`.75`), e não mais um
caso — só os quatro quartos juntos separam "a porta está certa" de "a porta acerta o `.5` e o `2.0`".
Mais um quarto **negativo** em Handicap (é assim que se escreve handicap; o `ABS` é a única razão de
funcionar) e um mercado sem linha, que tem de continuar `NULL` e não `FALSE`.

Confirmado **vermelho nos dois `.25`** contra o código anterior e verde depois.

O `/code-review` não achou defeito de correção, mas achou uma lacuna: o teste do `.25` só existia no
funil, e os dois unit tests do board eram 100% 1X2 (`line_value` vazio em toda linha mockada). Entrou
`value_opportunities_linha_de_quarto_nao_chega_ao_board` — três candidatos de Gols O/U idênticos fora
da linha, só a meia é publicada. A asserção é **diferente** da do funil de propósito: o funil grava o
veredito de cada porta e responde "por que reprovou"; o board só responde "aparece ou não", e a linha
de quarto **sumir** é a consequência que o usuário vê. Importa porque a paridade é declaradamente
temporária — quando o board passar a ler do funil, a guarda se aposenta e este teste é o que sobra.

Também confirmado que ele discrimina: com o macro revertido para a expressão antiga, vermelho.

**16 unit tests passam**; `dbt compile` limpo no projeto inteiro.

## O que NÃO foi feito

- **Sem `dbt run` local.** `dev` e `prod` apontam para o mesmo dataset `futebol`: um rebuild aqui
  viraria o funil de produção antes do deploy da imagem, e o job agendado (imagem velha) o viraria de
  volta.
- **Sem a suíte de data tests inteira.** Ela custa 7,66 GB por execução (medido hoje na DE#19), e ela
  não valida este conserto: os data tests rodam sobre as tabelas materializadas, que ainda são as
  antigas. `assert_funil_paridade_com_board` fica verde antes e depois — o conserto entra nos dois
  marts no mesmo commit.

## Sequenciamento

⚠️ **Entra antes da #96 (A7-2).** Depois do congelamento no apito, as linhas de kickoff já passado
ficam gravadas com `porta_linha_meia` errada e a guarda de imutabilidade impede a correção. Enquanto
o funil é tabela reconstruída, o conserto é retroativo.

⚠️ **Antes de 27/08 16:41 UTC**, quando expira a trava de relógio da #86 — o número acima vai
declarado lá.

⚠️ **O merge sozinho não muda produção.** Os modelos rodam de imagem pré-buildada: é o
`build-and-push.sh dbt_futebol` que faz produção pegar isto. Entre o merge e o build o detector de
deriva alarma, por desenho.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
