### PR TITLE
feat(taskf): a âncora da remedição, em duas passadas (#82)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -400,8 +400,9 @@ reading tied windows as movement. Guarded by `assert_premissas_sem_agregado_inst
 _Avoid_: "a média" unqualified, when the question is whether two builds can be compared
 
 **Escopo do PIT**:
-Which competitions a PIT aggregate counts. Today it is *da competição*: only fixtures of the
-same competition as the one being rated. It is **not one join** — `int_futebol_team_form_pit`
+Which competitions a PIT aggregate counts. Since #91 it is *todas*: every competition a team has
+played counts, whatever the one being rated. (Until then it was *da competição*, and production
+only serves the new default once the #91 deploy lands.) It is **not one join** — `int_futebol_team_form_pit`
 holds one, and each of the five premissa models holds its own local history besides (the `last5`
 of Gols, BTTS and Dupla Chance, the Handicap's `margin_stats`, the xG/ritmo spine). Nine
 predicates over six models; the axis reaches all of them or the cell comes out mixed. Table sheet
@@ -409,9 +410,28 @@ in ADR 0007.
 _Avoid_: "juntar os campeonatos" (silent about whether escopo, recorte, or both is changing)
 
 **Recorte do PIT**:
-Which stretch of past fixtures a PIT aggregate counts. Today it is season-to-date. A counting
-recorte ("the last N") crosses the season boundary by construction; a season recorte does not.
+Which stretch of past fixtures a PIT aggregate counts. Since #91 it is the last 10 fixtures;
+until then it was season-to-date. A counting recorte ("the last N") crosses the season boundary
+by construction; a season recorte does not — which is why the pair was flipped together, and not
+the escopo alone (ADR 0010).
 _Avoid_: janela — that word is taken by the odds collection window, and the two are unrelated
+
+**Âncora da remedição**:
+The célula `ambos` measured again under the code that #91 made the default, over the frozen
+universe, which the remediation's Teste 2 must reproduce. It replaces the reconciliation against
+the [0.1], which dies by construction once both the window and the pipeline change (ADR 0010). It
+lives outside the accumulative table, because a cell measured at another commit would break the
+same-execution invariant the 2×2 rests on.
+_Avoid_: baseline (taken by the Costura A), reconciliação (taken by the [0.1] one)
+
+**Meia-linha / linha de quarto**:
+A meia-linha (.5) is the only Handicap or Over/Under line that cannot push or half-push; a linha
+de quarto (.25/.75) is half a bet on each of its two neighbours, so part of the stake can come
+back. The 2-way de-vig normalises over two outcomes that are not exhaustive on anything but a
+meia-linha, so the published edge there describes a bet nobody can place. The test is
+`futebol_e_linha_meia()` and lives in one macro because it had four copies and three of them were
+wrong (#101, #113).
+_Avoid_: "linha inteira" for .25/.75 — a linha cheia is .0, and it pushes differently
 
 **Célula de medição**:
 One combination of escopo and recorte under which the whole premissa layer is rematerialised

--- a/dbt_futebol/analyses/taskf_pit_por_celula.sql
+++ b/dbt_futebol/analyses/taskf_pit_por_celula.sql
@@ -61,13 +61,17 @@
       bq query --use_legacy_sql=false --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_pit_por_celula.sql
 
+    ⚠️ NA #82 O DESTINO É OUTRO. A âncora da remedição escreve em `taskf_pit_por_celula_ancora`,
+    pela var `taskf_destino` (`medicao` | `ancora`, fail-closed) — ver macros/taskf_destino.sql e o
+    cabeçalho de analyses/taskf_teste2.sql, FASE 4. Esta acumulativa fica intocada.
+
     (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
 
     → RESULTADOS: `docs/TASKF_RESULTADOS.md`.
 */
 
 {%- set c      = taskf_celula() -%}
-{%- set tabela = 'smartbetting-dados.futebol_taskF.taskf_pit_por_celula' -%}
+{%- set tabela = taskf_destino('taskf_pit_por_celula') -%}
 {#- Ver o cabeçalho: sob `temporada` a coluna não existe no modelo porque sem teto ela seria o
     próprio played_total. -#}
 {%- set col_disponivel = 'played_total_disponivel' if c.recorte == 'ultimos_10' else 'played_total' -%}

--- a/dbt_futebol/analyses/taskf_remedicao.sql
+++ b/dbt_futebol/analyses/taskf_remedicao.sql
@@ -93,9 +93,15 @@ WITH agora AS (
     WHERE universo = 'completo'
 ),
 
+{#- As cópias _54 e _55 são anteriores à coluna `universo` (#58) e contêm só o que hoje se chama
+    `completo`. Qualquer outra tabela do lado antigo tem os quatro universos, e comparar sem
+    recortar faria a junção abrir 4x — a chave não inclui universo, e o resultado seria um delta
+    inflado com cara de achado. -#}
+{%- set anterior_tem_universo = anterior not in ['taskf_teste2_54', 'taskf_teste2_55'] -%}
+
 antes AS (
     SELECT * FROM {{ source('futebol_taskF', anterior) }}
-    {%- if anterior == 'taskf_teste2' %}
+    {%- if anterior_tem_universo %}
     WHERE universo = 'completo'
     {%- endif %}
 ),

--- a/dbt_futebol/analyses/taskf_remedicao.sql
+++ b/dbt_futebol/analyses/taskf_remedicao.sql
@@ -81,13 +81,23 @@
     contra uma cópia nova — o padrão é `taskf_teste2_<ticket>`, declarada em sources.yml. -#}
 {%- set anterior = var('taskf_remedicao_anterior', 'taskf_teste2_55') -%}
 
+{#- E qual é o lado ATUAL. Também é var, desde a #82: a âncora da remedição mora em
+    `taskf_teste2_ancora` e não na acumulativa (macros/taskf_destino.sql), e a pergunta desta
+    análise — "a re-medição devolveu os mesmos números?" — é exatamente a que a #82 faz da célula
+    `ambos` antiga contra a nova. Sem isto, a comparação viraria de novo uma query solta, que é o
+    defeito que este arquivo existe para não repetir. -#}
+{%- set atual = var('taskf_remedicao_agora', 'taskf_teste2') -%}
+
 WITH agora AS (
-    SELECT * FROM {{ source('futebol_taskF', 'taskf_teste2') }}
+    SELECT * FROM {{ source('futebol_taskF', atual) }}
     WHERE universo = 'completo'
 ),
 
 antes AS (
     SELECT * FROM {{ source('futebol_taskF', anterior) }}
+    {%- if anterior == 'taskf_teste2' %}
+    WHERE universo = 'completo'
+    {%- endif %}
 ),
 
 {#- FULL OUTER: linha que existe só de um lado é achado, não ausência de achado. -#}

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -111,6 +111,13 @@
     por extenso de propósito: ele é o contrato que as células seguintes têm de cumprir, e um
     INSERT de formato diferente falha alto em vez de alargar a tabela em silêncio.
 
+    ⚠️ E O DESTINO PODE SER A ÂNCORA, E NÃO ESTA TABELA (#82, ADR 0010). A célula `ambos` medida
+    sob o código pós-#91 NÃO se grava aqui: a primeira invariante da Costura B cobra `git_sha`
+    idêntico nas quatro células, e sobrescrever `ambos` com outro commit deixaria o 2×2 de ser uma
+    comparação. Ela vai para a tabela irmã `taskf_teste2_ancora`, pela var `taskf_destino`
+    (`medicao` | `ancora`, fail-closed) — ver macros/taskf_destino.sql. Esta tabela permanece o
+    registro congelado do 2×2 medido em 12–13/08, que é o que a ADR 0010 promete.
+
     ⚠️ E É POR ISSO QUE MUDAR O SCHEMA EXIGE DROPAR A TABELA. `CREATE TABLE IF NOT EXISTS` não
     acrescenta coluna a uma tabela que já existe: com o schema novo, o INSERT de lista explícita
     falha na primeira célula. Aconteceu três vezes — a #54 (as duas contagens de amostra), a #55
@@ -181,6 +188,26 @@
     As três guardas leem SÓ a tabela acumulativa (por `source()`), não penduram em modelo nenhum
     e por isso não entram nas fases 1 e 2 de carona.
 
+    FASE 4, só na #82 (ADR 0010): a ÂNCORA DA REMEDIÇÃO. É a fase 2 outra vez, na célula `ambos` —
+    que é o DEFAULT desde a #91, então sem `--vars` de eixo — com o destino trocado. O par
+    `taskf_teste2_ancora` / `taskf_pit_por_celula_ancora` recebe a medição e as acumulativas não são
+    tocadas, o que é o ponto: a Costura B continua verde sobre um 2×2 de um commit só.
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
+        --select int_futebol_team_form_pit int_futebol_premissas_1x2 int_futebol_premissas_ou \
+                 int_futebol_premissas_ah int_futebol_premissas_btts int_futebol_premissas_dc \
+        --exclude assert_taskf_pit_default_igual_baseline
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_pit_por_celula \
+        --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', taskf_destino: ancora}'
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_teste2 \
+        --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', taskf_destino: ancora}'
+      (os dois `bq query <` na mesma ordem)
+
+    ⚠️ A Costura A entra na exclusão porque o BASELINE dela ainda é o de 12/08 (célula `base`,
+    commit a3b954e — `baseline_pit_meta`), e o recongelamento é passo do DEPLOY da #91, a partir de
+    produção. Recongelar daqui carimbaria o baseline com os fatos de 12/08 do dataset de medição.
+
     ⚠️ O CARIMBO DO PIT vem DEPOIS do build da mesma célula, sempre. O rótulo dele sai das vars em
     tempo de compilação e o dado sai do que está materializado: fora de ordem, uma célula é
     gravada com o nome de outra. Ver o cabeçalho de analyses/taskf_pit_por_celula.sql.
@@ -212,7 +239,7 @@
 {%- set c      = taskf_celula() -%}
 {%- set j      = taskf_universo() -%}
 {%- set pisos  = taskf_pisos() -%}
-{%- set tabela = 'smartbetting-dados.futebol_taskF.taskf_teste2' -%}
+{%- set tabela = taskf_destino('taskf_teste2') -%}
 
 {#- Uma lista, três usos: o DDL, a lista de colunas do INSERT e a ordem da projeção. Escrita duas
     vezes, ela derivaria — e um INSERT posicional com colunas trocadas de lugar não dá erro, dá

--- a/dbt_futebol/docs/adr/0010-a-remedicao-do-teste-2-e-janela-nova-sobre-pipeline-juntado.md
+++ b/dbt_futebol/docs/adr/0010-a-remedicao-do-teste-2-e-janela-nova-sobre-pipeline-juntado.md
@@ -148,6 +148,22 @@ alguém investigaria como achado. Quem implementar precisa de granularidade de t
 seja estendendo o `cutoff` do macro, seja lendo a definição de universo da própria [F]. As duas
 janelas ladrilham exatamente nesse instante, e é por isso que ele precisa ser o mesmo dos dois lados.
 
+⚠️ **EMENDA DE 25/08 (#82, executada): a âncora NÃO cabe dentro da acumulativa.** Este documento
+diz "reconstruir a célula `ambos`", e a leitura literal disso é sobrescrevê-la em
+`futebol_taskF.taskf_teste2`. Não dá: a primeira invariante da Costura B
+(`assert_taskf_celulas_mesmo_universo`, CTE `execucao`) cobra `git_sha` **idêntico nas quatro
+células**, e uma célula medida noutro commit deixaria a guarda vermelha com razão — o 2×2 deixaria
+de ser uma comparação, e este mesmo documento promete que `futebol_taskF` permanece o registro
+congelado dele. A âncora nasce em `taskf_teste2_ancora`, por uma var fail-closed (`taskf_destino`,
+macros/taskf_destino.sql) na MESMA análise, e as acumulativas ficam intocadas.
+
+E ela saiu em **duas passadas**, não uma: entre a medição da [F] e hoje entrou também a **#113** —
+a quarta cópia do predicado de meia-linha, que deixava a linha de QUARTO entrar no universo de
+medição como se fosse meia (3.140 de 9.252 linhas na janela congelada). Uma correção nesse caminho
+depois da âncora a mataria pelo mesmo argumento de identidade de código que o parágrafo abaixo faz
+sobre a #71. P1 mede sem a #113 e isola #78+#71+#91; P2 mede com ela e é a âncora. Resultados e
+carimbos em `docs/TASKF_RESULTADOS.md`, seção "#82 — A âncora da remedição, em duas passadas".
+
 Isso torna a **#82 pré-requisito**, e a reescopa: de *"rebaselinar os 4 números da [F]"* para
 **"reconstruir a célula `ambos` sob o código pós-#78, como âncora da remedição"**. Sem isso a
 comparação falharia justamente em `superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado` e

--- a/dbt_futebol/macros/taskf_destino.sql
+++ b/dbt_futebol/macros/taskf_destino.sql
@@ -1,0 +1,52 @@
+{#
+    ONDE A MEDIÇÃO GRAVA — o 2×2 congelado da [F], ou a âncora da remedição (#82, ADR 0010).
+
+    A [F] mediu quatro células e as pôs em duas tabelas acumulativas de `futebol_taskF`
+    (`taskf_teste2` e `taskf_pit_por_celula`), uma linha por célula, cada execução substituindo só
+    a sua. A #82 precisa medir a célula `ambos` DE NOVO, sob o código que a #91 virou default, para
+    servir de âncora à remedição do Teste 2 — e não pode gravá-la ali dentro.
+
+    POR QUE NÃO PODE, e isto é medido e não estético: a primeira invariante da Costura B
+    (`assert_taskf_celulas_mesmo_universo`, CTE `execucao`) cobra `git_sha` IDÊNTICO nas quatro
+    células, e o cabeçalho dela diz por quê — "medir a `base` num commit e a `ambos` noutro, sobre
+    os mesmos fatos, passaria pelas duas primeiras pontas e ainda assim compararia duas coisas
+    diferentes". Sobrescrever a célula `ambos` com uma medição de outro commit deixaria a guarda
+    vermelha COM RAZÃO: o 2×2 deixaria de ser uma comparação. E a ADR 0010 promete o contrário —
+    "`futebol_taskF` permanece como registro congelado do 2×2".
+
+    Então a âncora nasce em tabela irmã, com o mesmo schema e o mesmo código de agregação. É uma
+    var, e não uma análise nova, porque copiar a agregação é exatamente o que o cabeçalho do
+    analyses/taskf_teste2.sql recusa por escrito: o que a âncora precisa reproduzir é o MESMO
+    cálculo, e duas cópias não ficam iguais para sempre.
+
+        taskf_destino  medicao (default) → smartbetting-dados.futebol_taskF.<tabela>
+                       ancora            → smartbetting-dados.futebol_taskF.<tabela>_ancora
+
+    FAIL-CLOSED, pelo mesmo motivo do taskf_eixos(): valor desconhecido levanta erro de compilação
+    em vez de cair no default. Um `taskf_destino: âncora` (com acento) escreveria por cima do 2×2
+    congelado em silêncio, e o dano é irreversível — a acumulativa não tem histórico.
+
+    O default é `medicao` porque o caminho perigoso tem de exigir declaração explícita, nunca o
+    contrário. E o projeto e o dataset ficam escritos aqui, fixos: o destino da medição NÃO segue
+    o target, senão um `--target dev` distraído publicaria medição no dataset do board (ADR 0007).
+
+    Uso:
+
+        {%- set tabela = taskf_destino('taskf_teste2') -%}
+        CREATE TABLE IF NOT EXISTS `{{ tabela }}` ( ... )
+#}
+
+{% macro taskf_destino(tabela) %}
+
+    {%- set destino = var('taskf_destino', 'medicao') -%}
+
+    {%- if destino not in ['medicao', 'ancora'] -%}
+        {{ exceptions.raise_compiler_error(
+            "taskf_destino inválido: '" ~ destino ~ "'. Valores aceitos: medicao | ancora.") }}
+    {%- endif -%}
+
+    {%- set sufixo = '' if destino == 'medicao' else '_ancora' -%}
+
+    {{ return('smartbetting-dados.futebol_taskF.' ~ tabela ~ sufixo) }}
+
+{% endmacro %}

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -584,6 +584,29 @@ sources:
           Mesmo papel e mesmas regras da taskf_teste2_54 acima: registro histórico, não se escreve
           nela, e a próxima mudança de schema cria a sua própria cópia com o número do ticket.
 
+      - name: taskf_teste2_ancora
+        description: >
+          A ÂNCORA DA REMEDIÇÃO (#82, ADR 0010): a célula `ambos` medida de novo sob o código que a
+          #91 virou default, no mesmo universo congelado e com o mesmo schema da acumulativa ao
+          lado. É o lado esquerdo da única conferência que sobrevive à troca de janela — o Teste 2
+          do pipeline novo, rodado sobre a janela congelada, tem de reproduzi-la.
+
+          ⚠️ Ela existe SEPARADA da taskf_teste2 por um motivo medido, não por organização: a
+          primeira invariante da Costura B cobra `git_sha` idêntico nas quatro células, então
+          sobrescrever `ambos` com uma medição de outro commit deixaria o 2×2 de ser uma
+          comparação — e a ADR 0010 promete que `futebol_taskF` permanece o registro congelado
+          dele. Escrita pelo MESMO analyses/taskf_teste2.sql, com `--vars '{taskf_destino: ancora}'`
+          (macros/taskf_destino.sql, fail-closed).
+
+          ⚠️ O que a invalida: qualquer mudança em `task01_base`, no de-vig, no
+          int_futebol_team_form_pit ou nos cinco modelos de premissas entre a medição dela e a
+          remedição. O `git_sha` da linha é o que permite conferir isso depois.
+
+      - name: taskf_pit_por_celula_ancora
+        description: >
+          O carimbo do PIT da âncora — mesma relação com o taskf_pit_por_celula que a
+          taskf_teste2_ancora tem com a taskf_teste2, e escrito na mesma execução (#82).
+
       - name: taskf_teste2
         description: >
           A saída do Teste 2 da medição, uma linha por (célula, UNIVERSO, mercado, premissa,

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -602,6 +602,19 @@ sources:
           int_futebol_team_form_pit ou nos cinco modelos de premissas entre a medição dela e a
           remedição. O `git_sha` da linha é o que permite conferir isso depois.
 
+      - name: taskf_teste2_ancora_p1
+        description: >
+          A PRIMEIRA das duas passadas da #82: a célula `ambos` sob o código pós-#91 mas ANTES da
+          #113, ou seja, ainda com a linha de quarto entrando no universo como se fosse meia.
+          Existe para que o movimento entre a célula de 12–13/08 e a âncora seja decomponível em
+          DUAS causas em vez de uma só — 12–13/08 → P1 é o efeito de #78 + #71 + #91 sobre a
+          medição; P1 → âncora é o efeito do universo corrigido pela #113. Sem ela, o delta
+          misturaria quatro causas e um defeito se esconderia dentro dele.
+
+          ⚠️ Registro histórico, como as taskf_teste2_54/_55: não se escreve nela. Comparada por
+          analyses/taskf_remedicao.sql com `--vars '{taskf_remedicao_agora: taskf_teste2_ancora,
+          taskf_remedicao_anterior: taskf_teste2_ancora_p1}'`.
+
       - name: taskf_pit_por_celula_ancora
         description: >
           O carimbo do PIT da âncora — mesma relação com o taskf_pit_por_celula que a

--- a/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
+++ b/dbt_futebol/tests/assert_taskf_base_reproduz_01.sql
@@ -8,6 +8,15 @@
 -- células não têm como significar coisa alguma. É a única das três invariantes que compara a
 -- medição contra algo de FORA dela.
 --
+-- ⚠️ ELA É VERDE POR CONGELAMENTO DESDE A ADR 0010, E ISSO É DELIBERADO. O cabeçalho abaixo
+-- previa que ela ficaria vermelha "na próxima remedição", quando as células fossem reconstruídas.
+-- Elas não serão: a ADR 0010 decidiu que a remedição roda em produção, e a #82 pôs a célula
+-- reconstruída em `taskf_teste2_ancora`, fora da acumulativa que esta guarda lê. Então ela segue
+-- comparando a `base` de 12–13/08 contra os números publicados da [0.1] — duas coisas paradas,
+-- que continuam batendo e continuarão. A aposentadoria dela (com o dataset de medição) é limpeza
+-- da task [B]; até lá, verde aqui significa "o registro congelado segue íntegro", e não "a
+-- medição de hoje reproduz a [0.1]".
+--
 -- ⚠️ E É `base` NO UNIVERSO `completo` (#58). Esta é a única das quatro guardas que NÃO se
 -- generaliza para os outros universos, e a razão não é economia: o lado esquerdo da comparação são
 -- os números PUBLICADOS da [0.1], que existem para um recorte só — os 169 jogos de 16/06 a 04/08.

--- a/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
+++ b/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
@@ -13,9 +13,16 @@
 -- o default. "O default reproduz o comportamento de antes das vars" deixou de ser verdade no
 -- mesmo commit em que deixou de ser desejável.
 --
--- O que ela afirma AGORA: o default não se move sozinho. O baseline foi regravado (pelo
--- analyses/taskf_congela_baseline.sql) a partir da célula `ambos` com AET/PEN no histórico
--- (#71), e a guarda segue comparando linha a linha contra ele. Deixou de ser guarda de
+-- O que ela afirma AGORA: o default não se move sozinho. O baseline É REGRAVADO (pelo
+-- analyses/taskf_congela_baseline.sql) a partir da célula `ambos` com AET/PEN no histórico (#71),
+-- e a guarda segue comparando linha a linha contra ele.
+--
+-- ⚠️ E ISSO É FUTURO, NÃO PASSADO — o recongelamento é PASSO DE DEPLOY da #91, a partir de
+-- PRODUÇÃO, e em 25/08 ele ainda não tinha acontecido: `futebol_taskF.baseline_pit_meta` diz
+-- 12/08 12:22:46, commit `a3b954e`, que é a célula `base`. Enquanto ele não rodar, esta guarda
+-- fica VERMELHA em qualquer build do PIT no default, e é por isso que a receita da âncora da #82
+-- a exclui por escrito. Recongelar a partir do `futebol_taskF` seria pior que não recongelar:
+-- carimbaria o baseline de produção com os fatos de 12/08 do dataset de medição. Deixou de ser guarda de
 -- vazamento-de-andaime e virou guarda de DERIVA: falha = a saída de produção mudou sem que o
 -- insumo tenha mudado, que é o mesmo modo de falha que ela sempre pegou, só que agora sobre o
 -- caminho que o board de fato serve.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -3042,6 +3042,14 @@ campo é `jogos_medios_disp`, que é o próprio `min_jogos`. Os campos mais movi
 em ordem: `jogos_medios_disp` (59 linhas), `pct_amostra_curta` (49), `n_p5` (49), `diferenca_p5`
 (49) — a assinatura de um piso de amostra que passou a contar outras partidas.
 
+### ⚠️ Os dois números da linha de quarto, e por que eles diferem
+
+A #113 publica **3.140** linhas de quarto e este doc publica **2.962** (8.567 − 5.605). Os dois
+estão certos, em denominadores diferentes: os 3.140 foram contados no de-vig de PRODUÇÃO reduzido
+à janela corrente, com os predicados do `task01_base` **menos o filtro de jogo encerrado** — 179
+jogos. Os 2.962 são a mesma conta dentro do universo de medição de verdade, os 169 jogos
+encerrados e precificados. A diferença são os 10 jogos que a #113 não filtrou.
+
 ### O passo 2 é cirúrgico, e é o que a #113 previu
 
 Fora o `linhas_no_universo` (que muda em todas as 60 linhas, porque o universo encolheu 34,6%), o
@@ -3123,8 +3131,15 @@ dataset: ele lê a landing direto, que é append-only e é a mesma que produçã
 
 ### O que invalida esta âncora
 
-Qualquer mudança em `macros/task01_base.sql`, no de-vig, no `int_futebol_team_form_pit` ou nos cinco
-modelos de premissas entre esta medição e a remedição. Não há guarda automática — a âncora é tabela
+Qualquer mudança de COMPORTAMENTO em `macros/task01_base.sql`, no de-vig, no
+`int_futebol_team_form_pit` ou nos cinco modelos de premissas entre esta medição e a remedição.
+
+⚠️ **Estender o `cutoff` do `task01_base` a timestamp NÃO invalida** — e é preciso dizer isso, porque
+a remedição tem essa extensão como pré-requisito declarado, e a lista lida ao pé da letra faria a
+remedição matar a própria âncora. O que a âncora exige é que o instante usado seja o teto
+(`2026-08-04 12:00:00 UTC`) e que o universo devolva os mesmos **169 jogos / 5.605 linhas**. Mudar a
+assinatura para conseguir exatamente isso é o oposto de invalidá-la; o que invalidaria seria mudar
+quais jogos ou quais linhas entram. Não há guarda automática — a âncora é tabela
 fora do dbt. O que existe é o `git_sha` gravado em cada linha (`6f9dcc6`) e esta lista.
 
 ### Reprodução

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -2992,3 +2992,165 @@ O rebaseline dos quatro números da [F] que a #78 avisou que ficariam vermelhos 
 reconstrução das células (`superioridade_xg`, `xg_combinado_alto`, `xg_baixo_combinado`,
 `ritmo_alto`). Isso é a #82 reescopada, sequenciada pela ADR 0010, e exige `dbt run --target
 taskF`. A #92 termina na régua.
+
+---
+
+## #82 — A âncora da remedição, em duas passadas
+
+⚠️ **ESTA SEÇÃO NÃO É PARTE DO 2×2.** O 2×2 das quatro células continua sendo o de 12–13/08,
+commit `7fdd1a3`, e as tabelas acima não foram tocadas. O que esta seção mede é uma célula `ambos`
+NOVA, sob o código que a #91 virou default, que existe para um único fim: ser o lado esquerdo da
+conferência que a **ADR 0010** pôs no lugar da reconciliação contra a [0.1] — *rodar o Teste 2 do
+pipeline novo sobre a janela congelada e cobrar que ele reproduza a célula `ambos`*.
+
+Ela mora em `futebol_taskF.taskf_teste2_ancora`, e não na acumulativa, por um motivo medido: a
+primeira invariante da Costura B cobra `git_sha` idêntico nas quatro células
+(`assert_taskf_celulas_mesmo_universo`, CTE `execucao`). Gravar `ambos` de outro commit ali dentro
+deixaria a guarda vermelha com razão — o 2×2 deixaria de ser uma comparação.
+
+### Carimbo de execução
+
+| Passada | Execução | Corte do universo | Destino |
+|---|---|---|---|
+| **P1** — código pós-#91, predicado de meia-linha ANTIGO | 2026-08-25 14:17:42 UTC, commit `7b4f9d2` | `kickoff` em [16/06, 04/08 12:00 UTC) — **169 jogos**, 8.567 linhas | `taskf_teste2_ancora_p1` |
+| **P2** — o mesmo, com a #113 mergeada. **É a âncora** | 2026-08-25 14:24:22 UTC, commit `6f9dcc6` | mesmos **169 jogos**, **5.605 linhas** | `taskf_teste2_ancora` |
+
+Nas duas, `odds_loaded_at` = **12/08 13:24:15** — o mesmo das quatro células de 12–13/08. A fase 1
+não foi re-rodada de propósito: os fatos que a medição lê já são os mesmos dos de produção (ver
+"Os fatos não se moveram", abaixo), e reconstruí-los reinjetaria a variação que a #55 mediu.
+
+### Por que DUAS passadas
+
+Porque o delta entre a célula de 12–13/08 e a âncora carrega quatro causas, e um delta de causa
+única é conferível enquanto um de quatro é uma esperança. A decomposição:
+
+| Passo | O que isola | Linhas do universo | Linhas movidas (de 60) | Campos movidos |
+|---|---|---|---|---|
+| 12–13/08 → **P1** | #78 (média reproduzível, 17/08) + #71 (AET/PEN no `team_log`) + #91 (o piso corta o disponível) + as views realinhadas | 8.567 → 8.567 | 60 | 848 |
+| **P1** → **P2** | #113 — a linha de quarto sai do universo | 8.567 → **5.605** | 60 | 934, dos quais 60 são o próprio `linhas_no_universo` |
+
+### O passo 1 move tudo, e o mecanismo tem número
+
+Das 60 linhas medidas, **as 60 se movem** — e não é achado, é a #71. `AET` e `PEN` passaram a
+contar no `team_log`, e no passado que alimenta esta janela existem **140 partidas nesse estado**
+(121 `PEN` + 19 `AET`, contra 7.888 `FT`). Elas são quase todas de mata-mata — e a janela congelada
+é 46,7% Copa do Mundo. Toda premissa que lê histórico de time muda de contagem por construção.
+
+A conferência de que é isso e não outra coisa é o comportamento das premissas que **não** leem
+histórico: `sem_rodizio`, `h2h_favoravel` e `desfalque_adversario` movem **um campo cada** — e o
+campo é `jogos_medios_disp`, que é o próprio `min_jogos`. Os campos mais movidos do passo 1 são,
+em ordem: `jogos_medios_disp` (59 linhas), `pct_amostra_curta` (49), `n_p5` (49), `diferenca_p5`
+(49) — a assinatura de um piso de amostra que passou a contar outras partidas.
+
+### O passo 2 é cirúrgico, e é o que a #113 previu
+
+Fora o `linhas_no_universo` (que muda em todas as 60 linhas, porque o universo encolheu 34,6%), o
+movimento do passo 2 está **inteiramente em Handicap e Gols** — os mercados 4 e 5, os únicos com
+linha que pode dar push:
+
+| mercado | linhas medidas que se movem além do universo | campos |
+|---|---|---|
+| Gols | 26 | 571 |
+| Handicap | 16 | 344 |
+| 1X2 / BTTS / Dupla Chance | **0** | 1 |
+
+O único campo fora de 4/5 é `forca_mismatch` (1X2), `jogos_medios_disp` 70,4 → 70,3 — 0,1 num
+campo diagnóstico, entre duas reconstruções dos modelos. É o empate de grade que o cabeçalho da
+`analyses/taskf_remedicao.sql` descreve, e a ADR 0010 já decidiu sobre esse número: *registrar e
+seguir, não preservar*.
+
+### As premissas que a #82 nasceu para rebaselinar, nas três leituras
+
+`n` e `diferença` no piso 0, e diferença no piso 5, em pontos percentuais:
+
+| mercado | premissa | benchmark | n₀ 13/08 → P1 → P2 | dif₀ 13/08 → P1 → P2 | dif₅ 13/08 → P1 → P2 |
+|---|---|---|---|---|---|
+| 1X2 | `superioridade_xg` | sharp | 129 → 129 → 129 | 2,6 → 2,6 → 2,6 | **−5,6 → −3,8 → −3,8** |
+| Gols | `xg_combinado_alto` | sharp | 361 → 361 → **231** | −2,5 → −2,5 → **+0,2** | −5,6 → −4,9 → −2,3 |
+| Gols | `xg_combinado_alto` | consenso | 274 → 274 → **152** | −4,3 → −4,3 → −0,7 | −7,1 → −6,4 → −1,1 |
+| Gols | `xg_baixo_combinado` | sharp | 319 → 319 → 224 | 1,1 → 1,1 → 1,0 | 2,3 → 2,3 → 2,3 |
+| Gols | `xg_baixo_combinado` | consenso | 628 → 628 → 407 | 1,8 → 1,8 → 0,6 | 2,8 → 3,0 → 0,5 |
+| Gols | `ritmo_alto` | sharp | 511 → 519 → 333 | −9,2 → −8,2 → −7,7 | −17,7 → −14,5 → −13,1 |
+| Gols | `ritmo_alto` | consenso | 584 → 597 → 370 | −4,6 → −3,7 → −0,2 | −10,4 → −8,2 → −2,4 |
+
+E as duas premissas mais fortes do Handicap, que a ADR 0010 tinha precificado como ressalva do
+recorte, agora com o universo corrigido:
+
+| premissa | benchmark | n₀ 13/08 → P1 → P2 | dif₀ 13/08 → P1 → P2 |
+|---|---|---|---|
+| `raramente_perde_por_2` | sharp | 394 → 415 → **193** | 8,2 → 8,3 → **5,5** |
+| `raramente_perde_por_2` | consenso | 392 → 407 → 270 | 6,7 → 6,9 → 6,9 |
+| `favorito_irregular` | sharp | 420 → 423 → **194** | 7,9 → 8,0 → **5,7** |
+| `favorito_irregular` | consenso | 407 → 409 → 271 | 5,8 → 5,8 → 5,5 |
+| `tende_golear` | sharp | 159 → 159 → 74 | 8,2 → 8,2 → **13,8** |
+| `clean_sheets_altos` | sharp | 92 → 86 → 51 | 23,7 → 26,8 → 25,3 |
+
+⚠️ **O que isto diz para a [B], e é o achado desta issue:** metade da amostra das duas premissas
+mais fortes do Handicap era linha de quarto, e o ganho delas cai ~2,5 pp quando ela sai. `xg_combinado_alto`
+troca de sinal contra a Pinnacle (−2,5 → +0,2). Nenhum desses números é o publicado da [0.1], e
+nenhum deles é comparável a ele — mas eles são a leitura que sobrevive à #113, e a [B] julga sobre
+o pipeline que serve o catálogo.
+
+### Os fatos não se moveram — medido, não suposto
+
+A âncora foi construída sobre os fatos de 12/08 do `futebol_taskF`, e é legítimo porque eles
+descrevem o mesmo passado que produção descreve hoje:
+
+| o quê, na janela congelada | `futebol` | `futebol_taskF` |
+|---|---|---|
+| `fact_odds_snapshot`, t15m / t1h / t24h | 191.454 / 204.928 / 194.184 | idêntico |
+| `int_futebol_odds_devig` reduzido à janela corrente | 19.610 | 19.610, `EXCEPT DISTINCT` zero nos dois sentidos |
+| `fact_fixtures` com kickoff < 04/08 12:00 | 8.036 | 8.037 |
+| `fact_fixture_stats` do mesmo recorte | 15.534 | 15.532 |
+
+O de-vig do `futebol_taskF` é um build **pré-#37** (uma linha por aposta) contra as quatro janelas
+de produção — mas sob a redução à janela corrente, que todo consumidor aplica, os dois dão o mesmo
+conjunto linha a linha. E as duas premissas de movimento de linha não leem o de-vig
+(`int_futebol_premissas_ou.sql`, CTE de movimento, lê `fact_odds_snapshot` direto).
+
+⚠️ **As duas divergências, com nome, e vão para a remedição como ressalva:**
+- fixture **1492145** (brasileirão, 25/02, `PST`, sem gols) existe no `futebol_taskF` e sumiu de
+  produção. Não entra em histórico nenhum.
+- fixture **1492290** (brasileirão, **21/07 — dentro da janela congelada**) tem `fact_fixture_stats`
+  em produção (times 1062 e 118) que o `futebol_taskF` não tem. As premissas de xG/ritmo desse jogo
+  podem divergir entre a âncora e o Teste 2 de produção **por dado, não por código**.
+
+⚠️ **As views do `futebol_taskF` eram de 12/08 e foram realinhadas ao código de hoje antes da P1**
+(`dbt run --target taskF --select path:models/staging int_futebol_desfalques
+int_futebol_player_importance int_futebol_corroboracao`), porque view é CÓDIGO e não fato — a #42
+e a #38 as tinham mudado. Nisso o `stg_futebol_injuries_coleta` (tabela, 591 linhas) foi criado no
+dataset: ele lê a landing direto, que é append-only e é a mesma que produção lê.
+
+### O que invalida esta âncora
+
+Qualquer mudança em `macros/task01_base.sql`, no de-vig, no `int_futebol_team_form_pit` ou nos cinco
+modelos de premissas entre esta medição e a remedição. Não há guarda automática — a âncora é tabela
+fora do dbt. O que existe é o `git_sha` gravado em cada linha (`6f9dcc6`) e esta lista.
+
+### Reprodução
+
+```bash
+# do dbt_futebol/, com o commit 6f9dcc6 em mãos
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt build --target taskF \
+  --select int_futebol_team_form_pit int_futebol_premissas_1x2 int_futebol_premissas_ou \
+           int_futebol_premissas_ah int_futebol_premissas_btts int_futebol_premissas_dc \
+  --exclude assert_taskf_pit_default_igual_baseline
+
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
+  --select taskf_pit_por_celula taskf_teste2 \
+  --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', taskf_destino: ancora}'
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_pit_por_celula.sql
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/taskf_teste2.sql
+
+# os dois deltas
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_remedicao \
+  --vars '{taskf_remedicao_agora: taskf_teste2_ancora_p1, taskf_remedicao_anterior: taskf_teste2}'
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_remedicao \
+  --vars '{taskf_remedicao_agora: taskf_teste2_ancora, taskf_remedicao_anterior: taskf_teste2_ancora_p1}'
+```
+
+⚠️ A Costura A entra na exclusão porque o baseline dela ainda é o de 12/08 (célula `base`, commit
+`a3b954e` — `baseline_pit_meta`). O recongelamento é passo do **deploy** da #91 e sai de PRODUÇÃO;
+recongelar a partir daqui carimbaria o baseline com os fatos de 12/08 do dataset de medição.


### PR DESCRIPTION
Closes #82.  O reescopo e o porquê de cada decisão estão no [comentário de grilling](https://github.com/tech-lamjav/analytics-engineering/issues/82#issuecomment-5411639867); aqui vai o que mudou no repo e o que saiu medido.

## O mecanismo

A âncora **não cabe** dentro de `futebol_taskF.taskf_teste2`: a primeira invariante da Costura B cobra `git_sha` idêntico nas quatro células, e uma célula de outro commit ali dentro deixaria o 2×2 de ser uma comparação. Ela nasce em `taskf_teste2_ancora`, por uma var fail-closed `taskf_destino` (`medicao` | `ancora`) lida pelas duas análises que escrevem tabela acumulativa — sem copiar a agregação, que é o que o cabeçalho do `taskf_teste2.sql` recusa por escrito.

`analyses/taskf_remedicao.sql` passa a aceitar o lado ATUAL por var também, então o delta é re-derivável em vez de query solta — a lição que o próprio arquivo registra sobre a #54. E o filtro de universo do lado antigo virou condicional: sem isso a junção abria 4× e devolvia um delta inflado com cara de achado (aconteceu comigo na primeira leitura).

## O resultado

| Passo | O que isola | Linhas do universo | Linhas movidas (de 60) |
|---|---|---|---|
| 12–13/08 → **P1** (`7b4f9d2`) | #78 + #71 + #91 + views realinhadas | 8.567 → 8.567 | 60 |
| **P1** → **P2** (`6f9dcc6`) — **a âncora** | #113 (linha de quarto sai) | 8.567 → **5.605** | 60, dos quais o movimento real é só em Handicap e Gols |

Os **169 jogos** e o `odds_loaded_at` (12/08 13:24:15) são idênticos nas três leituras — o universo não se mexeu, o histórico dentro dele sim.

**Por que o passo 1 move tudo:** 140 partidas `AET`/`PEN` entram no `team_log` pela #71, contra 7.888 `FT`, quase todas de mata-mata — e a janela é 46,7% Copa do Mundo. A conferência é o comportamento das premissas que não leem histórico: `sem_rodizio`, `h2h_favoravel` e `desfalque_adversario` movem **um campo cada**, e é o `min_jogos`.

**Por que o passo 2 é cirúrgico:** fora o `linhas_no_universo`, o movimento está inteiro nos mercados 4 e 5. Zero em 1X2, BTTS e Dupla Chance, que não têm linha que dê push.

## O que isso entrega para a [B]

- `raramente_perde_por_2` (sharp): n 415 → **193**, ganho 8,3 → **5,5** pp
- `favorito_irregular` (sharp): n 423 → **194**, ganho 8,0 → **5,7** pp
- `xg_combinado_alto` (sharp): troca de sinal, −2,5 → **+0,2**

Metade da amostra das duas premissas mais fortes do Handicap era linha de quarto.

## Fora da medição, o que o grilling achou

- **A Costura A afirmava no passado um recongelamento que não aconteceu** — `baseline_pit_meta` segue em 12/08, commit `a3b954e`, célula `base`. O recongelamento é passo do **deploy** da #91 e sai de PRODUÇÃO; a receita da âncora exclui a guarda por escrito, e o cabeçalho agora diz isso.
- **`assert_taskf_base_reproduz_01` é verde por congelamento** desde a ADR 0010 — as células nunca serão reconstruídas na acumulativa, então a previsão de "vermelha na próxima remedição" não se cumpre. Cabeçalho corrigido; a aposentadoria é limpeza da [B].
- **`CONTEXT.md`** descrevia escopo e recorte do PIT como `da_competicao`/`temporada` — falso desde a #91. Corrigido, mais os dois termos que esta issue precisou nomear (`Âncora da remedição`, `Meia-linha / linha de quarto`).
- **Emenda à ADR 0010**, registrando que a âncora não cabe na acumulativa e por que foram duas passadas.

## Verificação

- `dbt test --target taskF --select tag:costura_b` → **4/4 verde** (a acumulativa não foi tocada)
- fase 2 das duas passadas: `PASS=57 ERROR=0`
- fatos conferidos entre `futebol` e `futebol_taskF` na janela congelada: `fact_odds_snapshot` idêntico nas três janelas, de-vig reduzido à janela corrente com `EXCEPT DISTINCT` zero nos dois sentidos. As duas divergências (fixtures 1492145 e 1492290) estão nomeadas no doc e vão como ressalva para a remedição.

Nada aqui toca produção: destino fixo em `futebol_taskF`, nenhum modelo de `marts/`, nenhum `ALTER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016unvLVAGnCQPHqKi4Yp3mb
