### PR TITLE
fix(taskf): o recongelamento do baseline da Costura A, que era passo de deploy da #91

### DIFF
--- a/dbt_futebol/analyses/taskf_congela_baseline.sql
+++ b/dbt_futebol/analyses/taskf_congela_baseline.sql
@@ -7,12 +7,22 @@
     o lado esquerdo da igualdade que transforma essa promessa em fato verificável — o direito é
     tests/assert_taskf_pit_default_igual_baseline.sql.
 
-    ⚠️ RODA UMA VEZ SÓ, e ANTES de a var entrar no modelo. Re-congelar depois da var apaga a
-    guarda: o baseline passaria a sair do mesmo código que ele deveria auditar, e a Costura A
-    ficaria verde por construção. Se um dia for preciso re-congelar (mudança legítima de
-    comportamento do modelo), isso é decisão de quem revisa, não passo de rotina.
+    ⚠️ NÃO É PASSO DE ROTINA. Re-congelar sem uma mudança de comportamento que o justifique apaga
+    a guarda: o baseline passaria a sair do mesmo código que ele deveria auditar, e a Costura A
+    ficaria verde por construção. Re-congelar é decisão de quem revisa, no mesmo commit da
+    mudança que a justifica — nunca um passo executado porque a guarda ficou vermelha.
 
-    JÁ FOI RODADO: 2026-08-12 12:22 UTC, commit a3b954e, 21.054 linhas e 37 partições.
+    RODADO DUAS VEZES, e a segunda mudou o sentido da guarda:
+
+      2026-08-12 12:22 UTC, commit a3b954e, 21.054 linhas, 37 partições — do `futebol_taskF`,
+      célula `base`. Congelava "o default preserva o comportamento de antes das vars".
+
+      2026-08-25 17:59 UTC, commit 887a1f9, 21.078 linhas, 37 partições — **de PRODUÇÃO**, passo
+      de deploy da #91. A #91 (ADR 0010) virou os defaults para `todas` + `ultimos_10` e produção
+      passou a USAR o default: a premissa antiga morreu por decisão no mesmo commit em que deixou
+      de ser desejável. A guarda deixou de ser de vazamento-de-andaime e virou guarda de DERIVA
+      sobre o caminho que o board de fato serve. O baseline anterior ficou preservado nas cópias
+      `baseline_*_pre91` do mesmo dataset.
 
     Três tabelas, todas FORA do dbt de propósito — nenhuma é modelo, então nenhum `dbt run` as
     reconstrói:
@@ -27,18 +37,30 @@
                                           idênticas para sempre.
       baseline_pit_meta                   quando, de qual commit, quantas linhas.
 
-    Como rodar (do dbt_futebol/). O passo 1 é o que povoa o dataset de medição: com --target
-    taskF todo `ref()` resolve para futebol_taskF, então a ancestria (staging + fact_fixtures +
-    fact_standings_snapshot) tem de existir lá antes — o `+` no seletor é o que a constrói, lendo
-    as sources cruas, que são fixas no dataset de origem e não seguem o target:
+    ⚠️ COMO RODAR: `--target prod`, NÃO `--target taskF`. As três tabelas de baseline moram no
+    `futebol_taskF` porque são artefato da medição (os nomes acima são literais e não seguem o
+    target), mas o que elas congelam tem de sair de PRODUÇÃO. Congelar a partir do `futebol_taskF`
+    carimbaria o baseline de produção com os fatos parados do dataset de medição — pior que não
+    recongelar, e foi por isso que a receita anterior (`--target taskF`, com um `dbt run
+    --select +int_futebol_team_form_pit` antes para povoar a ancestria) saiu daqui.
 
-      DBT_PROFILES_DIR=.. ../.venv/bin/dbt run --target taskF \
-        --select +int_futebol_team_form_pit
+    Não há `dbt run` nenhum neste caminho: o `int_futebol_team_form_pit` de produção é `table` e
+    já está materializado pelo agendado. O que se congela é a saída que o board serve, não uma
+    reconstrução local dela. Confira antes que ela é pós-deploy da mudança que justifica o
+    recongelamento (`futebol.__TABLES__.last_modified_time` contra o carimbo do Cloud Run job).
 
-      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF \
-        --select taskf_congela_baseline --vars '{freeze_git_sha: '"$(git rev-parse --short HEAD)"'}'
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target prod \
+        --select taskf_congela_baseline --vars '{freeze_git_sha: <sha da imagem em produção>}'
       bq query --use_legacy_sql=false --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_congela_baseline.sql
+
+    O `freeze_git_sha` é o `PROCEDENCIA_SHA` do job — o commit que PRODUZIU a tabela —, nunca o
+    `git rev-parse HEAD` local: de um worktree ele carimba um commit que nem está no master.
+
+    Depois, a verificação que fecha o passo:
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt test --target prod \
+        --select assert_taskf_pit_default_igual_baseline
 
     (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
 */

--- a/dbt_futebol/analyses/taskf_teste2.sql
+++ b/dbt_futebol/analyses/taskf_teste2.sql
@@ -204,9 +204,10 @@
         --vars '{taskf_git_sha: '"$(git rev-parse --short HEAD)"', taskf_destino: ancora}'
       (os dois `bq query <` na mesma ordem)
 
-    ⚠️ A Costura A entra na exclusão porque o BASELINE dela ainda é o de 12/08 (célula `base`,
-    commit a3b954e — `baseline_pit_meta`), e o recongelamento é passo do DEPLOY da #91, a partir de
-    produção. Recongelar daqui carimbaria o baseline com os fatos de 12/08 do dataset de medição.
+    ⚠️ A Costura A entra na exclusão porque ela é DEFAULT-ONLY por definição: qualquer célula que
+    não seja o default a deixa vermelha por desenho. O baseline foi recongelado em 25/08 17:59 UTC
+    a partir de PRODUÇÃO (commit 887a1f9, 21.078 linhas), então o motivo antigo — "o baseline ainda
+    é o de 12/08, célula `base`, commit a3b954e" — não vale mais. A exclusão, sim.
 
     ⚠️ O CARIMBO DO PIT vem DEPOIS do build da mesma célula, sempre. O rótulo dele sai das vars em
     tempo de compilação e o dado sai do que está materializado: fora de ordem, uma célula é

--- a/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
+++ b/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
@@ -17,12 +17,20 @@
 -- analyses/taskf_congela_baseline.sql) a partir da célula `ambos` com AET/PEN no histórico (#71),
 -- e a guarda segue comparando linha a linha contra ele.
 --
--- ⚠️ E ISSO É FUTURO, NÃO PASSADO — o recongelamento é PASSO DE DEPLOY da #91, a partir de
--- PRODUÇÃO, e em 25/08 ele ainda não tinha acontecido: `futebol_taskF.baseline_pit_meta` diz
--- 12/08 12:22:46, commit `a3b954e`, que é a célula `base`. Enquanto ele não rodar, esta guarda
--- fica VERMELHA em qualquer build do PIT no default, e é por isso que a receita da âncora da #82
--- a exclui por escrito. Recongelar a partir do `futebol_taskF` seria pior que não recongelar:
--- carimbaria o baseline de produção com os fatos de 12/08 do dataset de medição. Deixou de ser guarda de
+-- ✅ O RECONGELAMENTO ACONTECEU: 2026-08-25 17:59 UTC, de PRODUÇÃO, carimbado com `887a1f9` —
+-- o `PROCEDENCIA_SHA` da imagem que produziu a tabela, que é o merge da #91/#71. 21.078 linhas
+-- e 37 partições, contra 21.054 do congelamento de 12/08 (commit `a3b954e`, célula `base`), que
+-- ficou preservado nas cópias `baseline_*_pre91`. Rodada a guarda logo depois, `--target prod`:
+-- verde.
+--
+-- ⚠️ Ele tinha de sair de PRODUÇÃO, não do `futebol_taskF`: congelar do dataset de medição
+-- carimbaria o baseline de produção com os fatos parados de 12/08, que é pior que não
+-- recongelar. A receita do `taskf_congela_baseline.sql` dizia `--target taskF` e foi corrigida
+-- no mesmo commit — ela é anterior a esta virada de sentido e mandava fazer exatamente o que
+-- este parágrafo proíbe.
+--
+-- Entre a #91 e esse recongelamento a guarda ficou VERMELHA em qualquer build do PIT no default,
+-- e é por isso que a receita da âncora da #82 a exclui por escrito. Deixou de ser guarda de
 -- vazamento-de-andaime e virou guarda de DERIVA: falha = a saída de produção mudou sem que o
 -- insumo tenha mudado, que é o mesmo modo de falha que ela sempre pegou, só que agora sobre o
 -- caminho que o board de fato serve.

--- a/docs/TASKF_RESULTADOS.md
+++ b/docs/TASKF_RESULTADOS.md
@@ -3166,6 +3166,13 @@ DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target taskF --select taskf_remed
   --vars '{taskf_remedicao_agora: taskf_teste2_ancora, taskf_remedicao_anterior: taskf_teste2_ancora_p1}'
 ```
 
-⚠️ A Costura A entra na exclusão porque o baseline dela ainda é o de 12/08 (célula `base`, commit
-`a3b954e` — `baseline_pit_meta`). O recongelamento é passo do **deploy** da #91 e sai de PRODUÇÃO;
-recongelar a partir daqui carimbaria o baseline com os fatos de 12/08 do dataset de medição.
+⚠️ A Costura A entrou na exclusão porque, no dia da âncora, o baseline dela ainda era o de 12/08
+(célula `base`, commit `a3b954e` — `baseline_pit_meta`), e recongelar a partir **daqui** carimbaria
+o baseline com os fatos de 12/08 do dataset de medição.
+
+✅ **O recongelamento aconteceu depois, no mesmo dia**: 25/08 17:59 UTC, a partir de PRODUÇÃO,
+carimbado `887a1f9` (o `PROCEDENCIA_SHA` da imagem que produziu a tabela), 21.078 linhas e 37
+partições; a guarda passou verde em `--target prod` logo em seguida, e o baseline de 12/08 ficou
+nas cópias `baseline_*_pre91`. **A exclusão continua necessária na medição** — a guarda é
+default-only por definição, então qualquer célula que não seja o default a deixa vermelha por
+desenho —, mas o motivo mudou: já não é "o baseline está velho", é "esta célula não é o default".


### PR DESCRIPTION
## O que aconteceu

A #91 (ADR 0010) virou os defaults do `int_futebol_team_form_pit` para `todas` + `ultimos_10`, e
produção passou a **usar** o default. A afirmação que a Costura A guardava — *"o default reproduz o
comportamento de antes das vars"* — morreu no mesmo commit em que deixou de ser desejável. O
recongelamento do baseline era o passo de deploy que fechava a virada, e ficou pendurado.

**Ele estava falhando em silêncio.** A tag do teste é `taskf`, não `guarda`, então o agendado não o
executa: entre o merge da #91 e hoje a Costura A ficava vermelha em qualquer build do PIT no
default e ninguém era avisado. Quem topava com ela era a medição da [F], e a receita da âncora da
#82 já a excluía por escrito — o que é a exclusão certa pelo motivo errado.

## O que foi feito

Recongelado **a partir de PRODUÇÃO**, 2026-08-25 17:59 UTC:

| | 12/08 (antes) | 25/08 (agora) |
|---|---|---|
| origem | `futebol_taskF`, célula `base` | **`futebol`** (produção) |
| carimbo | `a3b954e` | `887a1f9` — o `PROCEDENCIA_SHA` da imagem que produziu a tabela |
| linhas / partições | 21.054 / 37 | 21.078 / 37 |

Gates conferidos antes: a tabela de produção foi reconstruída em 25/08 16:31 UTC pela execução
`dbt-futebol-rzns2`, cujo env var confirma `PROCEDENCIA_SHA=887a1f9` — ou seja, é pós-#91. O
baseline anterior ficou preservado nas cópias `baseline_*_pre91` do mesmo dataset.

Depois: `dbt test --target prod --select assert_taskf_pit_default_igual_baseline` → **PASS**.

## Por que o código muda também

A receita do `taskf_congela_baseline.sql` mandava `--target taskF` — exatamente o que o cabeçalho da
guarda proíbe por escrito, porque congelar do dataset de medição carimbaria o baseline de produção
com os fatos parados de 12/08. Ela é anterior à virada de sentido da guarda; quem a executasse ao pé
da letra faria o oposto do pretendido. Vai corrigida aqui, junto com o `dbt run
--select +int_futebol_team_form_pit` que ela pedia e que não existe neste caminho: a tabela de
produção é `table` e o agendado já a materializa — o que se congela é a saída que o board serve, não
uma reconstrução local dela.

Os três cabeçalhos que afirmavam "o recongelamento ainda não aconteceu" (guarda,
`taskf_congela_baseline.sql`, `TASKF_RESULTADOS.md`) passam a dizer o que é verdade.

## O que não muda

Nada em produção. As três tabelas de baseline são artefato da medição, fora do dbt — nenhum
`dbt run` as reconstrói. A exclusão da Costura A na medição da [F] **continua necessária**, mas por
outro motivo: a guarda é default-only por definição, então qualquer célula que não seja o default a
deixa vermelha por desenho.

Fecha o passo de deploy pendente de #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016unvLVAGnCQPHqKi4Yp3mb