### PR TITLE
docs(adr): a promessa de que os servicos entravam pela tabela de alvos era falsa (DE #44)

### DIFF
--- a/docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md
+++ b/docs/adr/0001-carimbo-de-procedencia-da-imagem-dbt.md
@@ -107,5 +107,24 @@ no master e não na imagem. Sintoma e detector desligados pela mesma causa.
   fail-closed funcionando, não um defeito.
 - O `dbt_nba` **não tem nenhum teste `tag:guarda`** (os 10 são todos do futebol). O carimbo é
   a única cobertura que a NBA tem contra esta classe.
-- Os serviços Cloud Run do `data-engineering` sofrem da mesma deriva e ainda **não** estão
-  cobertos; o detector já é uma tabela declarativa de alvos para recebê-los.
+- ~~Os serviços Cloud Run do `data-engineering` sofrem da mesma deriva e ainda **não** estão
+  cobertos; o detector já é uma tabela declarativa de alvos para recebê-los.~~
+  **Corrigido em 24/08/2026 (DE #44).** A primeira metade continua verdadeira — e foi medida:
+  os 13 serviços da NBA rodaram **dois meses** (25/06–24/08) com `src/` defasado, sem que nada
+  acusasse. A segunda metade era **falsa** e atrasou o conserto: o desenho é genérico quanto ao
+  *alvo*, não quanto ao *repositório*. O `procedencia.sh` hasheia paths relativas a
+  `git rev-parse --show-toplevel`, que aqui é sempre o `analytics-engineering`; as paths de um
+  serviço estão no `data-engineering`. Acrescentar um nome à tabela `ALVOS` não teria funcionado.
+  A cobertura dos serviços passou a ser um mecanismo **irmão, com dono próprio**:
+  [`data-engineering/docs/adr/0001-carimbo-de-procedencia-dos-servicos-cloud-run.md`](https://github.com/tech-lamjav/data-engineering/blob/master/docs/adr/0001-carimbo-de-procedencia-dos-servicos-cloud-run.md).
+  O critério que decidiu foi versionamento acoplado: quem escreve o carimbo
+  (`deploy_cloud_run.sh`) e quem o confere têm de mudar a função de hash e o manifesto no mesmo
+  commit — e o escritor mora lá. Este ADR segue dono **apenas** dos dois jobs dbt.
+
+## Emenda de 24/08/2026 — as citações "Q4" e "Q14" nunca existiram
+
+O `checa_deriva.sh` remetia a "ADR 0001, Q4" e o `procedencia.sh` a "Q14 do ADR 0001". **Este
+documento nunca teve perguntas numeradas**: elas vieram da sessão de grilling que o gerou e não
+foram reconciliadas quando o texto virou ADR. Ponteiro quebrado dentro do artefato que existe
+justamente para ser lido por quem está confuso. Os dois comentários passaram a citar a seção
+real (*Decisões*, item 2, e este bullet de *Consequências*).

--- a/scripts/checa_deriva.sh
+++ b/scripts/checa_deriva.sh
@@ -27,8 +27,15 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 # Tabela declarativa de alvos. Acrescentar um alvo é acrescentar um nome aqui — desde que
-# `scripts/procedencia.sh` conheça as paths dele. Os serviços Cloud Run do repo
-# data-engineering entram por esta mesma porta quando chegarem (ver ADR 0001, Q4).
+# `scripts/procedencia.sh` conheça as paths dele.
+#
+# ⚠️ ISTO VALE SÓ PARA ALVOS DESTE REPO. Os serviços Cloud Run do `data-engineering` NÃO
+# entram por esta porta, ao contrário do que este comentário afirmou até 24/08/2026: o
+# `procedencia.sh` hasheia paths relativas ao `git rev-parse --show-toplevel`, que aqui é
+# sempre o analytics-engineering. O desenho é genérico quanto ao ALVO, não quanto ao
+# REPOSITÓRIO. Eles têm detector irmão e dono próprio lá — ver
+# data-engineering/docs/adr/0001-carimbo-de-procedencia-dos-servicos-cloud-run.md
+# (o bullet corrigido em Consequências do ADR 0001 conta por quê).
 if [ $# -gt 0 ]; then
     ALVOS=("$@")
 else

--- a/scripts/procedencia.sh
+++ b/scripts/procedencia.sh
@@ -50,7 +50,8 @@ if [ -z "$PROJECT_NAME" ]; then
 fi
 
 # Tabela declarativa: projeto -> paths que carregam comportamento.
-# Acrescentar um alvo é acrescentar um ramo aqui (ver Q14 do ADR 0001).
+# Acrescentar um alvo é acrescentar um ramo aqui (ver a decisão 2 do ADR 0001 — o critério é
+# "carrega comportamento", não "vai para a imagem").
 # `requirements.txt`, `profiles.yml` e o Dockerfile entram porque também vão para a imagem
 # e mudam o que ela faz (versão do dbt, target do BigQuery, etapas do build).
 case "$PROJECT_NAME" in


### PR DESCRIPTION
Emenda no ADR 0001 e conserto de três ponteiros quebrados. **Só comentário e documentação** — nenhuma linha de comportamento.

### A promessa era falsa, e atrasou o conserto

O último bullet de *Consequências* dizia que os serviços Cloud Run do `data-engineering` ainda não estavam cobertos "**mas o detector já é uma tabela declarativa de alvos para recebê-los**".

A primeira metade era verdadeira — e foi medida: os 13 serviços da NBA rodaram **dois meses** (25/06–24/08) com `src/` defasado, sem que nada acusasse. A segunda metade era **falsa**: o `procedencia.sh` hasheia paths relativas ao `git rev-parse --show-toplevel`, que aqui é sempre o `analytics-engineering`. O desenho é genérico quanto ao **alvo**, não quanto ao **repositório** — acrescentar um nome à tabela `ALVOS` não teria funcionado.

Isso não é detalhe de redação: a issue DE #44 descrevia o trabalho como "acrescentar um nome", citando exatamente essa frase.

A cobertura dos serviços virou mecanismo **irmão, com dono próprio** no `data-engineering` (tech-lamjav/data-engineering#57). O critério que decidiu foi versionamento acoplado: quem escreve o carimbo é o `deploy_cloud_run.sh`, que mora lá. Este ADR segue dono **apenas** dos dois jobs dbt.

### "Q4" e "Q14" nunca existiram

`checa_deriva.sh` remetia a "ADR 0001, Q4" e `procedencia.sh` a "Q14 do ADR 0001". Este ADR **nunca teve perguntas numeradas** — vieram da sessão de grilling que o gerou e não foram reconciliadas quando o texto virou ADR. Ponteiro quebrado dentro do artefato que existe justamente para ser lido por quem está confuso. Os dois passam a citar a seção real.

### Não gera deriva

`scripts/` não está entre as paths hasheadas, e nenhum arquivo hasheado foi tocado. Conferido rodando o próprio script nos dois alvos após a mudança:

```
dbt_futebol  fd3b1979e41efb81a7372eaa643adf1998d68c40
dbt_nba      c72c7ce065cbef10e503e8b8ba47bdc2ad050d2f
```

`bash -n` limpo nos dois scripts.

⚠️ **Mergear DEPOIS de tech-lamjav/data-engineering#57** — a emenda linka para o ADR novo em `master`, e o link 404 até lá. Mergear na ordem errada publica link morto dentro de uma correção sobre links mortos.

Relacionado a tech-lamjav/data-engineering#44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016unvLVAGnCQPHqKi4Yp3mb
