### PR TITLE
fix(futebol): a quarta cópia do predicado de meia-linha estava na medição (#113)

### DIFF
--- a/dbt_futebol/macros/futebol_linha_meia.sql
+++ b/dbt_futebol/macros/futebol_linha_meia.sql
@@ -45,13 +45,21 @@
   ({0, 1, 3}) pode ser alcançado por arredondamento a partir dela.
 
   ⚠️ POR QUE MACRO E NÃO SQL NO MODELO — e esta é a lição que o próprio defeito ensinou:
-  a expressão tinha TRÊS cópias (`fact_value_opportunities`, `fact_value_funnel` e a
-  análise `taskA_linha_de_base`), e o funil nasceu com o defeito porque copiou a
+  a expressão tinha QUATRO cópias (`fact_value_opportunities`, `fact_value_funnel`, a
+  análise `taskA_linha_de_base` e o `task01_meia_linha` do `macros/task01_base.sql`), e o funil
+  nasceu com o defeito porque copiou a
   expressão do board **byte a byte**, de propósito, para que a guarda
   `assert_funil_paridade_com_board` pudesse provar que o funil descreve o board. Predicado
   copiado é predicado que diverge no primeiro refactor — e aqui a divergência seria muda:
-  a paridade continuaria verde comparando dois erros iguais. Com um macro só, os três não
+  a paridade continuaria verde comparando dois erros iguais. Com um macro só, os quatro não
   têm como discordar. É a mesma razão de `futebol_expurgo.sql`.
+
+  ⚠️ E A QUARTA COPIA SÓ ENTROU AQUI NA #113, DEPOIS — a #101 corrigiu três e contou três. A que
+  faltava não estava no board: estava na MEDIÇÃO (`task01_meia_linha`, o filtro de linha do
+  universo dos Testes 2, 3 e 4), que é onde o defeito decidia peso de premissa em vez de decidir
+  o que aparece na tela. Na janela congelada da [F] ela deixava entrar 3.140 de 9.252 linhas —
+  34% do universo de medição — como se fossem meias. Contar cópia de cabeça é o modo de falha
+  que este parágrafo agora registra duas vezes.
 
   ⚠️ NULL É NULL, DE PROPÓSITO. Mercado sem linha (1X2 / BTTS / Dupla Chance) tem
   `line_value` NULL e o predicado resolve para NULL — não para FALSE. A porta não se

--- a/dbt_futebol/macros/task01_base.sql
+++ b/dbt_futebol/macros/task01_base.sql
@@ -106,14 +106,25 @@
 
 
 {#- Só meia-linha em Handicap e Over/Under: elimina push, que não tem liquidação
-    binária. MOD() do BQ devolve negativo p/ linha AH negativa -> ABS() antes.
+    binária.
 
     Existe como macro porque a guarda de descarte precisa do MESMO predicado fora da
     CTE `apostas`. Duplicá-lo deixaria a guarda derivar em silêncio da coisa que ela
-    guarda. `alias` inclui o ponto: task01_meia_linha('o.') -#}
+    guarda. `alias` inclui o ponto: task01_meia_linha('o.')
+
+    ⚠️ O TESTE EM SI NÃO MORA AQUI (#113). Ele mora em futebol_e_linha_meia(), com o board, o
+    funil e a linha de base — porque esta ERA a quarta cópia dele, e ela carregava o defeito que
+    a #101 corrigiu nas outras três: comparado em MEIOS
+    (`MOD(CAST(ABS(lv) * 2 AS INT64), 2) = 1`), o `.25` entra como meia, porque o BigQuery
+    arredonda meio para longe do zero e `0,25 * 2 = 0,5` vira 1. Medido na janela congelada da
+    [F]: 3.140 de 9.252 linhas do universo de medição eram linha de quarto — 34% do total e 40%
+    das linhas de Handicap e Gols. O `.75` escapava por sorte, não por construção.
+
+    O que sobra aqui é o ESCOPO — quais mercados têm linha que pode dar push —, que é decisão do
+    Teste 2 e não do predicado. -#}
 {% macro task01_meia_linha(alias='') %}
     ({{ alias }}market_id NOT IN (4, 5)
-     OR MOD(CAST(ABS({{ alias }}line_value) * 2 AS INT64), 2) = 1)
+     OR {{ futebol_e_linha_meia(alias ~ 'line_value') }})
 {% endmacro %}
 
 


### PR DESCRIPTION
Fecha a #113. Entra **entre a P1 e a P2 da #82** — ver o comentário de reescopo da #82.

## O que muda

`task01_meia_linha` (`macros/task01_base.sql`) passa a delegar para `futebol_e_linha_meia()`, a
macro que a #101 criou. Era a quarta cópia do predicado, e a única que a #101 não corrigiu — o
cabeçalho da `futebol_linha_meia.sql` contava três, e agora conta quatro.

## O número

Medido na janela congelada da [F] (`kickoff_utc ∈ [2026-06-16, 2026-08-04 12:00 UTC)`), sobre o
de-vig de produção reduzido à janela corrente, com os mesmos predicados do `task01_base`:

| | linhas |
|---|---|
| universo de medição (regra antiga) | 9.252 |
| dele, Handicap + Gols | 7.820 |
| dele, **linha de quarto entrando como meia** | **3.140** |

34% do universo de medição; 40% das linhas de Handicap e Gols. Na janela nova (04/08 12:00 em
diante), o vazamento é de 14.528 linhas nos mesmos dois mercados — a janela em que a remedição do
Teste 2 vai rodar.

## Teste

Sem unit test novo, de propósito: o predicado agora É o da `futebol_e_linha_meia()`, que a #101
cobriu com 15 unit tests (`.0/.25/.5/.75`, quarto negativo, mercado sem linha). Um teste novo aqui
testaria a mesma expressão duas vezes. O que fica medido é o EFEITO, e ele é o delta P1→P2 da #82,
publicado no `docs/TASKF_RESULTADOS.md`.

## Consequência declarada (não é escopo)

Os números publicados da [0.1] e o 2×2 da [F] foram medidos **com linha de quarto dentro**. Não se
rebaselina nada: a ADR 0010 já tirou a reconciliação contra a [0.1] do caminho que importa, e a [F]
é registro congelado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016unvLVAGnCQPHqKi4Yp3mb