### PR TITLE
feat(futebol): o funil vira append-only e congela no apito (#96)

### DIFF
--- a/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
+++ b/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
@@ -120,6 +120,53 @@ mil linhas/mês**. Dez anos de operação, com o dobro de ligas, não chegam a 1
 nem a 5 GB. **Não há expurgo do funil**, e a política se revisita se a tabela passar de 10
 milhões de linhas — que é uma forma de dizer que ela não se revisita.
 
+## A virada é um passo só, e ele derruba a tabela
+
+O passo 1 entregou o funil como tabela reconstruída. Virá-lo append-only não é uma mudança que
+o próximo build absorve sozinho: a `unique_key` do merge inclui `line_key`, que não existe nas
+linhas de lá, e num `MERGE ... ON` NULL nunca casa com NULL — a primeira execução sobre a tabela
+velha **duplicaria** toda linha de jogo futuro em vez de atualizá-la, e as linhas antigas ficariam
+com `origem` NULL para sempre.
+
+A cutover, então, é: **derrubar a tabela e deixar o primeiro build recriá-la**. Ele roda o ramo
+de full refresh, carimba `backfill` em 16/06 em diante — que é exatamente o que o carimbo quer
+dizer — e a partir daí toda escrita é incremental e congelada. O selo (`fact_value_funnel_selo`)
+nasce na mesma execução, sobre esses números.
+
+A ordem, e ela é apertada porque o `workflow-futebol-odds` dispara com frequência:
+
+1. mergear a AE e **deployar o workflow da DE** (o `--select` enumera modelo a modelo, e modelo
+   fora da lista nasce parado; nome desconhecido é só warning, então o workflow pode ir antes);
+2. `./build-and-push.sh dbt_futebol`;
+3. **imediatamente** `bq rm -f -t smartbetting-dados:futebol.fact_value_funnel`;
+4. disparar o workflow à mão e conferir: nenhuma linha com `origem` NULL, e o selo com linhas.
+
+Se uma execução agendada couber entre (2) e (3) e fizer o merge ruim, o conserto é o mesmo (3) e
+(4) de novo — o estado não é absorvente.
+
+⚠️ E daqui sai uma regra permanente: **funil e selo caem juntos, ou nenhum dos dois cai.** Um
+selo reconstruído a partir do funil de agora é um selo que concorda com qualquer coisa; um funil
+reconstruído sob um selo velho deixa a guarda vermelha para sempre — e guarda permanentemente
+vermelha morre ignorada.
+
+## As guardas mudam de escopo, e é por estarem certas
+
+Duas guardas do passo 1 ficariam vermelhas **por acerto** depois do congelamento, e por isso
+passam a ser escopadas ao que ainda não começou:
+
+- **reconciliação** — o funil nunca expurga e a fonte só emite enquanto a coleta emite aquele
+  fixture. No primeiro dia em que o de-vig soltar um jogo velho, o funil guarda mais história do
+  que a fonte. Ela passa a comparar o conjunto de que o modelo é responsável nesta execução:
+  candidato de kickoff futuro (ou desconhecido, que é gravável para sempre por fail-open);
+- **paridade com o board** — as duas tabelas param de andar juntas no instante do apito. O funil
+  congela ali; o board continua recalculando até o expurgo levá-lo, relendo premissas que a #78
+  já mostrou não serem reprodutíveis entre builds. Ela passa a comparar só o jogo por acontecer,
+  que é também o único conjunto em que a paridade interessa — é o que o assinante ainda pode
+  apostar.
+
+O que sai junto com os dois escopos é a história já congelada. Quem cobre essa metade é a guarda
+de imutabilidade, e ela consegue porque compara contra um registro escrito **fora** do funil.
+
 ## Os carimbos, e o que eles tornam legível
 
 Cada linha carrega `gravado_em` e `origem` (`backfill` | `corrente`). O backfill recalcula

--- a/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
+++ b/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
@@ -135,14 +135,23 @@ nasce na mesma execução, sobre esses números.
 
 A ordem, e ela é apertada porque o `workflow-futebol-odds` dispara com frequência:
 
-1. mergear a AE e **deployar o workflow da DE** (o `--select` enumera modelo a modelo, e modelo
-   fora da lista nasce parado; nome desconhecido é só warning, então o workflow pode ir antes);
+1. mergear a AE e **deployar o workflow da DE** — editar o `workflow_futebol_odds.yml` local não
+   muda o workflow live, então é `./scripts/deploy_workflows.sh workflow-futebol-odds` na DE. Vem
+   antes porque o `--select` enumera modelo a modelo e modelo fora da lista nasce parado; nome
+   desconhecido no `--select` é só warning, então o workflow pode ir na frente da imagem;
 2. `./build-and-push.sh dbt_futebol`;
 3. **imediatamente** `bq rm -f -t smartbetting-dados:futebol.fact_value_funnel`;
 4. disparar o workflow à mão e conferir: nenhuma linha com `origem` NULL, e o selo com linhas.
 
 Se uma execução agendada couber entre (2) e (3) e fizer o merge ruim, o conserto é o mesmo (3) e
 (4) de novo — o estado não é absorvente.
+
+⚠️ **Entre (2) e (3) as duas guardas novas dão ERRO, e é esperado.** Elas rodam da imagem nova
+contra a tabela velha: `assert_funil_congelado_no_apito` não acha a coluna `origem` e
+`assert_funil_imutavel_por_dia_de_kickoff` não acha o selo. É erro de compilação, não guarda
+vermelha, e passa sozinho no (4). Está escrito aqui porque a alternativa é alguém gastar um dia
+rediagnosticando um alarme que a própria ordem do deploy produziu — já aconteceu duas vezes com o
+board t24h.
 
 ⚠️ E daqui sai uma regra permanente: **funil e selo caem juntos, ou nenhum dos dois cai.** Um
 selo reconstruído a partir do funil de agora é um selo que concorda com qualquer coisa; um funil

--- a/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
+++ b/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
@@ -141,7 +141,10 @@ A ordem, e ela é apertada porque o `workflow-futebol-odds` dispara com frequên
    desconhecido no `--select` é só warning, então o workflow pode ir na frente da imagem;
 2. `./build-and-push.sh dbt_futebol`;
 3. **imediatamente** `bq rm -f -t smartbetting-dados:futebol.fact_value_funnel`;
-4. disparar o workflow à mão e conferir: nenhuma linha com `origem` NULL, e o selo com linhas.
+4. disparar o workflow à mão e conferir: nenhuma linha com `origem` NULL, o selo com linhas, e
+   `dbt ls --select tag:guarda --resource-type test` listando **42** (eram 36; entram as duas
+   guardas novas, o `not_null` de `gravado_em` e de `origem`, o `accepted_values` de `origem` e o
+   grão do selo — os carimbos precisam da tag porque o agendado roda só essa seleção).
 
 Se uma execução agendada couber entre (2) e (3) e fizer o merge ruim, o conserto é o mesmo (3) e
 (4) de novo — o estado não é absorvente.

--- a/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
+++ b/dbt_futebol/docs/adr/0011-o-funil-e-append-only-e-congela-no-apito.md
@@ -146,10 +146,9 @@ A ordem, e ela é apertada porque o `workflow-futebol-odds` dispara com frequên
 Se uma execução agendada couber entre (2) e (3) e fizer o merge ruim, o conserto é o mesmo (3) e
 (4) de novo — o estado não é absorvente.
 
-⚠️ **Entre (2) e (3) as duas guardas novas dão ERRO, e é esperado.** Elas rodam da imagem nova
-contra a tabela velha: `assert_funil_congelado_no_apito` não acha a coluna `origem` e
-`assert_funil_imutavel_por_dia_de_kickoff` não acha o selo. É erro de compilação, não guarda
-vermelha, e passa sozinho no (4). Está escrito aqui porque a alternativa é alguém gastar um dia
+⚠️ **Entre (2) e (3) as QUATRO guardas do funil dão ERRO, e é esperado.** Elas rodam da imagem
+nova contra a tabela velha: as duas novas não acham `origem` nem o selo, e as duas do passo 1 não
+acham `line_key`. É erro de compilação, não guarda vermelha, e passa sozinho no (4). Está escrito aqui porque a alternativa é alguém gastar um dia
 rediagnosticando um alarme que a própria ordem do deploy produziu — já aconteceu duas vezes com o
 board t24h.
 

--- a/dbt_futebol/macros/futebol_funil.sql
+++ b/dbt_futebol/macros/futebol_funil.sql
@@ -44,3 +44,40 @@
         {%- endfor %}
     END
 {%- endmacro %}
+
+
+{#-
+  A FRONTEIRA DO CONGELAMENTO, declarada num lugar só (issue #96, ADR 0011).
+
+  TRUE = esta linha ainda pode ser escrita. O funil é append-only: a linha é escrita e
+  atualizada enquanto o jogo não começou, e no apito ela para de ser tocada por build
+  nenhum e deploy nenhum.
+
+  É no **apito inicial**, e não no status final: entre um e outro há duas horas em que os
+  modelos de premissa continuam rodando, e tudo escrito ali seria nota nascida depois de a
+  bola rolar — nota que ninguém podia ler antes de apostar. É a fresta que a ADR 0009
+  existe para fechar.
+
+  ⚠️ Por que macro e não SQL repetido — a mesma lição de `futebol_expurgo.sql`, e aqui ela
+  vale em CINCO lugares: o modelo, os dois lados da `assert_funil_reconcilia_com_devig` e os
+  dois lados da `assert_funil_paridade_com_board`. Predicado copiado em cinco arquivos é
+  predicado que diverge no primeiro refactor, e a divergência é muda nos dois sentidos:
+  guarda mais frouxa que o modelo nunca acende, guarda mais estrita acende sem defeito. Com
+  um macro só, modelo e guardas não têm como discordar.
+
+  ⚠️ FIXTURE AUSENTE É FAIL-OPEN (ADR 0003). `NULL > CURRENT_TIMESTAMP()` é NULL, e sem o
+  `COALESCE(..., TRUE)` a linha nunca mais seria escrita: ela sumiria do funil e a
+  reconciliação acenderia vermelha, com razão. Preferimos a linha eternamente gravável à
+  linha perdida — não dá para congelar no apito de um jogo cuja hora não se sabe.
+
+  ⚠️ JOGO ADIADO REABRE, e de graça: o predicado lê o kickoff CORRENTE, não o que estava lá
+  quando a linha foi escrita. `PST`/`SUSP` empurram o kickoff para o futuro e a linha volta
+  a ser gravável — o jogo voltou a ser apostável, e o que estava escrito descrevia uma
+  partida que não aconteceu.
+
+  `kickoff_col` é expressão já qualificada pelo chamador (ex.: `f.kickoff_utc`), porque os
+  consumidores juntam as tabelas com aliases diferentes.
+-#}
+{% macro futebol_funil_e_gravavel(kickoff_col) -%}
+    COALESCE({{ kickoff_col }} > CURRENT_TIMESTAMP(), TRUE)
+{%- endmacro %}

--- a/dbt_futebol/models/marts/_fact_value_funnel.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel.yml
@@ -21,10 +21,22 @@ models:
       `assert_funil_reconcilia_com_devig`, que lê a FONTE (o de-vig) e nunca o próprio
       funil.
 
-      ⚠️ Materialização TABELA nesta entrega: como ela nasce cobrindo desde a primeira odd
-      coletada, o backfill sai de graça. O append-only com congelamento no apito (ADR 0011)
-      é a próxima entrega — e é ela que impede o rebuild de reescrever o passado quando as
-      portas mudarem (A1/A2/A3/A5).
+      ⚠️ APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011). A linha é escrita e atualizada
+      enquanto o `kickoff` do fixture está no FUTURO, e nenhuma escrita acontece depois
+      dele: o funil não é uma foto do que o código de hoje diria, é registro do que o Motor
+      disse. É o que faz a A7 valer a pena entrar ANTES da A1 — quando o preço sair da nota
+      e as portas mudarem, o funil de antes continua exatamente como estava.
+
+      ⚠️ `full_refresh=false` NO CONFIG, e é load-bearing: a fase de RECOVERY do
+      `workflow_futebol_odds` roda o mesmo `--select` com `--full-refresh`. Sem essa trava,
+      a primeira recuperação de deriva determinística apagaria o histórico inteiro — em
+      silêncio, e com o job verde.
+
+      ⚠️ RETENÇÃO: **não há expurgo do funil**. São ~45 mil linhas/mês; dez anos de operação
+      com o dobro de ligas não chegam a 10 milhões de linhas nem a 5 GB. A política se
+      revisita se a tabela passar de 10 milhões de linhas — que é uma forma de dizer que ela
+      não se revisita. O expurgo continua sendo do board (ADR 0009), e o funil guarda jogo
+      encerrado DE PROPÓSITO: é ele que responde quanto rendeu a faixa descartada.
 
       ⚠️ NÃO VAI PARA O SUPABASE (ADR 0006/0011): o app não lê funil. Sem migração no
       Postgres, sem RPC, sem tocar `check_schema_parity`.
@@ -56,6 +68,14 @@ models:
                 values: ['Home', 'Draw', 'Away', 'Over', 'Under', 'Yes', 'No', '1X', '12', 'X2']
       - name: line_value
         description: "NULL no 1X2, BTTS e Dupla Chance; a linha L (1.5/2.5/...) no Gols O/U; o handicap na ótica do mandante (o mesmo p/ Home e Away) no Handicap asiático."
+      - name: line_key
+        description: >
+          `line_value` como STRING, com NULL virando 'NONE'. É a coluna do grão que entra
+          na `unique_key` do merge, e ela existe por um motivo mecânico: num `MERGE ... ON`
+          NULL nunca casa com NULL, então `line_value` cru na chave faria toda linha de
+          1X2, BTTS e Dupla Chance ser reinserida a cada execução — em silêncio, até a
+          guarda de grão acender.
+        tests: [not_null]
       - name: janela
         description: "A janela de coleta que originou esta avaliação. São QUATRO por candidato (daily < t24h < t1h < t15m), não três — a `daily` entrou em 07/08/2026. É a quarta coluna do grão."
         tests:
@@ -167,6 +187,31 @@ models:
         description: "Parcela da penalidade global: best_odd > 4,5 (−15)."
       - name: pen_odd_juice
         description: "Parcela da penalidade global: best_odd < 1,40 (−10). FALSE na Dupla Chance de propósito — o gate de odd próprio (>= 1,25) já cobre o retorno mínimo."
+
+      # ------------------------------------------------------------------ os carimbos
+      - name: gravado_em
+        description: >
+          QUANDO o Motor disse isto (#96). Sob append-only, "quando o dbt carregou" e
+          "quando ficou registrado" são o mesmo instante — por isso este campo substituiu
+          o `dbt_loaded_at` em vez de conviver com ele. Em linha `corrente` ele é sempre
+          ANTERIOR ao `kickoff_utc`, e é isso que a `assert_funil_congelado_no_apito` prova.
+        tests: [not_null]
+      - name: origem
+        description: >
+          `backfill` no build que CRIA a tabela — aquelas linhas foram recalculadas com o
+          código de hoje sobre odds antigas, e são a única parte do funil que NÃO é
+          registro do que foi dito na época. `corrente` em toda escrita incremental, e essa
+          sim é registro de época. Com o carimbo, o dia da virada da A1 fica legível na
+          série sem ninguém precisar lembrar a data.
+
+          ⚠️ Linha `backfill` de jogo ainda futuro vira `corrente` no primeiro merge
+          seguinte — ela voltou a ser escrita antes do apito, então passou a ser registro
+          de época de verdade.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['backfill', 'corrente']
     tests:
       # O GRÃO — e aqui ele inclui a JANELA, ao contrário do board (ADR 0004/0011).
       #

--- a/dbt_futebol/models/marts/_fact_value_funnel.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel.yml
@@ -195,7 +195,13 @@ models:
           "quando ficou registrado" são o mesmo instante — por isso este campo substituiu
           o `dbt_loaded_at` em vez de conviver com ele. Em linha `corrente` ele é sempre
           ANTERIOR ao `kickoff_utc`, e é isso que a `assert_funil_congelado_no_apito` prova.
-        tests: [not_null]
+        tests:
+          # `tag:guarda` porque o agendado roda SÓ essa seleção. Carimbo nulo é o sintoma
+          # exato da cutover malfeita (merge sobre a tabela do passo 1), e sem a tag ele
+          # ficaria mudo justamente no dia em que precisa gritar.
+          - not_null:
+              config:
+                tags: ['guarda']
       - name: origem
         description: >
           `backfill` no build que CRIA a tabela — aquelas linhas foram recalculadas com o
@@ -208,10 +214,16 @@ models:
           seguinte — ela voltou a ser escrita antes do apito, então passou a ser registro
           de época de verdade.
         tests:
-          - not_null
+          # idem `gravado_em`: `tag:guarda` porque é o carimbo que denuncia a cutover
+          # malfeita, e o agendado só roda essa seleção.
+          - not_null:
+              config:
+                tags: ['guarda']
           - accepted_values:
               arguments:
                 values: ['backfill', 'corrente']
+              config:
+                tags: ['guarda']
     tests:
       # O GRÃO — e aqui ele inclui a JANELA, ao contrário do board (ADR 0004/0011).
       #
@@ -219,13 +231,19 @@ models:
       # cobre: a `assert_funil_reconcilia_com_devig` compara CONJUNTOS de chaves com
       # `EXCEPT DISTINCT`, que é insensível a duplicata — um fan-out que duplicasse toda
       # linha passaria por ela nos dois sentidos e só apareceria aqui.
+      #
+      # ⚠️ Sobre `line_key` e não `line_value`: as duas dão o mesmo grão (uma é função
+      # determinística da outra, e o BigQuery agrupa NULLs), mas é `line_key` que entra na
+      # `unique_key` do merge. Testando a chave REAL, esta é literalmente a guarda que o
+      # comentário do modelo promete — a que acende se o merge parar de casar e passar a
+      # inserir.
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - fixture_id
               - market
               - outcome
-              - line_value
+              - line_key
               - janela
           config:
             tags: ['guarda']

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -33,6 +33,13 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_cada_porta_reprova_sozinha
     model: fact_value_funnel
+    # O funil virou incremental na #96, e o dbt passa a exigir que todo unit test declare
+    # qual dos dois ramos ele exercita. Este roda o ramo de FULL REFRESH — o build que
+    # cria a tabela, sem o filtro de congelamento —, que é onde as portas se leem puras,
+    # sem o kickoff interferindo. O ramo incremental tem teste próprio, o quarto.
+    overrides:
+      macros:
+        is_incremental: false
     description: >
       Nove candidatos idênticos fora de uma coisa cada: o base (passa em tudo) e um por
       porta. Prova que as oito portas são independentes entre si e que
@@ -141,6 +148,13 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_duas_portas_o_empate_e_o_insumo_nulo
     model: fact_value_funnel
+    # O funil virou incremental na #96, e o dbt passa a exigir que todo unit test declare
+    # qual dos dois ramos ele exercita. Este roda o ramo de FULL REFRESH — o build que
+    # cria a tabela, sem o filtro de congelamento —, que é onde as portas se leem puras,
+    # sem o kickoff interferindo. O ramo incremental tem teste próprio, o quarto.
+    overrides:
+      macros:
+        is_incremental: false
     description: >
       Uma linha reprovando em duas portas ao mesmo tempo — as DUAS colunas FALSE, que é a
       propriedade que a coluna única de motivo destruiria; a "12" da Dupla Chance na sua
@@ -222,6 +236,13 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_quatro_janelas_um_candidato_uma_corrente
     model: fact_value_funnel
+    # O funil virou incremental na #96, e o dbt passa a exigir que todo unit test declare
+    # qual dos dois ramos ele exercita. Este roda o ramo de FULL REFRESH — o build que
+    # cria a tabela, sem o filtro de congelamento —, que é onde as portas se leem puras,
+    # sem o kickoff interferindo. O ramo incremental tem teste próprio, o quarto.
+    overrides:
+      macros:
+        is_incremental: false
     description: >
       O mesmo candidato coletado nas quatro janelas vira quatro linhas, e só a mais
       recente tem `janela_e_corrente`. O veredito das portas varia entre elas (é isso
@@ -287,6 +308,11 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_linha_meia_e_por_quarto_de_linha
     model: fact_value_funnel
+    # Ramo de full refresh (ver a nota no primeiro teste): o que se mede aqui é o
+    # predicado da linha meia, e o congelamento não tem nada a dizer sobre ele.
+    overrides:
+      macros:
+        is_incremental: false
     description: >
       Os quatro quartos de linha (.0, .25, .5, .75) em Gols O/U, uma linha de quarto
       NEGATIVA em Handicap, e um mercado sem linha. Só `.5` é meia; linha de quarto pode
@@ -356,3 +382,87 @@ unit_tests:
         - {fixture_id: 33, market: 'goals_over_under', is_half_line: false, porta_linha_meia: false, passou_no_gate: false, motivo_primario: 'linha_nao_meia'}
         - {fixture_id: 34, market: 'asian_handicap',   is_half_line: false, porta_linha_meia: false, passou_no_gate: false, motivo_primario: 'linha_nao_meia'}
         - {fixture_id: 35, market: 'match_winner',     is_half_line: ,      porta_linha_meia: true,  passou_no_gate: true,  motivo_primario: }
+
+  # ---------------------------------------------------------------------------
+  # 4. O CONGELAMENTO NO APITO (#96, ADR 0011).
+  #
+  # É a propriedade que transforma a tabela de foto em registro, e ela vive num
+  # `{% if is_incremental() %}` — o ramo que NENHUM dos três testes acima alcança,
+  # porque o unit test de modelo incremental roda o ramo de full refresh por default.
+  # O `overrides: macros: is_incremental: true` é o que traz o filtro para dentro do
+  # teste.
+  #
+  # Os três casos são os três estados que um kickoff pode ter na hora da escrita, e o
+  # aceite da #96 nomeia cada um deles:
+  #
+  #   · FUTURO   -> grava (o jogo ainda é apostável);
+  #   · PASSADO  -> não grava (é o congelamento; nota nascida com a bola rolando seria
+  #                nota que ninguém podia ler antes de apostar);
+  #   · NULL     -> grava (fail-open, ADR 0003: perder a linha quebraria a reconciliação,
+  #                e não dá para congelar no apito de um jogo cuja hora não se sabe).
+  #
+  # O JOGO ADIADO é o caso do kickoff futuro, e por isso não tem fixture próprio: o
+  # filtro lê o kickoff CORRENTE de `fact_fixtures`, não o que estava lá quando a linha
+  # foi escrita. `PST`/`SUSP` empurram o kickoff para frente e o fixture 30 passa a ser
+  # exatamente o fixture 31 — o mesmo predicado, a mesma resposta.
+  # ---------------------------------------------------------------------------
+  - name: funil_incremental_so_grava_antes_do_apito
+    model: fact_value_funnel
+    overrides:
+      macros:
+        is_incremental: true
+    description: >
+      No ramo incremental, o candidato de jogo já apitado NÃO é escrito e o de jogo por
+      acontecer é. É o congelamento da ADR 0011, e é ele que garante que nenhum build e
+      nenhum deploy reescreve uma linha depois do apito. O kickoff desconhecido continua
+      gravável de propósito, e a `origem` das linhas escritas é `corrente` — o carimbo que
+      as distingue do backfill, que é a única parte do funil recalculada com o código de
+      hoje.
+    given:
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # 30: jogo por acontecer -> grava. (É também o jogo adiado: o `PST` devolve o
+          # kickoff para o futuro e ele vira este caso.)
+          - {fixture_id: 30, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # 31: a bola já rolou -> NÃO grava. Escrever aqui seria nota nascida depois do
+          # apito, que é a fresta que a ADR 0009 existe para fechar.
+          - {fixture_id: 31, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # 32: fixture que `fact_fixtures` não conhece -> grava (fail-open).
+          - {fixture_id: 32, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 30 AS fixture_id, 'Home' AS outcome, 15 AS pts_premissas,
+                 0 AS premissas_sem_dado, 0 AS penalidades_1x2_pts
+          UNION ALL SELECT 31, 'Home', 15, 0, 0
+          UNION ALL SELECT 32, 'Home', 15, 0, 0
+
+      - input: ref('int_futebol_premissas_ou')
+        rows: []
+      - input: ref('int_futebol_premissas_ah')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+
+      # O dbt exige um mock de `this` em unit test de modelo incremental. O modelo NÃO lê
+      # `this` — o congelamento é um predicado sobre o kickoff, não sobre o que já está
+      # gravado —, então o mock é vazio e serve só para satisfazer a exigência.
+      - input: this
+        rows: []
+
+      # O 32 NÃO tem linha aqui, de propósito: é o fixture ausente.
+      - input: ref('fact_fixtures')
+        format: sql
+        rows: |
+          SELECT 30 AS fixture_id, TIMESTAMP '2099-01-01 00:00:00+00' AS kickoff_utc
+          UNION ALL SELECT 31, TIMESTAMP '2020-01-01 00:00:00+00'
+
+    expect:
+      rows:
+        - {fixture_id: 30, janela: 't15m', origem: 'corrente'}
+        - {fixture_id: 32, janela: 't15m', origem: 'corrente'}

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -17,6 +17,12 @@ version: 2
 # alguém mexer nos pesos e o teste ficar vermelho por score, é o número daqui que se
 # ajusta; não é o caso de teste que está errado.
 #
+# ⚠️ `overrides: macros: is_incremental` é OBRIGATÓRIO em todo teste daqui desde que o
+# funil virou incremental (#96): o dbt exige que cada um declare qual dos dois ramos
+# exercita. `false` é o ramo de FULL REFRESH — o build que cria a tabela, sem o filtro de
+# congelamento —, que é onde as portas se leem puras, sem o kickoff interferindo. Só o
+# último teste usa `true`, porque é o que mede o congelamento em si.
+#
 # ⚠️ As linhas do de-vig são MOCKS, não amostras: algumas combinações não ocorrem em
 # produção de propósito, porque isolar uma porta às vezes exige quebrar a implicação
 # que a liga a outra. Onde isso acontece está dito na linha.
@@ -33,10 +39,6 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_cada_porta_reprova_sozinha
     model: fact_value_funnel
-    # O funil virou incremental na #96, e o dbt passa a exigir que todo unit test declare
-    # qual dos dois ramos ele exercita. Este roda o ramo de FULL REFRESH — o build que
-    # cria a tabela, sem o filtro de congelamento —, que é onde as portas se leem puras,
-    # sem o kickoff interferindo. O ramo incremental tem teste próprio, o quarto.
     overrides:
       macros:
         is_incremental: false
@@ -148,10 +150,6 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_duas_portas_o_empate_e_o_insumo_nulo
     model: fact_value_funnel
-    # O funil virou incremental na #96, e o dbt passa a exigir que todo unit test declare
-    # qual dos dois ramos ele exercita. Este roda o ramo de FULL REFRESH — o build que
-    # cria a tabela, sem o filtro de congelamento —, que é onde as portas se leem puras,
-    # sem o kickoff interferindo. O ramo incremental tem teste próprio, o quarto.
     overrides:
       macros:
         is_incremental: false
@@ -236,10 +234,6 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_quatro_janelas_um_candidato_uma_corrente
     model: fact_value_funnel
-    # O funil virou incremental na #96, e o dbt passa a exigir que todo unit test declare
-    # qual dos dois ramos ele exercita. Este roda o ramo de FULL REFRESH — o build que
-    # cria a tabela, sem o filtro de congelamento —, que é onde as portas se leem puras,
-    # sem o kickoff interferindo. O ramo incremental tem teste próprio, o quarto.
     overrides:
       macros:
         is_incremental: false
@@ -308,8 +302,6 @@ unit_tests:
   # ---------------------------------------------------------------------------
   - name: funil_linha_meia_e_por_quarto_de_linha
     model: fact_value_funnel
-    # Ramo de full refresh (ver a nota no primeiro teste): o que se mede aqui é o
-    # predicado da linha meia, e o congelamento não tem nada a dizer sobre ele.
     overrides:
       macros:
         is_incremental: false

--- a/dbt_futebol/models/marts/_fact_value_funnel_selo.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel_selo.yml
@@ -4,8 +4,8 @@ models:
   - name: fact_value_funnel_selo
     description: >
       O SELO DE IMUTABILIDADE DO FUNIL (#96, ADR 0011). 1 linha por
-      (fixture_id, dia_kickoff) já passado, com a contagem e a soma de nota que o
-      `fact_value_funnel` tinha na primeira vez em que aquele dia ficou para trás.
+      (fixture_id, dia_kickoff) JÁ APITADO, com a contagem e a soma de nota que o
+      `fact_value_funnel` tinha na primeira execução depois do apito daquele fixture.
       Escrito UMA VEZ e nunca reescrito.
 
       Existe porque o aceite da #96 pede uma propriedade ENTRE BUILDS — "contagem e soma de
@@ -35,7 +35,11 @@ models:
         description: "O jogo. Está na chave para que o adiamento (`PST`/`SUSP`) não vire guarda vermelha permanente."
         tests: [not_null]
       - name: dia_kickoff
-        description: "`DATE(kickoff_utc)` em UTC. Só entram dias ESTRITAMENTE anteriores a `CURRENT_DATE()`: um dia só está inteiro no passado quando o seguinte começou."
+        description: >
+          `DATE(kickoff_utc)` em UTC. O selo fecha no APITO de cada fixture, não na virada
+          do dia: o grão é por fixture, então não há meio-dia em curso a proteger, e
+          esperar a meia-noite deixaria o dia mais novo até 24 h sem selo — justamente o dia
+          em que um rebuild indevido é mais provável, logo depois de um deploy.
         tests: [not_null]
       - name: linhas
         description: "Quantas linhas o funil tinha para esse (fixture, dia) no instante do selo."

--- a/dbt_futebol/models/marts/_fact_value_funnel_selo.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel_selo.yml
@@ -1,0 +1,62 @@
+version: 2
+
+models:
+  - name: fact_value_funnel_selo
+    description: >
+      O SELO DE IMUTABILIDADE DO FUNIL (#96, ADR 0011). 1 linha por
+      (fixture_id, dia_kickoff) já passado, com a contagem e a soma de nota que o
+      `fact_value_funnel` tinha na primeira vez em que aquele dia ficou para trás.
+      Escrito UMA VEZ e nunca reescrito.
+
+      Existe porque o aceite da #96 pede uma propriedade ENTRE BUILDS — "contagem e soma de
+      nota por dia de kickoff já passado não mudam" — e nenhuma consulta ao funil de agora
+      sabe o que o funil de ontem dizia. Um rebuild completo produz uma tabela internamente
+      coerente e inteiramente nova: qualquer evidência guardada DENTRO do funil seria
+      reescrita junto com ele. O selo é o registro que o rebuild não alcança, e é a mesma
+      lição da costura B da task [F] e da `assert_funil_reconcilia_com_devig` — guarda que
+      lê só o próprio produto não é guarda.
+
+      ⚠️ O grão inclui o FIXTURE, e não é detalhe: selar por dia deixaria a guarda vermelha
+      para sempre no primeiro `PST`. O jogo adiado muda de dia, some do agregado do dia
+      velho, e o selo daquele dia fica ÓRFÃO — a guarda o reconhece pelo dia corrente do
+      fixture e o ignora, e o fixture é selado de novo quando o dia NOVO dele passar.
+
+      ⚠️ `full_refresh=false` pelo mesmo motivo do funil: a fase de RECOVERY do
+      `workflow_futebol_odds` roda o mesmo `--select` com `--full-refresh`, e um selo
+      reconstruído a partir do funil de agora é um selo que concorda com qualquer coisa.
+
+      ⚠️ Se o funil PRECISAR ser reconstruído de propósito, o selo cai JUNTO, no mesmo
+      passo. Derrubar só um dos dois deixa a guarda permanentemente vermelha — e guarda
+      permanentemente vermelha morre ignorada.
+
+      ⚠️ NÃO VAI PARA O SUPABASE: não tem leitor no app.
+    columns:
+      - name: fixture_id
+        description: "O jogo. Está na chave para que o adiamento (`PST`/`SUSP`) não vire guarda vermelha permanente."
+        tests: [not_null]
+      - name: dia_kickoff
+        description: "`DATE(kickoff_utc)` em UTC. Só entram dias ESTRITAMENTE anteriores a `CURRENT_DATE()`: um dia só está inteiro no passado quando o seguinte começou."
+        tests: [not_null]
+      - name: linhas
+        description: "Quantas linhas o funil tinha para esse (fixture, dia) no instante do selo."
+        tests: [not_null]
+      - name: soma_nota
+        description: >
+          `SUM(CAST(score AS NUMERIC))`. NUMERIC, e não FLOAT64, de propósito: soma de float
+          depende da ordem das parcelas e a ordem de leitura de uma tabela do BigQuery não é
+          estável entre execuções — a guarda tremeria no último bit sem defeito nenhum (#92).
+          NULL só se toda linha do dia tiver nota NULL.
+      - name: selado_em
+        description: "Quando o selo foi escrito. Diagnóstico: diz de que build veio o número que a guarda está cobrando."
+        tests: [not_null]
+    tests:
+      # O grão. `tag:guarda` porque o selo é INSERT-ONLY por anti-join, e não por
+      # `unique_key`: se o anti-join quebrar, o selo duplica em silêncio e a guarda de
+      # imutabilidade passa a comparar contra duas testemunhas que discordam.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - fixture_id
+              - dia_kickoff
+          config:
+            tags: ['guarda']

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -608,21 +608,9 @@ LEFT JOIN fixtures USING (fixture_id)
 -- foto em registro: o merge só recebe candidato de jogo que AINDA NÃO COMEÇOU, então
 -- nenhuma linha de kickoff passado é reescrita por build nenhum nem por deploy nenhum.
 --
--- É no APITO INICIAL, não no status final: entre um e outro há duas horas em que os
--- modelos de premissa continuam rodando, e tudo escrito ali seria nota nascida DEPOIS
--- de a bola rolar — nota que ninguém podia ler antes de apostar. É a fresta que a
--- ADR 0009 existe para fechar.
---
--- JOGO ADIADO REABRE, e de graça: o predicado lê o kickoff CORRENTE de `fact_fixtures`,
--- não o que estava lá quando a linha foi escrita. `PST`/`SUSP` empurram o kickoff para o
--- futuro, a linha volta a ser gravável, e é o comportamento certo — o jogo voltou a ser
--- apostável e o que estava escrito descrevia uma partida que não aconteceu.
---
--- FIXTURE AUSENTE É FAIL-OPEN (kickoff NULL -> TRUE, ADR 0003). `NULL > CURRENT_TIMESTAMP()`
--- é NULL, e sem o COALESCE a linha nunca mais seria escrita: ela sumiria do funil e a
--- `assert_funil_reconcilia_com_devig` acenderia vermelha, com razão. Preferimos a linha
--- eternamente gravável à linha perdida — não dá para congelar no apito de um jogo cuja
--- hora não se sabe.
+-- O predicado mora em `futebol_funil.sql` — o mesmo que as duas guardas leem. Copiá-lo
+-- aqui faria dele cinco cópias, e cópia que diverge do que a guarda espera é divergência
+-- MUDA nos dois sentidos (ver o cabeçalho do macro).
 -- ============================================================================
-WHERE COALESCE(_fx_kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
+WHERE {{ futebol_funil_e_gravavel('_fx_kickoff_utc') }}
 {% endif %}

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -1,7 +1,11 @@
 {{ config(
-    materialized='table',
+    materialized='incremental',
+    incremental_strategy='merge',
+    unique_key=['fixture_id', 'market', 'outcome', 'line_key', 'janela'],
+    on_schema_change='append_new_columns',
+    full_refresh=false,
     cluster_by=['competition', 'fixture_id'],
-    description='O FUNIL DE AVALIAÇÃO (#95, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). MATERIALIZAÇÃO TABELA nesta entrega (#95): a tabela nasce cobrindo desde a primeira odd coletada (16/06), então o backfill sai de graça. O append-only com congelamento no apito (ADR 0011) é a próxima entrega. NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil).'
+    description='O FUNIL DE AVALIAÇÃO (#95/#96, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011): materialização INCREMENTAL por merge no grão (fixture_id, market, outcome, line_key, janela). A linha é escrita e atualizada enquanto o kickoff do fixture está no FUTURO e nenhuma escrita acontece depois dele — o funil deixa de ser uma foto do que o código de hoje diria e passa a ser registro do que o Motor disse. `full_refresh=false` no config porque a fase de RECOVERY do workflow_futebol_odds roda o mesmo --select com --full-refresh: sem isso, a primeira recuperação de deriva apagaria o histórico inteiro. Toda linha carrega `gravado_em` e `origem`: `backfill` no build que cria a tabela (recalculado com o código de hoje, e é a única parte que NÃO é registro de época) e `corrente` em toda escrita incremental. Jogo adiado (PST/SUSP) cujo kickoff volta para o futuro VOLTA a ser gravável — o filtro lê o kickoff corrente, não o da escrita anterior. Fixture ausente em fact_fixtures (kickoff NULL) é FAIL-OPEN: continua gravável para sempre, porque perdê-lo quebraria a reconciliação (ADR 0003). NÃO HÁ EXPURGO DO FUNIL (~45 mil linhas/mês; a política se revisita se a tabela passar de 10 milhões de linhas). NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil).'
 ) }}
 
 -- ============================================================================
@@ -487,6 +491,12 @@ SELECT
     market,
     outcome,
     line_value,
+    -- A CHAVE DO MERGE, e ela existe por um motivo mecânico: `line_value` é NULL no 1X2,
+    -- no BTTS e na Dupla Chance, e num MERGE ... ON, NULL nunca casa com NULL. Com
+    -- `line_value` cru na `unique_key` toda linha desses três mercados seria INSERIDA de
+    -- novo a cada execução, em silêncio, até a guarda de grão acender. O `COALESCE` para
+    -- 'NONE' é o mesmo que os dois lados das guardas já usam.
+    COALESCE(CAST(line_value AS STRING), 'NONE') AS line_key,
     janela_usada                AS janela,
     janela_prioridade,
     -- redução, não veredito: diz qual das quatro janelas o board publicaria. Quem for
@@ -572,9 +582,47 @@ SELECT
     n_outcomes_valor,
     is_half_line,
 
-    CURRENT_TIMESTAMP() AS dbt_loaded_at
+    -- ----------------------------------------------------------------- os carimbos (#96)
+    -- QUANDO o Motor disse isto. Sob append-only, "quando o dbt carregou" e "quando ficou
+    -- registrado" são o MESMO instante — por isso este campo substituiu o `dbt_loaded_at`
+    -- em vez de conviver com ele. Duas colunas de tempo com o mesmo valor são duas colunas
+    -- que um dia divergem e ninguém sabe qual manda.
+    CURRENT_TIMESTAMP()         AS gravado_em,
+    -- DE ONDE ela veio. `backfill` é o build que CRIA a tabela: aquelas linhas foram
+    -- recalculadas com o código de hoje sobre odds antigas, e são a única parte do funil
+    -- que NÃO é registro do que foi dito na época — têm de dizer isso de si mesmas. Toda
+    -- escrita incremental é `corrente`, e essa sim é registro de época.
+    --
+    -- ⚠️ Uma linha `backfill` de jogo ainda futuro vira `corrente` no primeiro merge
+    -- seguinte. É o comportamento certo: ela voltou a ser escrita antes do apito, então
+    -- passou a ser registro de época de verdade.
+    '{{ 'corrente' if is_incremental() else 'backfill' }}' AS origem
 FROM com_gate
 -- LEFT, nunca INNER: fixture ausente em `fact_fixtures` não pode sumir do funil — sumir
 -- seria a perda silenciosa que a tabela inteira existe para impedir, e quebraria a
 -- reconciliação contra o de-vig. O kickoff vem NULL e diz isso de si mesmo.
 LEFT JOIN fixtures USING (fixture_id)
+{% if is_incremental() %}
+-- ============================================================================
+-- O CONGELAMENTO (#96, ADR 0011). É esta linha, e só ela, que transforma a tabela de
+-- foto em registro: o merge só recebe candidato de jogo que AINDA NÃO COMEÇOU, então
+-- nenhuma linha de kickoff passado é reescrita por build nenhum nem por deploy nenhum.
+--
+-- É no APITO INICIAL, não no status final: entre um e outro há duas horas em que os
+-- modelos de premissa continuam rodando, e tudo escrito ali seria nota nascida DEPOIS
+-- de a bola rolar — nota que ninguém podia ler antes de apostar. É a fresta que a
+-- ADR 0009 existe para fechar.
+--
+-- JOGO ADIADO REABRE, e de graça: o predicado lê o kickoff CORRENTE de `fact_fixtures`,
+-- não o que estava lá quando a linha foi escrita. `PST`/`SUSP` empurram o kickoff para o
+-- futuro, a linha volta a ser gravável, e é o comportamento certo — o jogo voltou a ser
+-- apostável e o que estava escrito descrevia uma partida que não aconteceu.
+--
+-- FIXTURE AUSENTE É FAIL-OPEN (kickoff NULL -> TRUE, ADR 0003). `NULL > CURRENT_TIMESTAMP()`
+-- é NULL, e sem o COALESCE a linha nunca mais seria escrita: ela sumiria do funil e a
+-- `assert_funil_reconcilia_com_devig` acenderia vermelha, com razão. Preferimos a linha
+-- eternamente gravável à linha perdida — não dá para congelar no apito de um jogo cuja
+-- hora não se sabe.
+-- ============================================================================
+WHERE COALESCE(_fx_kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
+{% endif %}

--- a/dbt_futebol/models/marts/fact_value_funnel_selo.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel_selo.sql
@@ -1,0 +1,79 @@
+{{ config(
+    materialized='incremental',
+    on_schema_change='append_new_columns',
+    full_refresh=false,
+    cluster_by=['dia_kickoff'],
+    description='O SELO DE IMUTABILIDADE DO FUNIL (#96, ADR 0011). 1 linha por (fixture_id, dia_kickoff) já passado, com a CONTAGEM e a SOMA DE NOTA que o fact_value_funnel tinha na primeira vez em que aquele dia ficou para trás. Escrito UMA VEZ e nunca reescrito — é a única testemunha externa que a guarda de imutabilidade pode consultar: um rebuild que reescrevesse o passado apagaria, junto, qualquer evidência guardada DENTRO do próprio funil. É a mesma lição da costura B da task [F] e da guarda de reconciliação: guarda que lê só o próprio produto não é guarda. NÃO VAI PARA O SUPABASE e não tem leitor no app.'
+) }}
+
+-- ============================================================================
+-- POR QUE ESTA TABELA EXISTE
+--
+-- O aceite da #96 pede que "contagem e soma de nota por dia de kickoff já passado não
+-- mudem ENTRE BUILDS". Entre builds é a parte difícil: nenhuma consulta ao funil de agora
+-- sabe o que o funil de ontem dizia. O `gravado_em` quase resolve — mas ele é reescrito
+-- junto com a linha, então um rebuild completo produz uma tabela internamente coerente e
+-- inteiramente nova, e a guarda de congelamento (que só olha `origem = 'corrente'`) passa
+-- por ela sem acender. O selo é o registro que o rebuild NÃO consegue reescrever.
+--
+-- O GRÃO INCLUI O FIXTURE, e não é detalhe (ADR 0011, jogo adiado): selar só por dia
+-- deixaria a guarda vermelha para sempre no primeiro `PST`. O jogo adiado muda de dia,
+-- some do agregado do dia velho, e um selo por dia acusaria uma diferença que é o
+-- comportamento correto. Com o fixture na chave, o selo do dia velho fica ÓRFÃO (o
+-- fixture não mora mais lá), a guarda o reconhece e o ignora, e o fixture é selado de
+-- novo quando o dia NOVO dele passar.
+--
+-- ⚠️ `full_refresh=false` pelo mesmo motivo do funil: a fase de RECOVERY do
+-- `workflow_futebol_odds` roda o mesmo `--select` com `--full-refresh`. Um selo
+-- reconstruído a partir do funil de agora é um selo que concorda com qualquer coisa.
+--
+-- ⚠️ Quando o funil PRECISAR ser reconstruído de propósito (mudança de esquema que exija
+-- recriar a tabela), o selo tem de ser derrubado JUNTO, no mesmo passo. Derrubar só um
+-- dos dois deixa a guarda vermelha permanentemente — e guarda permanentemente vermelha
+-- morre ignorada.
+-- ============================================================================
+WITH passados AS (
+    SELECT
+        fixture_id,
+        DATE(kickoff_utc) AS dia_kickoff,
+        score
+    FROM {{ ref('fact_value_funnel') }}
+    -- Kickoff NULL não sela: sem hora não há dia, e a linha é gravável para sempre por
+    -- decisão do modelo (fail-open, ADR 0003). Selá-la seria congelar o que o funil
+    -- deliberadamente não congela.
+    WHERE kickoff_utc IS NOT NULL
+      -- `< CURRENT_DATE()` e não `kickoff < now`: um dia só está inteiro no passado
+      -- quando o dia seguinte começou. Selar um dia ainda em curso congelaria a metade
+      -- dele que ainda estava sendo escrita.
+      AND DATE(kickoff_utc) < CURRENT_DATE()
+),
+
+agregado AS (
+    SELECT
+        fixture_id,
+        dia_kickoff,
+        COUNT(*)                        AS linhas,
+        -- NUMERIC, e não FLOAT64: soma de float depende da ORDEM das parcelas, e a ordem
+        -- de leitura de uma tabela do BigQuery não é estável entre execuções. Em NUMERIC
+        -- a soma é exata, e a guarda compara igualdade sem tremer no último bit (#92).
+        SUM(CAST(score AS NUMERIC))     AS soma_nota
+    FROM passados
+    GROUP BY fixture_id, dia_kickoff
+)
+
+SELECT
+    a.fixture_id,
+    a.dia_kickoff,
+    a.linhas,
+    a.soma_nota,
+    CURRENT_TIMESTAMP() AS selado_em
+FROM agregado a
+{% if is_incremental() %}
+-- INSERT-ONLY: sem `unique_key`, o incremental do dbt-bigquery insere e nunca atualiza.
+-- O anti-join é o que impede a duplicata — e é ele, não o merge, que garante que um selo
+-- já escrito jamais é revisto.
+LEFT JOIN {{ this }} s
+       ON s.fixture_id = a.fixture_id
+      AND s.dia_kickoff = a.dia_kickoff
+WHERE s.fixture_id IS NULL
+{% endif %}

--- a/dbt_futebol/models/marts/fact_value_funnel_selo.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel_selo.sql
@@ -3,7 +3,7 @@
     on_schema_change='append_new_columns',
     full_refresh=false,
     cluster_by=['dia_kickoff'],
-    description='O SELO DE IMUTABILIDADE DO FUNIL (#96, ADR 0011). 1 linha por (fixture_id, dia_kickoff) já passado, com a CONTAGEM e a SOMA DE NOTA que o fact_value_funnel tinha na primeira vez em que aquele dia ficou para trás. Escrito UMA VEZ e nunca reescrito — é a única testemunha externa que a guarda de imutabilidade pode consultar: um rebuild que reescrevesse o passado apagaria, junto, qualquer evidência guardada DENTRO do próprio funil. É a mesma lição da costura B da task [F] e da guarda de reconciliação: guarda que lê só o próprio produto não é guarda. NÃO VAI PARA O SUPABASE e não tem leitor no app.'
+    description='O SELO DE IMUTABILIDADE DO FUNIL (#96, ADR 0011). 1 linha por (fixture_id, dia_kickoff) JÁ APITADO, com a CONTAGEM e a SOMA DE NOTA que o fact_value_funnel tinha na primeira execução depois do apito daquele fixture. Escrito UMA VEZ e nunca reescrito — é a única testemunha externa que a guarda de imutabilidade pode consultar: um rebuild que reescrevesse o passado apagaria, junto, qualquer evidência guardada DENTRO do próprio funil. É a mesma lição da costura B da task [F] e da guarda de reconciliação: guarda que lê só o próprio produto não é guarda. NÃO VAI PARA O SUPABASE e não tem leitor no app.'
 ) }}
 
 -- ============================================================================
@@ -32,7 +32,7 @@
 -- dos dois deixa a guarda vermelha permanentemente — e guarda permanentemente vermelha
 -- morre ignorada.
 -- ============================================================================
-WITH passados AS (
+WITH apitados AS (
     SELECT
         fixture_id,
         DATE(kickoff_utc) AS dia_kickoff,
@@ -42,10 +42,12 @@ WITH passados AS (
     -- decisão do modelo (fail-open, ADR 0003). Selá-la seria congelar o que o funil
     -- deliberadamente não congela.
     WHERE kickoff_utc IS NOT NULL
-      -- `< CURRENT_DATE()` e não `kickoff < now`: um dia só está inteiro no passado
-      -- quando o dia seguinte começou. Selar um dia ainda em curso congelaria a metade
-      -- dele que ainda estava sendo escrita.
-      AND DATE(kickoff_utc) < CURRENT_DATE()
+      -- NO APITO, e não na virada do dia. O grão é por FIXTURE, então não há "metade do
+      -- dia ainda sendo escrita" a proteger: um jogo que já começou está inteiramente
+      -- congelado, e esperar a meia-noite deixaria o dia mais novo até 24 h sem selo —
+      -- justamente o dia em que um rebuild indevido é mais provável, logo depois de um
+      -- deploy. É a mesma fronteira que congela o funil, e de propósito.
+      AND kickoff_utc < CURRENT_TIMESTAMP()
 ),
 
 agregado AS (
@@ -57,7 +59,7 @@ agregado AS (
         -- de leitura de uma tabela do BigQuery não é estável entre execuções. Em NUMERIC
         -- a soma é exata, e a guarda compara igualdade sem tremer no último bit (#92).
         SUM(CAST(score AS NUMERIC))     AS soma_nota
-    FROM passados
+    FROM apitados
     GROUP BY fixture_id, dia_kickoff
 )
 

--- a/dbt_futebol/tests/assert_funil_congelado_no_apito.sql
+++ b/dbt_futebol/tests/assert_funil_congelado_no_apito.sql
@@ -1,0 +1,46 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DE CONGELAMENTO (#96, ADR 0011): nenhuma linha do funil foi escrita depois do
+-- apito inicial do seu próprio jogo.
+--
+-- É a guarda que prova a promessa central da entrega. O funil deixou de ser uma foto do
+-- que o código de hoje diria e passou a ser registro do que o Motor disse — e "o que ele
+-- disse" só vale se tiver sido dito ANTES de a bola rolar. Uma linha com
+-- `gravado_em > kickoff_utc` é nota que ninguém podia ter lido antes de apostar; ela não
+-- responde a pergunta que o funil existe para responder, contamina ela (ADR 0009).
+--
+-- ⚠️ ESCOPADA A `origem = 'corrente'`, e a exclusão é obrigatória, não conveniência. O
+-- backfill é o build que criou a tabela: ele recalculou 16/06 em diante com o código de
+-- hoje, então `gravado_em` é POSTERIOR ao apito em toda linha de jogo já disputado, por
+-- construção. Sem o escopo esta guarda nasceria vermelha em ~100% da história e morreria
+-- ignorada no primeiro dia. É exatamente por isso que a `origem` existe como coluna: sem
+-- ela não haveria como escrever esta guarda sem mentir.
+--
+-- ⚠️ E é justamente por causa desse escopo que ela NÃO cobre o rebuild. Um
+-- `--full-refresh` reescreve a tabela inteira carimbada `backfill`, e passa por aqui em
+-- silêncio. Quem pega isso é `assert_funil_imutavel_por_dia_de_kickoff`, que compara
+-- contra um selo escrito FORA do funil. As duas guardas se completam e nenhuma das duas
+-- substitui a outra.
+--
+-- ⚠️ Kickoff NULL (fixture ausente em `fact_fixtures`) cai fora do predicado sozinho —
+-- `gravado_em > NULL` é NULL, nunca TRUE. É o comportamento certo: a linha é gravável
+-- para sempre por decisão do modelo (fail-open, ADR 0003), e não dá para acusar atraso
+-- contra um apito cuja hora não se sabe. Quem grita sobre fixture ausente é a
+-- reconciliação, com diagnóstico próprio.
+--
+-- ⚠️ Ponto cego declarado, o de sempre (ADR 0005, subtask C4): até a C4 fechar, o job do
+-- agendado devolve sucesso mesmo com esta guarda vermelha.
+
+SELECT
+    fixture_id,
+    market,
+    outcome,
+    line_key,
+    janela,
+    kickoff_utc,
+    gravado_em,
+    origem,
+    TIMESTAMP_DIFF(gravado_em, kickoff_utc, MINUTE) AS minutos_depois_do_apito,
+    'linha escrita DEPOIS do apito do próprio jogo — o filtro de congelamento do modelo deixou passar, e esta nota nasceu com a bola rolando' AS diagnostico
+FROM {{ ref('fact_value_funnel') }}
+WHERE origem = 'corrente'
+  AND gravado_em > kickoff_utc

--- a/dbt_futebol/tests/assert_funil_imutavel_por_dia_de_kickoff.sql
+++ b/dbt_futebol/tests/assert_funil_imutavel_por_dia_de_kickoff.sql
@@ -1,0 +1,96 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DE IMUTABILIDADE (#96, ADR 0011): contagem e soma de nota, por dia de kickoff já
+-- passado, não mudam entre builds.
+--
+-- É a guarda que dá sentido à ordem em que a [A] foi fatiada. A A7 entra ANTES da A1
+-- porque, quando o preço sair da nota e as portas mudarem, o funil de antes tem de
+-- continuar exatamente como estava. Uma tabela reconstruída reescreveria 16/06 em diante
+-- sob as regras novas e o funil antigo — a coisa inteira que a A7 existe para salvar —
+-- deixaria de existir sem deixar rastro. Esta guarda é o rastro.
+--
+-- ⚠️ ELA COMPARA CONTRA UM REGISTRO ESCRITO FORA DO FUNIL (`fact_value_funnel_selo`), e
+-- essa é a decisão inteira. A versão tentadora seria conferir a coerência interna do
+-- funil — `gravado_em` contra `kickoff_utc`, portas contra `passou_no_gate`. Ela FECHA
+-- SEMPRE depois de um rebuild, porque a tabela reconstruída é internamente coerente e
+-- inteiramente nova. É a mesma armadilha da costura B da task [F] e a mesma razão pela
+-- qual a `assert_funil_reconcilia_com_devig` lê a fonte: guarda que lê só o próprio
+-- produto não é guarda, é uma segunda cópia dele.
+--
+-- O que ela pega, e o que cada caso significa:
+--
+--   · CONTAGEM diferente — linha nasceu ou sumiu num dia já encerrado. O filtro de
+--     congelamento do modelo parou de valer, ou a tabela foi reconstruída;
+--   · SOMA DE NOTA diferente com a mesma contagem — as mesmas linhas foram REPONTUADAS.
+--     É o modo de falha silencioso, e é exatamente o que a A1/A2/A3/A5 provocariam num
+--     funil reconstruído: mesma população, régua nova, história reescrita;
+--   · agregado AUSENTE para um selo cujo fixture ainda mora naquele dia — as linhas do
+--     jogo desapareceram do funil inteiras.
+--
+-- ⚠️ SELO ÓRFÃO É IGNORADO, e é a exceção que o jogo adiado exige (ADR 0011). `PST`/`SUSP`
+-- devolvem o kickoff para o futuro, a linha volta a ser gravável e o jogo passa a morar
+-- em OUTRO dia. O selo do dia velho continua lá descrevendo um dia em que aquele fixture
+-- não está mais, e acusá-lo seria acender vermelho sobre o comportamento correto. A
+-- condição `dia_atual = dia_kickoff` é o que separa "o fixture mudou de dia" (silêncio,
+-- ele sela de novo quando o dia novo passar) de "as linhas sumiram" (vermelho: o fixture
+-- não aparece em lugar nenhum do funil, `dia_atual` vem NULL, e o COALESCE o traz para
+-- dentro).
+--
+-- ⚠️ Ponto cego declarado, o de sempre (ADR 0005, subtask C4): até a C4 fechar, o job do
+-- agendado devolve sucesso mesmo com esta guarda vermelha.
+
+WITH funil AS (
+    SELECT
+        fixture_id,
+        DATE(kickoff_utc) AS dia_kickoff,
+        score
+    FROM {{ ref('fact_value_funnel') }}
+    WHERE kickoff_utc IS NOT NULL
+),
+
+-- Onde cada fixture mora AGORA. É o que distingue o jogo adiado do jogo apagado.
+dia_atual AS (
+    SELECT
+        fixture_id,
+        MAX(dia_kickoff) AS dia_atual
+    FROM funil
+    GROUP BY fixture_id
+),
+
+agora AS (
+    SELECT
+        fixture_id,
+        dia_kickoff,
+        COUNT(*)                    AS linhas,
+        -- NUMERIC dos dois lados: soma de FLOAT64 depende da ordem das parcelas e a ordem
+        -- de leitura do BigQuery não é estável entre execuções — a guarda tremeria no
+        -- último bit sem defeito nenhum (#92).
+        SUM(CAST(score AS NUMERIC)) AS soma_nota
+    FROM funil
+    GROUP BY fixture_id, dia_kickoff
+)
+
+SELECT
+    s.fixture_id,
+    s.dia_kickoff,
+    s.selado_em,
+    s.linhas       AS linhas_seladas,
+    a.linhas       AS linhas_agora,
+    s.soma_nota    AS soma_nota_selada,
+    a.soma_nota    AS soma_nota_agora,
+    CASE
+        WHEN a.fixture_id IS NULL
+            THEN 'dia de kickoff selado que não existe mais no funil — as linhas do jogo foram apagadas'
+        WHEN a.linhas <> s.linhas
+            THEN 'contagem de um dia de kickoff já passado mudou desde o selo — linha nasceu ou sumiu depois do apito, ou a tabela foi reconstruída'
+        ELSE 'mesma contagem e SOMA DE NOTA diferente: as mesmas linhas foram repontuadas sob uma régua que não existia quando o jogo aconteceu — a história do funil foi reescrita'
+    END AS diagnostico
+FROM {{ ref('fact_value_funnel_selo') }} s
+LEFT JOIN agora     a USING (fixture_id, dia_kickoff)
+LEFT JOIN dia_atual d USING (fixture_id)
+-- selo órfão (o fixture mudou de dia) sai daqui; fixture sumido do funil inteiro fica.
+WHERE COALESCE(d.dia_atual, s.dia_kickoff) = s.dia_kickoff
+  AND (
+        a.fixture_id IS NULL
+     OR a.linhas    <> s.linhas
+     OR a.soma_nota IS DISTINCT FROM s.soma_nota
+      )

--- a/dbt_futebol/tests/assert_funil_paridade_com_board.sql
+++ b/dbt_futebol/tests/assert_funil_paridade_com_board.sql
@@ -38,6 +38,25 @@
 -- `fact_value_funnel`, com linha construída. A guarda impede as duas cópias de divergirem
 -- onde o assinante enxerga; não onde a análise da [A] vai olhar.
 --
+-- ⚠️ ESCOPADA AO JOGO QUE AINDA NÃO COMEÇOU (#96), e sem isso ela não sobreviveria ao
+-- congelamento. Desde a ADR 0011 as duas tabelas param de andar juntas no instante do
+-- apito: o funil congela a linha ali e o board CONTINUA recalculando a dele até o expurgo
+-- levá-la — o que só acontece quando o status vira ao vivo ou terminal, ou quando a
+-- carência de 24 h vence. Nessa fresta o board relê premissas que foram recoletadas
+-- depois do apito, e a #78 já mostrou premissa que acende em número diferente de linhas a
+-- cada build com o insumo congelado. As duas tabelas divergiriam ali por acerto das duas,
+-- e a guarda acenderia vermelha sobre o comportamento que a ADR 0011 mandou construir.
+--
+-- O escopo é o mesmo predicado que governa a escrita do funil — kickoff no futuro, ou
+-- kickoff desconhecido (fail-open dos dois lados: o board não expurga fixture ausente e o
+-- funil não para de gravá-lo). Dentro dele a paridade continua sendo a igualdade EXATA de
+-- payload que o aceite da #95 pediu, e é onde ela vale: é o conjunto que o assinante
+-- ainda pode apostar.
+--
+-- ⚠️ O que sai junto com o escopo: uma divergência de fórmula que só aparecesse em jogo já
+-- apitado passa por aqui em silêncio. Não há como ser diferente — depois do apito não
+-- existe mais um par comparável, porque um dos dois lados parou no tempo de propósito.
+--
 -- ⚠️ ESTA GUARDA TEM DATA DE VALIDADE. No passo 2 o board passa a ser o funil filtrado, a
 -- paridade vira tautologia e ela é APOSENTADA no mesmo commit. Guarda que não pode falhar
 -- é ruído com cara de cobertura.
@@ -67,24 +86,29 @@
     'valor_fonte', 'pin_n_outcomes', 'is_half_line', 'competition', 'season'
 ] %}
 
-WITH board AS (
-    SELECT
-        fixture_id,
-        market,
-        outcome,
-        COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
-        janela_usada                                    AS janela,
-        score,
-        {{ payload | join(',\n        ') }}
-    FROM {{ ref('fact_value_opportunities') }}
-),
-
-fixtures AS (
+WITH fixtures AS (
     SELECT
         fixture_id,
         status_short AS _fx_status_short,
         kickoff_utc  AS _fx_kickoff_utc
     FROM {{ ref('fact_fixtures') }}
+),
+
+board AS (
+    SELECT
+        b.fixture_id,
+        b.market,
+        b.outcome,
+        COALESCE(CAST(b.line_value AS STRING), 'NONE')  AS line_key,
+        b.janela_usada                                  AS janela,
+        b.score,
+        b.{{ payload | join(',\n        b.') }}
+    FROM {{ ref('fact_value_opportunities') }} b
+    -- o escopo do cabeçalho, escrito contra `fact_fixtures` porque o board não publica o
+    -- kickoff. LEFT + COALESCE(..., TRUE): fixture ausente FICA, do mesmo jeito que fica
+    -- do lado do funil.
+    LEFT JOIN fixtures fx USING (fixture_id)
+    WHERE COALESCE(fx._fx_kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
 ),
 
 -- O funil na leitura que o board faria: janela corrente, gate aprovado, e — só para a
@@ -105,6 +129,8 @@ funil_publicavel AS (
     LEFT JOIN fixtures fx USING (fixture_id)
     WHERE f.janela_e_corrente
       AND f.passou_no_gate
+      -- kickoff no futuro, ou desconhecido: o par comparável (ver o cabeçalho).
+      AND COALESCE(f.kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
       AND NOT COALESCE(
             {{ futebol_expurga_do_board('fx._fx_status_short', 'fx._fx_kickoff_utc') }},
             FALSE

--- a/dbt_futebol/tests/assert_funil_paridade_com_board.sql
+++ b/dbt_futebol/tests/assert_funil_paridade_com_board.sql
@@ -77,12 +77,24 @@
 -- Ficam de fora as colunas que só existem de um lado: `faixa`, `evidencias`, `avisos` e
 -- `janela_deteccao` são do board (derivados ou de outra pergunta), `n_outcomes_valor`,
 -- `janela_prioridade` e as oito portas são do funil.
+--
+-- ⚠️ AS QUATRO COLUNAS DE FLOAT ENTRAM ARREDONDADAS, e não por gosto. `avg_odd` é uma
+-- média que o de-vig recalcula a cada leitura, e soma de FLOAT64 depende da ORDEM das
+-- parcelas — ordem que o BigQuery não promete estável entre execuções. Medido em 21/08 na
+-- validação da #96: o board trazia `1.7433333333333336` e o funil `1.7433333333333334`
+-- para a MESMA linha. Duas linhas vermelhas, nenhum defeito, o 16º dígito. É o mesmo
+-- knife-edge de float que a #92 já pagou uma vez.
+--
+-- A casa 10 é folgada de propósito: uma divergência de FÓRMULA — a coisa que esta guarda
+-- existe para pegar — é ordens de grandeza maior que 1e-10, e nenhuma delas passaria por
+-- aqui. O que passa é só o ruído de recomputação.
+{%- set payload_float = ['edge', 'best_odd', 'avg_odd', 'prob_justa_fechamento'] %}
 {%- set payload = [
-    'edge', 'pts_valor', 'pts_premissas', 'premissas_sem_dado', 'pts_corroboracao',
+    'pts_valor', 'pts_premissas', 'premissas_sem_dado', 'pts_corroboracao',
     'penalidades', 'penalidades_globais_pts', 'penalidades_especificas_pts',
     'pen_odd_outlier', 'pen_poucas_casas', 'pen_odd_longshot', 'pen_odd_juice',
     'modelo_api_concorda', 'linha_sharp_confirma',
-    'best_odd', 'best_book', 'avg_odd', 'n_casas', 'prob_justa_fechamento',
+    'best_book', 'n_casas',
     'valor_fonte', 'pin_n_outcomes', 'is_half_line', 'competition', 'season'
 ] %}
 
@@ -102,13 +114,14 @@ board AS (
         COALESCE(CAST(b.line_value AS STRING), 'NONE')  AS line_key,
         b.janela_usada                                  AS janela,
         b.score,
-        b.{{ payload | join(',\n        b.') }}
+        {% for c in payload_float %}ROUND(b.{{ c }}, 10) AS {{ c }},
+        {% endfor %}b.{{ payload | join(',\n        b.') }}
     FROM {{ ref('fact_value_opportunities') }} b
     -- o escopo do cabeçalho, escrito contra `fact_fixtures` porque o board não publica o
     -- kickoff. LEFT + COALESCE(..., TRUE): fixture ausente FICA, do mesmo jeito que fica
     -- do lado do funil.
     LEFT JOIN fixtures fx USING (fixture_id)
-    WHERE COALESCE(fx._fx_kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
+    WHERE {{ futebol_funil_e_gravavel('fx._fx_kickoff_utc') }}
 ),
 
 -- O funil na leitura que o board faria: janela corrente, gate aprovado, e — só para a
@@ -118,10 +131,12 @@ funil_publicavel AS (
         f.fixture_id,
         f.market,
         f.outcome,
-        COALESCE(CAST(f.line_value AS STRING), 'NONE')  AS line_key,
+        -- a coluna GRAVADA, não recomputada (ver a mesma nota na reconciliação).
+        f.line_key,
         f.janela,
         f.score,
-        f.{{ payload | join(',\n        f.') }}
+        {% for c in payload_float %}ROUND(f.{{ c }}, 10) AS {{ c }},
+        {% endfor %}f.{{ payload | join(',\n        f.') }}
     FROM {{ ref('fact_value_funnel') }} f
     -- LEFT + COALESCE(..., FALSE): fixture ausente é fail-open aqui pelo mesmo motivo que
     -- é fail-open no board — a linha fica, e quem grita sobre fixture ausente é a
@@ -129,8 +144,11 @@ funil_publicavel AS (
     LEFT JOIN fixtures fx USING (fixture_id)
     WHERE f.janela_e_corrente
       AND f.passou_no_gate
-      -- kickoff no futuro, ou desconhecido: o par comparável (ver o cabeçalho).
-      AND COALESCE(f.kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
+      -- kickoff no futuro, ou desconhecido: o par comparável (ver o cabeçalho). Mesmo
+      -- macro que congela o modelo, e — como do lado do board — lido de `fact_fixtures`,
+      -- nunca da coluna da própria linha: a coluna congela no apito e os dois lados de um
+      -- `EXCEPT` precisam do MESMO relógio.
+      AND {{ futebol_funil_e_gravavel('fx._fx_kickoff_utc') }}
       AND NOT COALESCE(
             {{ futebol_expurga_do_board('fx._fx_status_short', 'fx._fx_kickoff_utc') }},
             FALSE

--- a/dbt_futebol/tests/assert_funil_reconcilia_com_devig.sql
+++ b/dbt_futebol/tests/assert_funil_reconcilia_com_devig.sql
@@ -44,6 +44,15 @@
 -- linha que suma de um dia encerrado não acende aqui — acende em
 -- `assert_funil_imutavel_por_dia_de_kickoff`, que é a guarda escrita para essa metade.
 --
+-- ⚠️ ELA COMPARA UMA TABELA CONTRA UMA VIEW VIVA, então ela é sensível ao ATRASO entre o
+-- build e a execução dela. Odd coletada nesse intervalo aparece na fonte e ainda não no
+-- funil, e a guarda acusa "candidato que não virou linha" sem que exista defeito. Medido
+-- na validação da #96: 6 minutos de atraso bastaram para 84 linhas de UM fixture. No
+-- workflow ela roda logo depois do modelo, então o intervalo é pequeno — mas quem rodar a
+-- guarda à mão horas depois do último build vai ver isso, e a resposta é rodar o modelo
+-- antes, não caçar defeito. Não é novidade desta entrega: no passo 1 a tabela também era
+-- reconstruída a cada execução, com a mesma exposição.
+--
 -- ⚠️ Ponto cego declarado, o de sempre (ADR 0005, subtask C4): até a C4 fechar, o job do
 -- agendado devolve sucesso mesmo com esta guarda vermelha. Ela encurta o tempo até alguém
 -- saber; não impede a tabela errada de ser publicada.
@@ -51,7 +60,10 @@
 WITH kickoff AS (
     -- O kickoff CORRENTE, lido do mesmo lugar que o modelo lê. Jogo adiado volta a ser
     -- gravável sozinho, porque o kickoff dele voltou para o futuro.
-    SELECT fixture_id, kickoff_utc
+    -- prefixado porque o funil tem uma coluna `kickoff_utc` PRÓPRIA (a congelada), e as
+    -- duas no mesmo escopo tornam a referência ambígua — que é exatamente o par que esta
+    -- guarda não pode confundir.
+    SELECT fixture_id, kickoff_utc AS _fx_kickoff_utc
     FROM {{ ref('fact_fixtures') }}
 ),
 
@@ -65,12 +77,10 @@ fonte AS (
     FROM {{ ref('int_futebol_odds_devig') }}
     LEFT JOIN kickoff USING (fixture_id)
     WHERE market_id IN ({{ futebol_mercados_pontuados_ids() }})
-      -- O MESMO predicado que congela o modelo, COALESCE e tudo: kickoff no futuro, ou
-      -- fixture que `fact_fixtures` não conhece (fail-open — o modelo grava essa linha
-      -- para sempre, então a fonte tem de cobrá-la para sempre). Copiado aqui de
-      -- propósito e não extraído para macro: são três linhas e o macro esconderia
-      -- justamente o que esta guarda precisa deixar visível.
-      AND COALESCE(kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
+      -- O MESMO predicado que congela o modelo, lido do MESMO macro — nunca copiado.
+      -- Aqui a divergência seria muda nos dois sentidos: mais frouxa e a guarda não
+      -- acende, mais estrita e ela acende sem defeito.
+      AND {{ futebol_funil_e_gravavel('_fx_kickoff_utc') }}
 ),
 
 funil AS (
@@ -78,11 +88,22 @@ funil AS (
         fixture_id,
         market,
         outcome,
-        COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
+        -- a coluna GRAVADA, não recomputada: assim a comparação também VERIFICA a chave
+        -- do merge, em vez de refazê-la e concordar consigo mesma.
+        line_key,
         janela
     FROM {{ ref('fact_value_funnel') }}
-    -- O funil carrega o kickoff, então aqui o predicado se lê direto da própria linha.
-    WHERE COALESCE(kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
+    -- ⚠️ O KICKOFF VEM DE `fact_fixtures`, e NÃO da coluna da própria linha. O funil
+    -- carrega o kickoff que valia quando a linha foi escrita pela última vez, e ele PARA
+    -- de ser atualizado no apito — enquanto o lado da fonte, acima, lê o kickoff vivo.
+    -- Dois relógios diferentes nos dois lados de um `EXCEPT` produzem vermelho eterno com
+    -- o diagnóstico errado, e o caso é concreto: fixture que ainda não existia em
+    -- `fact_fixtures` quando a odd foi coletada grava `kickoff_utc` NULL, entra aqui por
+    -- fail-open PARA SEMPRE, e some da fonte no instante em que o fixture aparece com
+    -- kickoff no passado — a guarda acusaria "fan-out num dos joins" para todo o sempre,
+    -- sobre uma linha que não tem defeito nenhum.
+    LEFT JOIN kickoff USING (fixture_id)
+    WHERE {{ futebol_funil_e_gravavel('_fx_kickoff_utc') }}
 )
 
 SELECT

--- a/dbt_futebol/tests/assert_funil_reconcilia_com_devig.sql
+++ b/dbt_futebol/tests/assert_funil_reconcilia_com_devig.sql
@@ -24,11 +24,38 @@
 -- contagens iguais convivem confortavelmente com um erro que tira uma linha de um lado e
 -- põe outra do outro.
 --
+-- ⚠️ ESCOPADA AO QUE AINDA É GRAVÁVEL (#96). Desde o congelamento no apito (ADR 0011) as
+-- duas tabelas deixaram de ter o mesmo universo, e a igualdade sem escopo passou a ser
+-- falsa por construção nos DOIS sentidos:
+--
+--   · o funil guarda história que a fonte não guarda. Ele nunca expurga (~45 mil
+--     linhas/mês, para sempre); o de-vig só emite enquanto a coleta emite aquele fixture.
+--     No primeiro dia em que a fonte soltar um jogo velho, a guarda sem escopo acenderia
+--     vermelha POR ESTAR CERTA — e guarda permanentemente vermelha morre ignorada;
+--   · a fonte pode passar a emitir candidato de jogo já apitado, e o funil — corretamente
+--     — não o grava mais. Cobrar essa linha seria cobrar a violação do congelamento.
+--
+-- O escopo é, então, o conjunto de que o modelo é responsável NESTA execução: candidato
+-- cujo fixture ainda não começou (ou cujo kickoff se desconhece, que é gravável para
+-- sempre por fail-open). Dentro dele a igualdade continua exata e os dois modos de falha
+-- acima continuam cobertos.
+--
+-- ⚠️ O preço do escopo, dito em voz alta: a história JÁ CONGELADA sai da conferência. Uma
+-- linha que suma de um dia encerrado não acende aqui — acende em
+-- `assert_funil_imutavel_por_dia_de_kickoff`, que é a guarda escrita para essa metade.
+--
 -- ⚠️ Ponto cego declarado, o de sempre (ADR 0005, subtask C4): até a C4 fechar, o job do
 -- agendado devolve sucesso mesmo com esta guarda vermelha. Ela encurta o tempo até alguém
 -- saber; não impede a tabela errada de ser publicada.
 
-WITH fonte AS (
+WITH kickoff AS (
+    -- O kickoff CORRENTE, lido do mesmo lugar que o modelo lê. Jogo adiado volta a ser
+    -- gravável sozinho, porque o kickoff dele voltou para o futuro.
+    SELECT fixture_id, kickoff_utc
+    FROM {{ ref('fact_fixtures') }}
+),
+
+fonte AS (
     SELECT
         fixture_id,
         {{ futebol_market_slug('market_id') }}          AS market,
@@ -36,7 +63,14 @@ WITH fonte AS (
         COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
         janela_usada                                    AS janela
     FROM {{ ref('int_futebol_odds_devig') }}
+    LEFT JOIN kickoff USING (fixture_id)
     WHERE market_id IN ({{ futebol_mercados_pontuados_ids() }})
+      -- O MESMO predicado que congela o modelo, COALESCE e tudo: kickoff no futuro, ou
+      -- fixture que `fact_fixtures` não conhece (fail-open — o modelo grava essa linha
+      -- para sempre, então a fonte tem de cobrá-la para sempre). Copiado aqui de
+      -- propósito e não extraído para macro: são três linhas e o macro esconderia
+      -- justamente o que esta guarda precisa deixar visível.
+      AND COALESCE(kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
 ),
 
 funil AS (
@@ -47,6 +81,8 @@ funil AS (
         COALESCE(CAST(line_value AS STRING), 'NONE')    AS line_key,
         janela
     FROM {{ ref('fact_value_funnel') }}
+    -- O funil carrega o kickoff, então aqui o predicado se lê direto da própria linha.
+    WHERE COALESCE(kickoff_utc > CURRENT_TIMESTAMP(), TRUE)
 )
 
 SELECT


### PR DESCRIPTION
## O que muda

O funil deixa de ser uma foto do que o código de hoje diria e passa a ser **registro do que o
Motor disse**. Cada `(candidato, janela)` é escrito uma vez, atualizado enquanto o jogo ainda não
começou, e **congelado no apito**.

É isto que faz a A7 valer a pena entrar antes da A1: quando o preço sair da nota e as portas
mudarem, o funil de antes continua exatamente como estava.

## As peças

| peça | o que faz |
|---|---|
| `fact_value_funnel` incremental por merge | grão + `line_key`; `WHERE COALESCE(kickoff > CURRENT_TIMESTAMP(), TRUE)` no ramo incremental |
| `line_key` (coluna nova) | num `MERGE ... ON` NULL nunca casa com NULL. Com `line_value` cru na chave, **toda** linha de 1X2, BTTS e DC seria reinserida a cada execução — em silêncio |
| `full_refresh=false` | a fase de RECOVERY do `workflow-futebol-odds` roda o mesmo `--select` com `--full-refresh`. Sem a trava, a primeira recuperação de deriva apagaria o histórico inteiro, com o job verde |
| `gravado_em` / `origem` | `backfill` no build que cria a tabela, `corrente` em toda escrita incremental |
| `fact_value_funnel_selo` (modelo novo) | contagem e soma de nota de cada `(fixture, dia de kickoff)` que ficou para trás, escrito uma vez |
| 2 guardas novas (`tag:guarda`) | congelamento e imutabilidade |

**`gravado_em` substituiu o `dbt_loaded_at`** em vez de conviver com ele: sob append-only são o
mesmo instante, e duas colunas de tempo com o mesmo valor são duas colunas que um dia divergem e
ninguém sabe qual manda.

## Por que o selo é um modelo, e não uma query

O aceite pede uma propriedade **entre builds**, e nenhuma consulta ao funil de agora sabe o que o
funil de ontem dizia. Um rebuild produz uma tabela internamente coerente e inteiramente nova:
qualquer evidência guardada **dentro** do funil é reescrita junto com ele — inclusive o
`gravado_em`, e é por isso que a guarda de congelamento sozinha não pega o rebuild. O selo é o
registro que o rebuild não alcança. Mesma lição da costura B da task [F] e da
`assert_funil_reconcilia_com_devig`: guarda que lê só o próprio produto não é guarda.

O grão do selo inclui o **fixture**, e não é detalhe: selar por dia deixaria a guarda vermelha
para sempre no primeiro `PST`.

## ⚠️ Duas guardas mudaram de escopo — e essa é a decisão a vetar, se for para vetar

O aceite diz *"a guarda de paridade da entrega anterior continua verde"*. Ela **não continuaria**
sem escopo, e o mesmo vale para a reconciliação (que o ticket já mandava escopar). As duas ficariam
vermelhas **por estarem certas**:

- **reconciliação** — o funil nunca expurga; a fonte só emite enquanto a coleta emite aquele
  fixture. No primeiro dia em que o de-vig soltar um jogo velho, o funil guarda mais história do
  que a fonte;
- **paridade** — as duas tabelas param de andar juntas no instante do apito. O funil congela ali;
  o board continua recalculando até o expurgo levá-lo (status ao vivo/terminal, ou carência de
  24 h), relendo premissas que a #78 já mostrou não serem reprodutíveis entre builds.

As duas passam a comparar o conjunto de que o modelo é responsável nesta execução: **jogo por
acontecer** (ou de kickoff desconhecido, que é gravável para sempre por fail-open). O que sai
junto com o escopo é a história já congelada — e quem cobre essa metade é a guarda de
imutabilidade, que consegue porque compara contra um registro escrito fora do funil.

A rescopagem da paridade é **derivada**, não pedida literalmente pelo ticket. Está aqui em voz
alta para poder ser vetada em review, e não descoberta depois.

## O que o code review mudou

Rodado nos dois eixos (standards + spec). Achados de verdade, todos corrigidos no commit
`3a1514f`:

1. **Bug real.** A reconciliação lia o kickoff **vivo** de um lado e o **congelado** do outro.
   Caso concreto: fixture que ainda não existia em `fact_fixtures` quando a odd foi coletada grava
   `kickoff_utc` NULL, entra por fail-open **para sempre**, e some da fonte no instante em que o
   fixture aparece com kickoff no passado → vermelho eterno com o diagnóstico errado ("fan-out").
   Os dois lados das **duas** guardas passam a ler `fact_fixtures`.
2. **O selo fechava tarde demais.** Era `DATE(kickoff) < CURRENT_DATE()`, o que deixava o dia mais
   novo até 24 h sem selo — justamente o dia em que um rebuild indevido é mais provável, logo
   depois de um deploy. O grão é por fixture, então não havia meio-dia em curso a proteger: agora
   sela **no apito**.
3. **`origem`/`gravado_em` ganharam `tag:guarda`.** O agendado roda só essa seleção, e carimbo
   nulo é o sintoma exato da cutover malfeita. Sem a tag, ficaria mudo no único dia em que precisa
   gritar.
4. **O predicado de congelamento virou macro** (`futebol_funil_e_gravavel`), lido nos cinco sites.
   Era a mesma lição que o cabeçalho do `futebol_expurgo.sql` já ensinava; o comentário que
   declinava a extração estava errado.
5. **As guardas leem o `line_key` gravado** em vez de recomputá-lo — assim a comparação
   **verifica** a chave do merge em vez de refazê-la e concordar consigo mesma. O teste de grão
   passa a testar `line_key` pelo mesmo motivo.

## 🐛 E um defeito do passo 1 que a validação achou de raspão

A paridade comparava `avg_odd` em **FLOAT64 cru**. O de-vig recalcula essa média a cada leitura,
soma de float depende da ordem das parcelas, e a ordem do BigQuery não é estável entre execuções.
Medido em 21/08: board `1.7433333333333336` vs funil `1.7433333333333334` — **duas linhas
vermelhas, nenhum defeito, o 16º dígito**. É o mesmo knife-edge que a #92 já pagou.

As quatro colunas de float (`edge`, `best_odd`, `avg_odd`, `prob_justa_fechamento`) entram
arredondadas na casa 10. Folgada de propósito: divergência de **fórmula** — a coisa que a guarda
existe para pegar — é ordens de grandeza maior que 1e-10.

Isto **não** é da #96; é latente desde a #95 e teria acendido sozinho em prod qualquer dia
destes. Consertado aqui porque o aceite pede que a paridade continue verde, e uma guarda que
treme no último bit não fica verde de forma confiável.

## Validação, sem tocar produção

Dataset próprio `futebol_funil96` (ADR 0007), com `--defer` contra o manifest de prod. Dropado ao
fim.

| passo | resultado |
|---|---|
| build inicial (ramo full refresh) | 98.948 linhas, 100% `backfill` |
| merge seguinte | tocou **só** as 8.362 de jogo futuro, carimbadas `corrente`; total continua 98.948 (zero duplicata — o `line_key` segura) |
| escritas depois do apito | **0** |
| mudar uma porta (`n_casas >= 3` → `>= 99`) e remergear | guarda de imutabilidade **verde**: nenhum dia selado se moveu |
| `dbt run --full-refresh` | **recusado** — saiu `MERGE`, não `CREATE TABLE` |
| suíte no dataset próprio | 39 testes verdes (inclusive os 5 unit tests do funil) |
| suíte de unit tests inteira | 17 verdes |

**As duas guardas novas foram falsificadas** (guarda que não pode acender é ruído com cara de
cobertura):

- repontuar 182 linhas de um dia já selado → `assert_funil_imutavel_por_dia_de_kickoff` **FAIL 1**;
- carimbar 378 linhas como escritas 90 min depois do apito → `assert_funil_congelado_no_apito`
  **FAIL 378**.

As duas foram **refalsificadas depois** do commit de review, para provar que o refactor não
esvaziou nenhuma delas.

⚠️ **A reconciliação compara uma tabela contra uma view viva**, então é sensível ao atraso entre o
build e a execução dela: 6 minutos bastaram para 84 linhas de um fixture cuja odd foi coletada
nesse intervalo. Rodando modelo e guarda em sequência — a ordem do workflow — 39/39. Não é
novidade desta entrega (no passo 1 a tabela também era reconstruída a cada execução, com a mesma
exposição), mas está escrito no cabeçalho da guarda para ninguém caçar defeito onde não há.

⚠️ As duas guardas rescopadas **não rodam mais contra a prod de hoje**: elas leem `line_key`, que
a tabela do passo 1 não tem. Rodaram verdes contra prod antes dessa mudança; depois dela, a
conferência é a do passo 4 do cutover.

## 🚨 Cutover: mergear NÃO basta, e a tabela precisa cair

A `unique_key` inclui `line_key`, que não existe nas linhas do passo 1. A primeira execução sobre
a tabela velha **duplicaria** toda linha de jogo futuro em vez de atualizá-la. A virada é derrubar
a tabela e deixar o primeiro build recriá-la — ele roda o ramo de full refresh, carimba `backfill`
em 16/06 em diante (que é exatamente o que o carimbo quer dizer) e o selo nasce na mesma execução.

```bash
# 1. na DE (PR irmão: tech-lamjav/data-engineering) — editar o yml local não muda o workflow live
./scripts/deploy_workflows.sh workflow-futebol-odds

# 2. na AE, depois do merge
./build-and-push.sh dbt_futebol

# 3. IMEDIATAMENTE depois do (2)
bq rm -f -t smartbetting-dados:futebol.fact_value_funnel

# 4. disparar o workflow à mão e conferir
#    - nenhuma linha com origem NULL
#    - fact_value_funnel_selo com linhas
```

⚠️ **Entre (2) e (3) as QUATRO guardas do funil dão ERRO, e é esperado**: rodam da imagem nova
contra a tabela velha — as duas novas não acham `origem` nem o selo, e as duas do passo 1 não
acham `line_key`. É erro de compilação, não guarda vermelha,
e passa sozinho no (4). Está escrito porque a alternativa é alguém gastar um dia rediagnosticando
um alarme que a própria ordem do deploy produziu.

Se uma execução agendada couber entre (2) e (3) e fizer o merge ruim, o conserto é o mesmo (3) e
(4) de novo — o estado não é absorvente.

⚠️ E daqui sai uma regra permanente, escrita na ADR: **funil e selo caem juntos, ou nenhum dos
dois cai.**

## Não-objetivos, declarados

- **O board não muda.** O flip (board lendo o funil) é o passo 2 da ADR 0011 e espera a #85.
- **Nada vai para o Supabase**: sem migração, sem RPC, sem `check_schema_parity`.
- **Nenhuma porta mudou de predicado.** A única alteração de comportamento é *quando* a linha é
  escrita.
- **Retenção**: não há expurgo do funil (~45 mil linhas/mês). Declarado no yml e na ADR.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
