### PR TITLE
analise(futebol): a linha de base remedida, lida do funil (#106)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -97,6 +97,37 @@ app never reads it.
 _Avoid_: reading the funil as a board with more rows, or expecting a rebuilt table to
 preserve a funil at all
 
+**Linha de base remedida**:
+The *antes* of every comparison the [A] makes: each porta's count, alone and marginal,
+read from the funil with one janela fixed per candidato. It is a reading, never a
+re-implementation of the five branches — two measurements of the same thing weeks apart
+are only comparable if they came from the same table. It needs no seed: the funil is
+append-only, so the slice between two deploys **is** the freeze, and what the analysis
+records is the cut predicate, not a copy of the numbers.
+_Avoid_: baseline (taken by the Costura A of the [F]), "linha de base do board" (that is
+the retired hand-made copy)
+
+**Escopo vivo / escopo histórico**:
+The two populations a funil reading can have. **Vivo** is the fixtures that have not
+kicked off — and because every future-fixture row is rewritten on each odds cycle, it
+carries the current code by construction, with no confounder from a deploy. **Histórico**
+is the whole funil, which buys an order of magnitude more fixtures at the price of rows
+whose score was written under older code. A deploy that changes only one porta invalidates
+the histórico for that porta alone; the other seven keep the larger N. Which one a number
+comes from is a column, never a caveat in prose.
+_Avoid_: calling the vivo "o board" — the board is the published subset, the escopo vivo
+is the whole candidate universe of the same fixtures
+
+**Cobertura da Pinnacle**:
+Whether Pinnacle priced the outcome set at all (`pin_n_outcomes`) — the branch filter the
+board has carried since before ADR 0002, and a **different question** from whether the set
+is complete. A line Pinnacle never priced falls back to consenso and gets a perfectly valid
+fair probability; it still fails this one. It is the older of two gates with the same
+intent, and it is asymmetric across markets: the BTTS branch gates on `n_outcomes_valor`
+and so admits consenso, while Handicap and Gols gate on Pinnacle and do not.
+_Avoid_: labelling it "completude do conjunto" — that name belongs to the ADR 0002 rule,
+which lives in the de-vig and surfaces as prob justa being absent
+
 **Saída não catalogada**:
 An outcome that was priced, inside a market the Motor does model, that the Motor chooses
 not to score — Dupla Chance prices 1X, 12 and X2, and only 1X and X2 are published. It
@@ -220,7 +251,14 @@ yields **no** fair probability. Normalising over a partial set inflates every pr
 in it (one outcome alone yields certainty), so a partial set is not a weak estimate but an
 invalid one. A line built on an incomplete set keeps its real outcome count as diagnosis
 and loses fair probability, edge and value points.
-_Avoid_: treating a partial set as a degraded estimate
+
+**Pinnacle being absent is not an incomplete set.** In a market Pinnacle normally covers,
+its absence sends the line to the consenso fallback, which de-vigs its own complete set and
+does yield a fair probability — at the price of a 3× higher edge floor. The two are
+routinely conflated because the board's Handicap and Gols branches gate on
+`pin_n_outcomes` under the name "completude"; see **cobertura da Pinnacle**.
+_Avoid_: treating a partial set as a degraded estimate; reading a consenso line as an
+incomplete set
 
 **Double Chance (conjunto)**:
 Its three outcomes (1X/12/X2) are *not* exhaustive — they sum to ~2 — so Double Chance is

--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -103,7 +103,8 @@ read from the funil with one janela fixed per candidato. It is a reading, never 
 re-implementation of the five branches — two measurements of the same thing weeks apart
 are only comparable if they came from the same table. It needs no seed: the funil is
 append-only, so the slice between two deploys **is** the freeze, and what the analysis
-records is the cut predicate, not a copy of the numbers.
+records is the cut predicate, not a copy of the numbers. Lives in
+`analyses/taskA_linha_de_base_funil.sql`; the numbers are in `docs/TASKA_RESULTADOS.md`.
 _Avoid_: baseline (taken by the Costura A of the [F]), "linha de base do board" (that is
 the retired hand-made copy)
 

--- a/dbt_futebol/analyses/taskA_linha_de_base.sql
+++ b/dbt_futebol/analyses/taskA_linha_de_base.sql
@@ -1,5 +1,52 @@
 {#
-    LINHA DE BASE DO BOARD — entregável de aceite da task [A].
+    ⚠️⚠️ APOSENTADA em 25/08/2026 (#106). NÃO É MAIS A LINHA DE BASE DA TASK [A].
+
+    A linha de base agora sai de `taskA_linha_de_base_funil.sql`, que LÊ o `fact_value_funnel`
+    em vez de reimplementar os cinco ramos. Duas medições da mesma coisa em semanas diferentes
+    só são comparáveis se saírem da MESMA tabela — e este arquivo acumulou três invalidações
+    sem ninguém notar, exatamente porque cada rerodada era uma tabela nova:
+
+      1. ele mede uma porta de odd (`n3_faixa_odd`) que **não existe em produção** — é proposta
+         da A5 (#104). Uma porta que não existe não pode remover linha do *antes*, ou o
+         antes/depois da A5 mede zero contra zero;
+      2. os números da entrega original são pré-`.25` (#101) — o arquivo já foi corrigido pelo
+         commit `c33608c`, mas os números publicados na época não se reproduzem;
+      3. eles são pré-#91, que solta o histórico do time da competição e move a nota.
+
+    Some junto com a A5.
+
+    ─────────────────────────────────────────────────────────────────────────────────
+    O QUE AINDA SERVE:
+
+      • a OUTRA METADE DA RECONCILIAÇÃO da #106 — e é por isso que ela não foi apagada.
+        Rerodar as duas, ENTRE DOIS CICLOS DE ODDS, é como se prova que o funil descreve o
+        board: este arquivo lê `int_futebol_odds_devig` ao vivo e o funil lê a tabela
+        congelada, então um ciclo no meio move o de-vig debaixo das duas. Os números da
+        conferência e a explicação de cada divergência moram no `docs/TASKA_RESULTADOS.md`,
+        seção do #106, e não aqui.
+
+            DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile \
+              --select taskA_linha_de_base taskA_linha_de_base_funil
+            bq query --use_legacy_sql=false --format=csv \
+              < target/compiled/dbt_futebol/analyses/taskA_linha_de_base.sql
+            bq query --use_legacy_sql=false --format=csv \
+              < target/compiled/dbt_futebol/analyses/taskA_linha_de_base_funil.sql
+
+        ⚠️ As duas divergências são ESTRUTURAIS e esperadas: este arquivo inclui o EMPATE do
+        1X2 (que o funil tira da fila) e exclui a saída "12" da DC (que o `INNER JOIN` com as
+        premissas engole e o funil carimba `porta_saida_catalogada = FALSE`). Os dois blocos
+        têm o mesmo tamanho — um por fixture — então os TOTAIS coincidem por acidente
+        aritmético, com conjuntos diferentes. Comparar só o total esconde as duas.
+        Divergência ALÉM dessas duas é defeito do funil (ADR 0011 declarou quem perde).
+      • o ESBOÇO DO REGIME `novo` (`n1_casas4`, `n2_outlier`, `n3_faixa_odd`, `n4_nota40`,
+        `n5_consenso50`) e a nota normalizada por teto de mercado/lado, que a A3 e a A5 vão
+        querer. O funil não tem essa nota — ela não existe em produção.
+
+    O QUE NÃO SERVE MAIS: qualquer número daqui como *antes* de qualquer subtask da [A].
+    O *antes* está em `docs/TASKA_RESULTADOS.md`, seção do #106.
+    ─────────────────────────────────────────────────────────────────────────────────
+
+    LINHA DE BASE DO BOARD — entregável de aceite original da task [A].
 
     "Uma query mostrando, no board de hoje, quantas oportunidades cada porta remove,
     separadamente. Serve de linha de base."
@@ -36,7 +83,7 @@
 
     Rodar com:
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_linha_de_base
-      bq query --use_legacy_sql=false < ../target/compiled/dbt_futebol/analyses/taskA_linha_de_base.sql
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/taskA_linha_de_base.sql
 #}
 
 WITH fixtures AS (

--- a/dbt_futebol/analyses/taskA_linha_de_base_funil.sql
+++ b/dbt_futebol/analyses/taskA_linha_de_base_funil.sql
@@ -1,0 +1,436 @@
+/*
+    [A-106] A LINHA DE BASE REMEDIDA — o *antes* de toda comparação da task [A], LIDO DO FUNIL.
+
+    ⚠️ OS NÚMEROS NÃO MORAM AQUI. Eles estão em `docs/TASKA_RESULTADOS.md`, seção do #106, com
+    o instante da rodada publicada. Este cabeçalho carrega DECISÕES e PREDICADOS — o que muda
+    quando a lógica muda. Foi guardar número em cabeçalho que deixou a `taskA_linha_de_base.sql`
+    acumular três invalidações sem ninguém notar.
+
+    Substitui `taskA_linha_de_base.sql`, que reimplementava os cinco ramos à mão. Duas medições
+    da mesma coisa em semanas diferentes só são comparáveis se saírem da MESMA tabela.
+
+    Fonte única: `fact_value_funnel`. Nenhum ramo é reconstruído aqui, nenhum `WHERE` de porta é
+    reescrito. As oito portas já são COLUNAS BOOLEANAS lá (ADR 0011) — esta análise só as ordena
+    numa fila e conta.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A JANELA ESTÁ FIXADA: `janela_e_corrente = TRUE`.
+
+    São QUATRO janelas por candidato (`daily` < `t24h` < `t1h` < `t15m`) desde 07/08. Contar as
+    quatro conta a mesma candidata até quatro vezes. A escolhida é a CORRENTE porque é a redução
+    que o board publica — e é a mesma que a cópia à mão usa, sem o que a reconciliação compararia
+    populações diferentes. O fator real de inflação está medido no documento de resultados, e ele
+    é bem menor que o teto de 4× no escopo vivo: jogo futuro quase só tem `daily`.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    DOIS ESCOPOS, E O HISTÓRICO CONTÉM O VIVO — de propósito.
+
+      a. vivo       o que `futebol_funil_e_gravavel()` ainda deixa escrever — o MESMO predicado
+                    do congelamento do funil, e não uma quarta cópia dele. Toda linha de jogo por
+                    acontecer é reescrita a cada ciclo de odds, então ela carrega o código
+                    CORRENTE por construção, e nenhuma linha de kickoff futuro tem carimbo
+                    anterior à #91. É a linha de base sem confundidor.
+                    ⚠️ Ele é SUBCONJUNTO ESTRITO da população que a ADR 0009 deixa no board, e
+                    não o mesmo conjunto: o expurgo corta por STATUS, com o relógio só como rede
+                    de 24 h, e `PST`/`SUSP`/`INT` sobrevivem ao kickoff no passado de propósito
+                    ("um corte por relógio a mataria", diz o macro). O critério do ticket
+                    ("população já expurgada") está satisfeito — nada de expurgado entra — mas
+                    por um predicado MAIS ESTRITO, e o preço está medido no documento de
+                    resultados. A escolha se justifica pelo que define o escopo: linha ainda
+                    gravável é linha reescrita a cada ciclo, logo linha com o código de hoje.
+                    Fixture sem kickoff conhecido entra aqui (fail-open, ADR 0003): ele é
+                    gravável para sempre, logo carrega o código corrente.
+      b. historico  o funil inteiro (o vivo INCLUSO). Compra uma ordem de grandeza de fixtures ao
+                    preço de linhas cuja nota nasceu sob código mais velho. Uma linha viva
+                    aparece nas duas — são duas leituras da mesma tabela, não uma partição, e
+                    somar as duas conta as vivas duas vezes.
+
+    ⚠️ `nota_valida_no_escopo` é COLUNA e não ressalva em prosa. A #91 (`887a1f9`) tocou apenas
+    `int_futebol_premissas_*` e `int_futebol_team_form_pit`: ela muda a `porta_nota` e mais nada.
+    As outras SETE portas são bit a bit idênticas antes e depois dela, e para elas o histórico
+    inteiro é ganho puro de N. Só o que depende da nota sai `FALSE` no histórico — e quem decide
+    isso é o campo `depende_da_nota` de cada linha da fila, nunca o texto do rótulo: rótulo é
+    display, e casar contra ele faz um rename corromper a validade em silêncio.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    AS TRÊS DESCONTINUIDADES DA SÉRIE, declaradas antes da medição:
+
+      1. #91 (`887a1f9`), em produção 25/08 16:31:32 UTC (primeira execução com
+         `PROCEDENCIA_SHA=887a1f9`). A única que parte a série, e só na `porta_nota`.
+      2. O conserto do `.25` (#101), em produção 21/08 19:05 UTC. O ticket manda declará-lo como
+         descontinuidade — e ele é, contra os números PUBLICADOS na rodada anterior. DENTRO da
+         série ele não existe: o backfill que criou o funil rodou 21/08 21:21 UTC, depois dele.
+         A seção 5 mede isso a cada rodada, em vez de afirmá-lo aqui.
+      3. `origem = 'backfill'` — o build de 21/08 21:21 que criou a tabela, recalculado com o
+         código daquele dia sobre odds antigas. A ADR 0011 o chama de "a única parte do funil que
+         NÃO é registro de época". A seção 5 publica a fatia; `origem` está na tabela para quem
+         quiser cortar.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O CONGELAMENTO DISPENSA SEED. A [F] congelou baseline num seed porque as tabelas eram
+    rematerializadas; aqui o append-only (ADR 0011) É o congelamento. A fatia que esta análise
+    lê fica preservada para sempre, e quem quiser reproduzir uma rodada exata — ou relê-la na
+    véspera da A1, com N maior — acrescenta o predicado de corte:
+
+        AND gravado_em <  TIMESTAMP '<instante da rodada>'   -- teto
+        AND gravado_em >= TIMESTAMP '2026-08-25 16:31:32'    -- pós-#91, se quiser a nota limpa
+
+    A entrega congela o PREDICADO, não uma cópia dos números. O `docs/TASKA_RESULTADOS.md` grava
+    o instante de cada rodada publicada, e é ele que torna a rodada reproduzível.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A ORDEM DA FILA — e ela NÃO é a do `motivo_primario`.
+
+        01 saída catalogada → 02 cobertura da Pinnacle → 03 valor estimável (ADR 0002)
+        → 04 linha meia → 05 liquidez → 06 odd mínima da DC → 07 edge → 08 nota
+
+    O `motivo_primario` do mart põe `linha_meia` e `odd_dc` no FIM da lista; aqui elas entram no
+    meio, onde o ticket as põe. A divergência é deliberada e não muda nada em produção: o
+    `motivo_primario` é conveniência de leitura de UMA linha (ADR 0011), e a leitura marginal sai
+    dos booleanos, nunca dele. Quem lê marginal a partir de um campo de motivo único mede a ordem
+    do `CASE`, não a severidade da porta.
+
+    O ticket enumera seis portas e omite `porta_valor_estimavel` e `porta_odd_dc`. As duas estão
+    aqui — é a mesma enumeração incompleta que a spec da [F] teve com AH e DC (#52), e uma fila
+    com porta faltando devolve marginal errada em todas as seguintes.
+
+    ⚠️ O ÚLTIMO DEGRAU DA FILA É `passou_no_gate`, LIDO DO MART — não a conjunção reescrita aqui.
+    O mart deriva `passou_no_gate` das oito colunas e o seu cabeçalho diz que ela é "jamais
+    escrita à mão"; uma nona cópia num arquivo de análise é como a expressão de meia-linha chegou
+    a quatro cópias (#101/#114). Os prefixos `c1..c7` existem porque são o produto da análise — a
+    conjunção inteira já existe e se lê.
+
+    ⚠️ AS DUAS PORTAS DE "COMPLETUDE" SÃO COISAS DIFERENTES, e por isso saem com nomes diferentes.
+    A `porta_conjunto_completo` é `pin_n_outcomes >= N` — a versão anterior à #22, que pergunta
+    "a Pinnacle cobriu?". A regra da ADR 0002 (`n_outcomes_valor = conjunto_esperado`) mora no
+    de-vig e aparece como `porta_valor_estimavel`. Medido (números no documento de resultados),
+    o aninhamento existe no sentido CONTRÁRIO ao que o cabeçalho do mart declara: reprovar em
+    valor implica reprovar em cobertura, e nunca o inverso. Aqui é só rótulo; o predicado é
+    assunto da #118. Nada em produção muda nesta entrega.
+
+    ⚠️ O EMPATE DO 1X2 SAI DA FILA (seção 2, com os números inteiros). Ele é um terço do universo
+    do 1X2 POR CONSTRUÇÃO — nunca teve lado apostado, nenhuma premissa se aplica (ADR 0005/0006).
+    Pôr uma população estruturalmente sem candidatura dentro de uma fila que mede severidade de
+    porta infla o denominador de toda porta a montante e some no numerador da que interessa: a
+    maioria dos empates reprova no EDGE, que vem ANTES da nota, então sob o motivo genérico
+    (`sem_lado_apostado`) eles seriam contados por um fator de 3 a menos. O corte é a primeira
+    linha do funil do 1X2 (a linha `00`, "com lado apostado") e a seção 2 publica os empates
+    inteiros ao lado.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    AS CINCO SEÇÕES (coluna `secao`), e o que `n_entrada`/`n_saida` querem dizer em cada uma.
+    Em todas, `n_entrada` é o DENOMINADOR da linha e `n_saida` o numerador. `corte` é o eixo de
+    cruzamento e só a seção 4 o usa; `n_isolado`/`n_marginal` só a seção 1.
+
+      1. fila            a fila cumulativa. `n_isolado` = quantas ESTA porta remove sozinha do
+                         universo (as somas se sobrepõem, uma linha reprova em várias);
+                         `n_marginal` = quantas ela ainda remove DEPOIS das anteriores (as somas
+                         fecham). É a marginal que diz o que a porta acrescenta.
+      2. empate 1X2      os empates inteiros e onde eles caem. Fora da fila.
+      3. nota            decis da nota, com as três faixas de hoje por cima. Decil porque no
+                         funil a Baixa é a maioria e três baldes só dizem "quase tudo é Baixa";
+                         e porque a A4 (#107) tem mandato para mover as fronteiras — o decil
+                         sobrevive à mudança de escala, as faixas de hoje saem junto para a
+                         comparação com o board continuar possível.
+      4. barreiras A5    as barreiras PROPOSTAS pela A5 (#104), que NÃO estão em produção: faixa
+                         de odd, `n_casas >= 4` e `pen_odd_outlier`. Ficam FORA da fila e fora do
+                         cumulativo — uma porta que não existe não pode remover linha do *antes*,
+                         ou o antes/depois da A5 mede zero contra zero. Saem por TRÊS eixos, e é
+                         de propósito: `pts_premissas` (o eixo em que o ticket mediu), a NOTA
+                         publicada (em que a direção se inverte) e `pts_premissas` restrito às
+                         linhas com preço da Pinnacle (o recorte exato da frase do ticket).
+      5. procedencia     `origem`, carimbo pré/pós-#91 e o efeito da janela. A auditoria da
+                         própria medição, remedida a cada rodada em vez de afirmada em prosa.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    ESTA ANÁLISE NÃO MUDA NADA EM PRODUÇÃO. `dbt compile` + `bq query`, e nada de `dbt run`.
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_linha_de_base_funil
+      bq query --use_legacy_sql=false --format=csv \
+        < target/compiled/dbt_futebol/analyses/taskA_linha_de_base_funil.sql
+*/
+
+{%- set FAIXA = "CASE WHEN {c} IS NULL THEN 'n. sem avaliacao'
+                        WHEN {c} = 0     THEN '0. zero'
+                        WHEN {c} < 30    THEN '1. 1-29'
+                        ELSE                  '2. >=30' END" -%}
+
+WITH funil AS (
+    SELECT
+        f.*,
+        {# O histórico contém o vivo: duas leituras da mesma tabela, não uma partição. #}
+        escopo
+    FROM {{ ref('fact_value_funnel') }} f
+    CROSS JOIN UNNEST(
+        IF({{ futebol_funil_e_gravavel('f.kickoff_utc') }},
+           ['a. vivo', 'b. historico'],
+           ['b. historico'])
+    ) AS escopo
+    {# A JANELA FIXADA. Sem isto todo número abaixo infla. #}
+    WHERE f.janela_e_corrente
+),
+
+{# ─────────────────────────────────────────────────────────────────────────────────
+    AS OITO PORTAS, renomeadas UMA vez. O empate continua aqui dentro, marcado pela
+    coluna que o mart já carrega — quem separa as duas populações é o `WHERE` de cada
+    seção, e não uma segunda cópia deste bloco.
+    ───────────────────────────────────────────────────────────────────────────────── #}
+portas AS (
+    SELECT
+        escopo,
+        market,
+        score,
+        pts_premissas,
+        valor_fonte,
+        best_odd,
+        n_casas,
+        pen_odd_outlier,
+        origem,
+        gravado_em,
+        sem_lado_apostado,
+        porta_saida_catalogada  AS p1,
+        porta_conjunto_completo AS p2,
+        porta_valor_estimavel   AS p3,
+        porta_linha_meia        AS p4,
+        porta_liquidez          AS p5,
+        porta_odd_dc            AS p6,
+        porta_edge              AS p7,
+        porta_nota              AS p8,
+        {# a conjunção das oito, DERIVADA NO MART. Ver o ⚠️ do cabeçalho. #}
+        passou_no_gate          AS c8
+    FROM funil
+),
+
+{# `c_k` = passou em TODAS as portas até a k. A porta k remove `c_{k-1} AND NOT p_k`.
+    `c8` não aparece aqui: ele é `passou_no_gate` e já veio pronto. #}
+cum AS (
+    SELECT
+        *,
+        p1                                                   AS c1,
+        p1 AND p2                                            AS c2,
+        p1 AND p2 AND p3                                     AS c3,
+        p1 AND p2 AND p3 AND p4                              AS c4,
+        p1 AND p2 AND p3 AND p4 AND p5                       AS c5,
+        p1 AND p2 AND p3 AND p4 AND p5 AND p6                AS c6,
+        p1 AND p2 AND p3 AND p4 AND p5 AND p6 AND p7         AS c7
+    FROM portas
+),
+
+{# ─────────────────────────────────────────────────────────────────────────────────
+    SEÇÃO 1 — A FILA. Sobre `NOT sem_lado_apostado`: o empate tem seção própria, e o
+    corte é a linha `00`.
+    ───────────────────────────────────────────────────────────────────────────────── #}
+fila_long AS (
+    SELECT escopo, market, f.*
+    FROM cum
+    CROSS JOIN UNNEST([
+        {# `depende_da_nota` decide `nota_valida_no_escopo`. É um campo, e não um teste
+            contra o rótulo: rótulo é display, e um rename não pode corromper a validade. #}
+        STRUCT('00. universo (com lado apostado)' AS item, TRUE AS entrou, TRUE AS passou, TRUE AS passa_sozinha, FALSE AS depende_da_nota),
+        STRUCT('01. saida catalogada',                     TRUE,           c1,             p1,                   FALSE),
+        STRUCT('02. cobertura da Pinnacle (pin_n_outcomes)', c1,           c2,             p2,                   FALSE),
+        STRUCT('03. valor estimavel (ADR 0002)',            c2,            c3,             p3,                   FALSE),
+        STRUCT('04. linha meia (AH/Gols)',                  c3,            c4,             p4,                   FALSE),
+        STRUCT('05. liquidez >= 3 casas',                   c4,            c5,             p5,                   FALSE),
+        STRUCT('06. odd minima da DC (>= 1,25)',            c5,            c6,             p6,                   FALSE),
+        STRUCT('07. edge acima do piso',                    c6,            c7,             p7,                   FALSE),
+        STRUCT('08. nota >= 40',                            c7,            c8,             p8,                   TRUE)
+    ]) AS f
+    WHERE NOT sem_lado_apostado
+),
+
+sec_fila AS (
+    SELECT
+        escopo,
+        '1. fila'                                      AS secao,
+        item,
+        mercado,
+        CAST(NULL AS STRING)                           AS corte,
+        COUNTIF(entrou)                                AS n_entrada,
+        COUNTIF(NOT passa_sozinha)                     AS n_isolado,
+        COUNTIF(entrou AND NOT passou)                 AS n_marginal,
+        COUNTIF(entrou AND passou)                     AS n_saida,
+        {# Só a porta de nota depende da #91; as outras sete são idênticas antes e depois. #}
+        (escopo = 'a. vivo' OR NOT depende_da_nota)    AS nota_valida_no_escopo
+    FROM fila_long, UNNEST([market, 'ZZ. TODOS']) AS mercado
+    GROUP BY escopo, item, mercado, depende_da_nota
+),
+
+{# ─────────────────────────────────────────────────────────────────────────────────
+    SEÇÃO 2 — O EMPATE DO 1X2, inteiro, e onde ele cai. Fora da fila, mesmos prefixos.
+    ───────────────────────────────────────────────────────────────────────────────── #}
+sec_empate AS (
+    SELECT
+        escopo,
+        '2. empate 1X2'      AS secao,
+        item,
+        'match_winner'       AS mercado,
+        CAST(NULL AS STRING) AS corte,
+        COUNT(*)             AS n_entrada,
+        CAST(NULL AS INT64)  AS n_isolado,
+        CAST(NULL AS INT64)  AS n_marginal,
+        COUNTIF(e)           AS n_saida,
+        (escopo = 'a. vivo' OR NOT depende_da_nota) AS nota_valida_no_escopo
+    FROM cum
+    CROSS JOIN UNNEST([
+        STRUCT('10. empates (universo)'              AS item, TRUE           AS e, FALSE AS depende_da_nota),
+        STRUCT('11. reprova antes do edge',                   NOT c6,              FALSE),
+        STRUCT('12. reprova NO edge',                         c6 AND NOT p7,       FALSE),
+        STRUCT('13. chega a nota e reprova na nota',          c7 AND NOT p8,       TRUE),
+        STRUCT('14. passaria em tudo (nota)',                 c8,                  TRUE)
+    ])
+    WHERE sem_lado_apostado
+    GROUP BY escopo, item, depende_da_nota
+),
+
+{# ─────────────────────────────────────────────────────────────────────────────────
+    SEÇÃO 3 — A NOTA POR FAIXA: decis, com as três faixas de hoje na mesma etiqueta.
+    Denominador = quem CHEGA à porta de nota, que é o `c7` da fila e não uma terceira
+    cópia da conjunção das sete.
+    ───────────────────────────────────────────────────────────────────────────────── #}
+sec_nota AS (
+    SELECT
+        escopo,
+        '3. nota' AS secao,
+        item,
+        mercado,
+        CAST(NULL AS STRING) AS corte,
+        {# o denominador é o mesmo em todas as linhas do (escopo, mercado): quem CHEGOU à
+            porta de nota. `SUM(COUNT(*)) OVER` e não `COUNT(*) OVER` — a janela roda DEPOIS
+            do GROUP BY, e um COUNT ali contaria decis, não linhas. #}
+        SUM(COUNT(*)) OVER (PARTITION BY escopo, mercado) AS n_entrada,
+        CAST(NULL AS INT64) AS n_isolado,
+        CAST(NULL AS INT64) AS n_marginal,
+        COUNT(*)            AS n_saida,
+        (escopo = 'a. vivo') AS nota_valida_no_escopo
+    FROM (
+        SELECT
+            escopo,
+            market,
+            {# o decil, e a faixa de HOJE ao lado dele na mesma etiqueta: a A4 (#107) tem
+                mandato para mover as fronteiras, e o decil sobrevive à mudança de escala. #}
+            CONCAT(
+                'D', CAST(LEAST(DIV(CAST(score AS INT64), 10), 9) AS STRING), ' (',
+                CASE WHEN score >= 80 THEN 'ALTA'
+                     WHEN score >= 60 THEN 'MEDIA'
+                     WHEN score >= 40 THEN 'BAIXA'
+                     ELSE 'fora da regua' END, ')'
+            ) AS item
+        FROM cum
+        WHERE NOT sem_lado_apostado AND c7
+    ), UNNEST([market, 'ZZ. TODOS']) AS mercado
+    GROUP BY escopo, mercado, item
+),
+
+{# ─────────────────────────────────────────────────────────────────────────────────
+    SEÇÃO 4 — AS BARREIRAS PROPOSTAS PELA A5 (#104), FORA DA FILA E FORA DO CUMULATIVO.
+    Nenhuma está em produção. Cada uma sozinha, por três eixos — e são três porque as
+    duas primeiras não concordam nem no SINAL, e a terceira é o recorte exato em que a
+    frase do ticket foi medida.
+    ───────────────────────────────────────────────────────────────────────────────── #}
+barreiras AS (
+    SELECT
+        escopo,
+        market,
+        eixo || ' ' || faixa AS corte,
+        b.item,
+        b.passa
+    FROM (
+        SELECT
+            escopo, best_odd, n_casas, pen_odd_outlier, market,
+            e.eixo, e.faixa
+        FROM cum
+        CROSS JOIN UNNEST([
+            STRUCT('1. pts_premissas' AS eixo,
+                   {{ FAIXA.replace('{c}', 'pts_premissas') }} AS faixa),
+            STRUCT('2. nota publicada',
+                   {{ FAIXA.replace('{c}', 'score') }}),
+            {# o recorte da frase do ticket: "entre linhas com preço da Pinnacle". Linha de
+                consenso vira NULL e some no WHERE abaixo — o eixo mede o subconjunto, e não
+                o universo com um rótulo enganoso por cima. #}
+            STRUCT('3. pts_premissas (so Pinnacle)',
+                   IF(valor_fonte <> 'pinnacle', NULL,
+                      {{ FAIXA.replace('{c}', 'pts_premissas') }}))
+        ]) AS e
+        WHERE NOT sem_lado_apostado
+          AND e.faixa IS NOT NULL
+    )
+    CROSS JOIN UNNEST([
+        STRUCT('20. faixa de odd do mercado' AS item,
+               best_odd BETWEEN IF(market = '{{ futebol_mercados_pontuados()[12] }}', 1.25, 1.50)
+                            AND IF(market = '{{ futebol_mercados_pontuados()[12] }}', 2.00, 4.00) AS passa),
+        STRUCT('21. liquidez >= 4 casas', n_casas >= 4),
+        STRUCT('22. sem odd fora da curva', NOT pen_odd_outlier)
+    ]) AS b
+),
+
+sec_barreiras AS (
+    SELECT
+        escopo,
+        '4. barreiras A5 (nao estao em producao)' AS secao,
+        item,
+        mercado,
+        corte,
+        COUNT(*)            AS n_entrada,
+        CAST(NULL AS INT64) AS n_isolado,
+        CAST(NULL AS INT64) AS n_marginal,
+        COUNTIF(passa)      AS n_saida,
+        {# os três eixos leem a nota ou os pontos de premissa, e os dois vêm da #91. #}
+        (escopo = 'a. vivo') AS nota_valida_no_escopo
+    FROM barreiras, UNNEST([market, 'ZZ. TODOS']) AS mercado
+    GROUP BY escopo, item, mercado, corte
+),
+
+{# ─────────────────────────────────────────────────────────────────────────────────
+    SEÇÃO 5 — A PROCEDÊNCIA. A auditoria da própria medição: de onde vieram as linhas
+    que os números acima contam. As duas descontinuidades de instante são MEDIDAS aqui
+    a cada rodada, em vez de afirmadas no cabeçalho.
+    ───────────────────────────────────────────────────────────────────────────────── #}
+sec_procedencia AS (
+    SELECT
+        escopo,
+        '5. procedencia'     AS secao,
+        item,
+        'ZZ. TODOS'          AS mercado,
+        CAST(NULL AS STRING) AS corte,
+        COUNT(*)             AS n_entrada,
+        CAST(NULL AS INT64)  AS n_isolado,
+        CAST(NULL AS INT64)  AS n_marginal,
+        COUNTIF(e)           AS n_saida,
+        TRUE                 AS nota_valida_no_escopo
+    FROM cum
+    CROSS JOIN UNNEST([
+        STRUCT('30. linhas na janela corrente'    AS item, TRUE AS e),
+        STRUCT('31. origem = backfill',           origem = 'backfill'),
+        STRUCT('32. gravadas pos-#91',            gravado_em >= TIMESTAMP '2026-08-25 16:31:32'),
+        STRUCT('33. gravadas pre-.25 (#101)',     gravado_em <  TIMESTAMP '2026-08-21 19:05:00'),
+        STRUCT('34. publicadas (passou_no_gate)', c8)
+    ])
+    GROUP BY escopo, item
+),
+
+tudo AS (
+    SELECT * FROM sec_fila
+    UNION ALL SELECT * FROM sec_empate
+    UNION ALL SELECT * FROM sec_nota
+    UNION ALL SELECT * FROM sec_barreiras
+    UNION ALL SELECT * FROM sec_procedencia
+)
+
+SELECT
+    escopo,
+    secao,
+    item,
+    mercado,
+    corte,
+    n_entrada,
+    n_isolado,
+    n_marginal,
+    n_saida,
+    ROUND(SAFE_DIVIDE(n_marginal, NULLIF(n_entrada, 0)) * 100, 1) AS pct_marginal,
+    ROUND(SAFE_DIVIDE(n_saida,    NULLIF(n_entrada, 0)) * 100, 1) AS pct_saida,
+    nota_valida_no_escopo,
+    {# o instante da rodada, que é o que o predicado de corte congela. #}
+    CURRENT_TIMESTAMP() AS medido_em
+FROM tudo
+ORDER BY escopo, secao, item, mercado, corte

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -1,0 +1,331 @@
+# Task [A] — Resultados
+
+Documento vivo. Cada subtask da [issue #15](https://github.com/tech-lamjav/analytics-engineering/issues/15)
+acrescenta a sua seção aqui. O SQL que produz cada número está em `dbt_futebol/analyses/`.
+
+Os resultados moram neste arquivo, e não no cabeçalho das análises, para que o SQL mude quando a
+lógica muda e não quando os números mudam. Mesmo padrão do `TASK01_RESULTADOS.md` e do
+`TASKF_RESULTADOS.md`.
+
+**A [A] tem seis subtasks e todas comparam contra o mesmo *antes*. Ele está na
+[seção do #106](#ticket-106--a-linha-de-base-remedida).** Citar de memória é como a
+`taskA_linha_de_base.sql` acumulou três invalidações sem ninguém notar.
+
+---
+
+# Ticket #106 — A linha de base remedida
+
+**Análise:** `dbt_futebol/analyses/taskA_linha_de_base_funil.sql`
+**Fonte:** `fact_value_funnel` (ADR 0011), janela fixada em `janela_e_corrente`
+**Rodada publicada:** **2026-08-25 19:30:24 UTC**
+
+## O predicado de corte (é ele que está congelado, não os números)
+
+O funil é append-only e congela no apito: a fatia que produziu os números abaixo fica preservada
+para sempre. Não há seed — o append-only **é** o congelamento. Para reproduzir esta rodada exata:
+
+```sql
+FROM fact_value_funnel
+WHERE janela_e_corrente
+  AND gravado_em < TIMESTAMP '2026-08-25 19:30:24'   -- o teto desta rodada
+```
+
+Para reler o mesmo *antes* com N maior na véspera da A1, sobe-se o teto e não se muda mais nada.
+A A1 herda a cláusula.
+
+## Veredito
+
+**Cinco linhas publicadas de 7.024 candidatas no escopo vivo — 0,1%. E duas portas fazem quase
+todo o trabalho: a cobertura da Pinnacle e o edge.**
+
+O caminho inteiro, escopo vivo, todos os mercados (`marginal` = quantas a porta ainda remove
+depois das anteriores):
+
+| # | porta | entra | remove (marginal) | sai | remove sozinha |
+|---|---|---:|---:|---:|---:|
+| 00 | universo (com lado apostado) | 6.941 | — | 6.941 | — |
+| 01 | saída catalogada | 6.941 | 83 | 6.858 | 83 |
+| 02 | **cobertura da Pinnacle** (`pin_n_outcomes`) | 6.858 | **3.808** | 3.050 | 3.819 |
+| 03 | valor estimável (ADR 0002) | 3.050 | **0** | 3.050 | 111 |
+| 04 | linha meia (AH/Gols) | 3.050 | 1.858 | 1.192 | 4.165 |
+| 05 | liquidez ≥ 3 casas | 1.192 | 12 | 1.180 | 2.019 |
+| 06 | odd mínima da DC (≥ 1,25) | 1.180 | 31 | 1.149 | 55 |
+| 07 | **edge acima do piso** | 1.149 | **1.028** | 121 | 6.381 |
+| 08 | nota ≥ 40 | 121 | 116 | **5** | 6.842 |
+
+Fora da fila, com os números inteiros: **83 empates de 1X2** (seção 2) e **83 saídas "12" de Dupla
+Chance** (a porta 01). Cada um é exatamente um por fixture — 83 fixtures vivos.
+
+Três leituras que a fila entrega e a cópia à mão não entregava:
+
+**1. A porta de nota não é a que corta o board.** Ela recebe 121 linhas e devolve 5. As 6.820
+linhas que nunca chegaram até ela caíram em portas ESTRUTURAIS — cobertura, linha meia, edge. Toda
+subtask que se propõe a "afrouxar a régua" (A1, A4) está mexendo numa porta que vê 1,7% do universo.
+
+**2. A `porta_valor_estimavel` é redundante hoje — marginal ZERO em todos os mercados e nos dois
+escopos.** Nenhuma linha reprova nela sem já ter reprovado na cobertura da Pinnacle: medido,
+**19.449 linhas reprovam na cobertura e passam no valor, e ZERO no sentido inverso**. Isso é o
+oposto do aninhamento declarado no cabeçalho do mart, e é o corpo de delito da #118 (abaixo).
+
+**3. O BTTS publica zero no escopo vivo.** Das 166 candidatas, 164 chegam ao edge e **as 164
+morrem lá**. O BTTS só tem preço de consenso (a Pinnacle não o cobre) e por isso enfrenta piso de
+edge `0,03` contra `0` — 3× maior. No histórico ele publica 17 de 938.
+
+## As três descontinuidades da série
+
+Declaradas antes da medição, como a #86 fez com o `.25`.
+
+| descontinuidade | instante | efeito |
+|---|---|---|
+| **#91** (`887a1f9`) — histórico do time solto da competição | 25/08 **16:31:32** UTC | Parte a série, e **só na `porta_nota`**: a #91 tocou apenas `int_futebol_premissas_*` e `int_futebol_team_form_pit`. As outras sete portas são idênticas antes e depois. Sai como coluna `nota_valida_no_escopo`. |
+| **`.25`** (#101) — linha de quarto deixa de contar como meia | 21/08 **19:05** UTC | Real contra os números **publicados** na rodada anterior. **Inexistente dentro da série**: o backfill que criou o funil rodou 21/08 **21:21** UTC, depois dele, e `COUNTIF(gravado_em < '2026-08-21 19:05') = 0`. |
+| **`origem = 'backfill'`** | 21/08 21:21 UTC | 27.993 das 40.672 linhas do escopo histórico na janela corrente — **68,8%**. A ADR 0011 as chama de "a única parte do funil que NÃO é registro de época". Não afeta o escopo vivo (**0%**). |
+
+## Os dois escopos, e qual deles é "a linha de base"
+
+| | escopo vivo | escopo histórico |
+|---|---:|---:|
+| fixtures | 83 | 469 |
+| linhas (janela corrente) | 7.024 | 40.672 |
+| linhas publicadas | 5 | 98 |
+| `origem = backfill` | 0% | 68,8% |
+| gravadas pós-#91 | **100%** | 18,0% |
+
+**Nenhuma linha de kickoff futuro carrega carimbo pré-#91 — 0 de 7.787.** Como o merge reescreve
+toda linha de jogo por acontecer a cada ciclo de odds, o board ao vivo **já é pós-#91 por
+construção**. É essa propriedade — linha ainda gravável é linha reescrita a cada ciclo, logo linha
+com o código de hoje — que define o escopo vivo, e é ela que satisfaz o critério do ticket sem
+custo nenhum.
+
+⚠️ **Mas "escopo vivo" e "população já expurgada" NÃO são o mesmo conjunto.** O expurgo da ADR 0009
+corta por **status**, com o relógio apenas como rede de 24 h, e `PST`/`SUSP`/`INT` sobrevivem ao
+kickoff no passado de propósito — "um corte por relógio a mataria", diz o `futebol_expurgo.sql`.
+Medido nesta rodada:
+
+| | linhas | |
+|---|---:|---|
+| não expurgadas do board (ADR 0009) | **7.489** | o que o board de fato mostra |
+| escopo vivo (`futebol_funil_e_gravavel`) | **7.024** | a linha de base |
+| no board e **fora** da linha de base | **465** (5 fixtures: 4 `NS`, 1 `PST`) | ~6% |
+| na linha de base e **expurgadas** | **0** | — |
+
+⚠️ **Estas quatro linhas são a única conferência deste documento que a análise NÃO reproduz**,
+e é de propósito: o funil não carrega `status` (ADR 0011, D10 — status muda depois do apito e
+uma coluna congelada com o status de antes mentiria), então medir o expurgo exige juntar
+`fact_fixtures` e inlinar o `futebol_expurga_do_board`. É conferência de uma vez, feita em
+25/08, e não parte da entrega recorrente. Todo o resto sai da `taskA_linha_de_base_funil.sql`.
+
+O escopo vivo é **subconjunto estrito**: nada de expurgado entra — o critério do ticket está
+cumprido — mas ele é mais estrito que o board por 465 linhas, que são jogo passado do apito ainda
+dentro da carência e jogo adiado. Quem comparar a linha de base contra uma contagem do board vai
+encontrar essa diferença, e a causa é esta, não defeito.
+
+**Recomendação: o vivo é a linha de base; o histórico é o contexto.** O *antes* existe para ser
+comparado com o *depois* da A1, e a A1 muda exatamente a `porta_nota` — a única coluna que o
+histórico não pode sustentar. Para as outras sete portas o histórico é ganho puro de N (5,8× as
+linhas, 5,7× os fixtures) e deve ser citado. **Qual número a [A] cita é escolha do PM; os dois
+saem da mesma análise, na mesma coluna `escopo`.**
+
+⚠️ O histórico **contém** o vivo — são duas leituras da mesma tabela, não uma partição. Somar as
+duas linhas conta as linhas vivas duas vezes.
+
+## A janela: 1,11×, não 4×
+
+O ticket avisa que contar as quatro janelas (`daily` < `t24h` < `t1h` < `t15m`) infla todo número
+até 4×. Medido: no funil inteiro a redução é **120.510 → 40.672 (2,96×)**; **no escopo vivo é
+7.787 → 7.024, ou 1,11×**. Jogo futuro quase só tem `daily` — as outras três janelas só existem
+para jogo que já começou. O 4× é o teto teórico, não o número.
+
+## A fila por mercado (escopo vivo, `marginal / saída`)
+
+| porta | 1X2 | Handicap | Gols | BTTS | Dupla Chance |
+|---|---:|---:|---:|---:|---:|
+| 00. universo | 0 / 166 | 0 / 3.058 | 0 / 3.302 | 0 / 166 | 0 / 249 |
+| 01. saída catalogada | 0 / 166 | 0 / 3.058 | 0 / 3.302 | 0 / 166 | **83 / 166** |
+| 02. cobertura da Pinnacle | 22 / 144 | **1.712 / 1.346** | **2.052 / 1.250** | 0 / 166 | 22 / 144 |
+| 03. valor estimável | 0 / 144 | 0 / 1.346 | 0 / 1.250 | 0 / 166 | 0 / 144 |
+| 04. linha meia | 0 / 144 | **1.004 / 342** | **854 / 396** | 0 / 166 | 0 / 144 |
+| 05. liquidez ≥ 3 | 0 / 144 | 10 / 332 | 0 / 396 | 2 / 164 | 0 / 144 |
+| 06. odd mínima da DC | 0 / 144 | 0 / 332 | 0 / 396 | 0 / 164 | 31 / 113 |
+| 07. edge | 104 / 40 | 304 / 28 | 351 / 45 | **164 / 0** | 105 / 8 |
+| 08. nota ≥ 40 | 40 / **0** | 27 / **1** | 41 / **4** | 0 / **0** | 8 / **0** |
+
+Handicap e Gols perdem **56% e 62%** na cobertura da Pinnacle e outros **75% e 68%** na linha meia
+— antes de qualquer régua. Os 5 publicados do dia são 4 de Gols e 1 de Handicap.
+
+## O empate do 1X2, separado — e ele não sobrevive até a porta de nota
+
+O empate é um terço do universo do 1X2 **por construção**: não tem lado apostado, nenhuma premissa
+se aplica (ADR 0005/0006). Ele **sai da fila** e o corte é a primeira linha do funil do 1X2 —
+pôr uma população estruturalmente sem candidatura dentro de uma fila que mede severidade de porta
+infla o denominador de toda porta a montante e some no numerador da que interessa.
+
+| | vivo | histórico |
+|---|---:|---:|
+| empates (universo) | **83** | **469** |
+| reprovam **antes** do edge | 11 (13,3%) | 11 (2,3%) |
+| reprovam **no edge** | **62 (74,7%)** | **314 (67,0%)** |
+| chegam à nota e reprovam nela | 10 (12,0%) | 144 (30,7%) |
+| passariam em tudo | 0 | 0 |
+
+⚠️ **O critério de aceite, na letra, seria cumprido e falho por um fator de 3.** "O empate aparece
+separado, pelo motivo próprio `sem_lado_apostado`" só descreveria **144** dos 469 — porque o
+`motivo_primario` marca a PRIMEIRA porta reprovada e o edge vem antes da nota. Os outros 325 já
+tinham caído. Publicar os 469 inteiros com a quebra de onde eles caem é mais forte do que o
+critério pede, e é a única leitura em que os dois números querem dizer o que parecem.
+
+Nota máxima de um empate na rodada: **31** — abaixo dos 40 mesmo quando o edge deixa passar. Os
+pontos vêm de valor e corroboração; o teto de premissa é zero, e será zero explicitamente quando a
+A6 introduzir o denominador.
+
+## A nota por faixa: decis, e o topo da escala está vazio
+
+Denominador = quem **chega** à porta de nota (121 no vivo, 1.175 no histórico).
+
+| decil | faixa de hoje | vivo | histórico |
+|---|---|---:|---:|
+| D0 (0–9) | fora da régua | 56 (46,3%) | 588 (50,0%) |
+| D1 (10–19) | fora da régua | 22 (18,2%) | 182 (15,5%) |
+| D2 (20–29) | fora da régua | 20 (16,5%) | 179 (15,2%) |
+| D3 (30–39) | fora da régua | 18 (14,9%) | 128 (10,9%) |
+| D4 (40–49) | BAIXA | 3 (2,5%) | 62 (5,3%) |
+| D5 (50–59) | BAIXA | 2 (1,7%) | 27 (2,3%) |
+| D6 (60–69) | MÉDIA | **0** | 8 (0,7%) |
+| D7 (70–79) | MÉDIA | **0** | 1 (0,1%) |
+| D8–D9 (80+) | ALTA | **0** | **0** |
+
+⚠️ Nenhuma linha ALTA CONFIANÇA em nenhum dos dois escopos, e **metade de quem chega à nota tira
+menos de 10**. Com as três faixas de hoje a leitura seria "quase tudo é Baixa" e não diria onde; o
+decil diz. E ele sobrevive à A4 (#107), que tem mandato para mover as fronteiras — as faixas de
+hoje saem ao lado para a comparação com o board continuar possível.
+
+## As barreiras propostas pela A5 — e a direção depende de qual nota se lê
+
+⚠️ **Nenhuma das três está em produção.** Elas ficam **fora da fila e fora do cumulativo**: uma
+porta que não existe não pode remover linha do *antes*, ou o antes/depois da A5 mede zero contra
+zero. O ticket pede este bloco e ele está aqui, separado.
+
+Taxa de aprovação da faixa de odd (1,50–4,00; 1,25–2,00 na DC), escopo vivo:
+
+Taxa de aprovação da faixa de odd (1,50–4,00; 1,25–2,00 na DC). Os três eixos saem da coluna
+`corte` da seção 4 — nenhum destes números vem de query fora da análise:
+
+| faixa | 1. `pts_premissas` | 2. **nota publicada** | 3. `pts_premissas`, **só Pinnacle** |
+|---|---:|---:|---:|
+| **escopo vivo** | | | |
+| zero | 45,5% (530/1.166) | 20,0% (649/3.249) | 72,1% (404/560) |
+| 1–29 | 40,9% (1.777/4.344) | 52,4% (1.672/3.191) | 70,9% (1.379/1.946) |
+| ≥ 30 | **19,9%** (268/1.348) | **60,8%** (254/418) | **46,4%** (222/478) |
+| **escopo histórico** | | | |
+| zero | 37,7% (3.749/9.939) | 17,8% (3.694/20.759) | 63,4% (3.224/5.086) |
+| 1–29 | 38,7% (9.273/23.940) | 53,4% (8.726/16.340) | 65,4% (7.793/11.913) |
+| ≥ 30 | **19,1%** (1.121/5.855) | **65,4%** (1.723/2.635) | **44,9%** (1.059/2.359) |
+
+**O ticket tem razão no eixo em que ele mediu, e a direção se inverte no outro.** Por pontos de
+premissa a faixa corta mais forte justo onde há mais premissa acesa (19,9% contra 45,5% no vivo);
+**pela nota publicada ela corta mais forte onde a nota é ZERO** (20,0% contra 60,8%).
+
+O número literal do ticket — "62% das linhas com zero premissa e só 47% das com ≥30 pontos, entre
+linhas com preço da Pinnacle" — é o **eixo 3, escopo histórico**: **63,4% contra 44,9%**. Reproduz
+dentro de um ponto percentual, e a diferença é o funil ter crescido desde a medição original. As
+três leituras são a mesma tabela vista por eixos diferentes, e **a A5 precisa declarar qual delas
+está usando antes de defender a barreira** — a mesma barreira parece corte de ruído num eixo e
+corte de sinal no outro.
+
+As outras duas, escopo vivo, por `pts_premissas` (zero / 1–29 / ≥30): `n_casas >= 4` aprova
+61,6% / 57,6% / 50,5% e `NOT pen_odd_outlier` aprova 86,1% / 91,2% / 98,6%.
+
+## Reconciliação contra a cópia à mão — uma vez, e ela se aposenta
+
+As duas rodaram **entre dois ciclos de odds** (última escrita do funil 19:01:46 UTC; as duas
+consultas às 19:16 e 19:18), sobre o mesmo escopo vivo e a mesma janela corrente. Sem isso o
+de-vig se moveria debaixo delas: a cópia à mão lê `int_futebol_odds_devig` ao vivo e o funil lê a
+tabela congelada.
+
+O funil foi lido duas vezes — 19:16:58 e a rodada publicada, 19:30:24 — e **as duas saem
+idênticas linha a linha na fila, no empate e na procedência**; a conferência abaixo vale para as
+duas. (Entre elas só se moveram as barreiras da A5, porque preço novo da Pinnacle troca o
+`valor_fonte` de linhas que já existiam sem inserir linha nenhuma.)
+
+**O universo bate exato (6.941 = 6.941) e a saída bate exata (5 = 5).** As duas divergências
+intermediárias são as **estruturais declaradas de antemão**, e nenhuma outra apareceu:
+
+| mercado | cópia à mão | funil | causa |
+|---|---:|---:|---|
+| `match_winner` | 249 | 166 | a cópia à mão inclui o **empate** (83); o funil o tira da fila |
+| `double_chance` | 166 | 249 | o `INNER JOIN` com as premissas some com a **"12"** (83); o funil a carimba `porta_saida_catalogada = FALSE` |
+
+Os dois blocos têm 83 linhas — um por fixture — e por isso os totais coincidem por acidente
+aritmético, com conjuntos diferentes. Porta a porta, nos três mercados que as duas leem igual:
+
+| porta | Handicap | Gols | BTTS |
+|---|---|---|---|
+| completude / cobertura | 18 + 1.694 = **1.712** ✅ | 60 + 1.992 = **2.052** ✅ | 0 = 0 ✅ |
+| linha meia | 1.004 = **1.004** ✅ | 854 = **854** ✅ | — |
+| liquidez | 10 = **10** ✅ | 0 = 0 ✅ | 2 = **2** ✅ |
+| edge | 304 = **304** ✅ | 351 = **351** ✅ | 164 = **164** ✅ |
+| nota | 27 = **27** ✅ | 41 = **41** ✅ | 0 = 0 ✅ |
+
+A soma `de-vig válido + completude` da cópia à mão dá exatamente a `cobertura da Pinnacle` do funil
+porque as linhas sem prob justa também não têm cobertura — é a mesma leitura em outra ordem, e é a
+medição que prova o item 2 do veredito.
+
+Na Dupla Chance, a `porta_odd_dc` do funil (31) mais o edge (105) dão os **136** que a cópia à mão
+atribui inteiros ao edge: ela não tem a porta de odd da DC, e as 31 linhas que caem nela também
+cairiam no edge. No 1X2, os 166 do edge da cópia à mão são os 104 do funil mais os 62 empates, e os
+50 que ela leva à nota são os 40 do funil mais os 10 empates. Fecha nos dois.
+
+**Contra os números publicados na rodada anterior, não há tabela — cinco causas mudaram entre as
+duas** (a porta de odd que aquela medição incluía e não existe em produção; o `.25` da #101; o
+histórico da #91; a #71; e o próprio dia do board). A direção é a única coisa comparável, e é a
+esperada: as mudanças do `.25` só **apertam**, monotonicamente. Aqui vale a precisão — a cópia à
+mão **já foi corrigida** pelo `.25` (commit `c33608c`), e é por isso que os marginais de linha meia
+batem byte a byte hoje. A descontinuidade do `.25` é contra os **números publicados**, não contra o
+arquivo como ele está.
+
+A partir daqui `analyses/taskA_linha_de_base.sql` está **aposentada** — marcada no cabeçalho, não
+apagada: ela é a outra metade desta reconciliação e carrega o esboço do regime `novo` que a A3+A5
+vai querer. Ela some com a A5.
+
+## Achado fora do escopo: a `porta_conjunto_completo` não é a regra da ADR 0002
+
+O cabeçalho do `fact_value_funnel` diz que `porta_conjunto_completo` e `porta_valor_estimavel` são
+**aninhadas** ("conjunto incompleto implica prob justa ausente") e avisa contra somá-las. Medido, o
+aninhamento existe **no sentido contrário**: reprovar em valor implica reprovar em cobertura, e
+nunca o inverso — **19.449 linhas de um lado, 0 do outro**. `valor_estimavel` tem marginal **zero**
+em todos os mercados e nos dois escopos. A tabela abaixo é a janela corrente inteira (= escopo
+histórico); as três primeiras linhas somam os 19.449.
+
+| mercado | `valor_fonte` | cobertura | valor | linhas |
+|---|---|---|---|---:|
+| asian_handicap | consenso | **false** | **true** | **8.948** |
+| goals_over_under | consenso | **false** | **true** | **10.468** |
+| match_winner | consenso | **false** | **true** | 33 |
+| asian_handicap | pinnacle | true | true | 8.902 |
+| goals_over_under | pinnacle | true | true | 7.982 |
+| btts | consenso | true | true | 938 |
+
+A causa: a regra da ADR 0002 (`n_outcomes_valor = conjunto_esperado`) mora no de-vig e no funil é a
+`porta_valor_estimavel`. A `porta_conjunto_completo` é outra coisa — é o `WHERE d.pin_n_outcomes >= N`
+dos ramos do board, a versão **anterior à #22**, que nunca saiu. Ela pergunta *"a Pinnacle
+cobriu?"*, não *"o conjunto está completo?"*. E é **assimétrica entre mercados**: o ramo do BTTS
+gateia em `n_outcomes_valor` e admite consenso; Handicap e Gols gateiam na Pinnacle e não admitem.
+
+**Dentro da #106 isto é só rótulo** — a fila publica as duas com nomes diferentes e nada em
+produção muda. **Fora dela mexe numa decisão já tomada**: o item 3 da spec-mãe (#15) decidiu que a
+completude "continua exatamente como está", e essa confirmação foi dada sobre o **nome**. O
+predicado que existe barra **19.449 linhas** de Handicap, Gols e 1X2 precificadas só por consenso —
+e linha de consenso ainda enfrenta piso de edge 3× maior, o que **acopla a porta de cobertura à
+régua de edge por um caminho que ninguém desenhou**. Se é conserto, emenda de ADR ou comportamento
+correto mal documentado é grelha própria: **#118**.
+
+## Como rerodar
+
+```bash
+cd dbt_futebol
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_linha_de_base_funil
+bq query --use_legacy_sql=false --format=csv \
+  < target/compiled/dbt_futebol/analyses/taskA_linha_de_base_funil.sql
+```
+
+Nada em produção muda: é `compile` + `bq query`, nunca `dbt run`.


### PR DESCRIPTION
A entrega da **#106** — a linha de base remedida, lida do funil — mais o vocabulário que a grelha pediu. Só análise e documentação: **nenhum modelo, nenhum macro, nenhuma guarda**. `analysis-paths` não é caminho comportamental, então **não precisa de `build-and-push.sh` nem de entrada em selector**.

## O que entra

| arquivo | |
|---|---|
| `dbt_futebol/analyses/taskA_linha_de_base_funil.sql` | a fila lida do `fact_value_funnel`, em cinco seções |
| `docs/TASKA_RESULTADOS.md` | os números, com a rodada carimbada |
| `dbt_futebol/analyses/taskA_linha_de_base.sql` | marcada `⚠️ APOSENTADA` — **não** apagada |
| `dbt_futebol/CONTEXT.md` | três entradas novas e uma emenda |

## O número

**Cinco linhas publicadas de 7.024 candidatas no escopo vivo — 0,1%.** Duas portas fazem quase todo o trabalho:

| # | porta | entra | remove (marginal) | sai |
|---|---|---:|---:|---:|
| 01 | saída catalogada | 6.941 | 83 | 6.858 |
| 02 | **cobertura da Pinnacle** | 6.858 | **3.808** | 3.050 |
| 03 | valor estimável (ADR 0002) | 3.050 | **0** | 3.050 |
| 04 | linha meia (AH/Gols) | 3.050 | 1.858 | 1.192 |
| 05 | liquidez ≥ 3 casas | 1.192 | 12 | 1.180 |
| 06 | odd mínima da DC | 1.180 | 31 | 1.149 |
| 07 | **edge acima do piso** | 1.149 | **1.028** | 121 |
| 08 | nota ≥ 40 | 121 | 116 | **5** |

**A porta de nota recebe 121 e devolve 5** — A1 e A4 vão mexer numa porta que vê **1,7%** do universo. As outras 6.820 linhas caíram em portas estruturais.

## Duas emendas ao ticket, ambas medidas

- **A faixa de odd não entra na fila.** É proposta da A5 (#104), não está em produção — porta que não existe não pode remover linha do *antes*, ou o antes/depois da A5 mede zero contra zero. Sai em bloco próprio, por **três eixos**, porque a direção do ticket depende do eixo: por `pts_premissas` a faixa aprova **19,9%** contra 45,5%; pela **nota publicada**, **60,8%** contra 20,0%. A frase literal do ticket é o eixo 3 no histórico: 63,4% contra 44,9%.
- **O empate do 1X2 sai da fila, com os 469 inteiros.** O critério na letra (`sem_lado_apostado`) descreveria **144 de 469** — 67% já caem no **edge**, que vem antes da nota. Erro de 3×. Nota máxima de um empate: **31**.

## Uma correção contra o próprio ticket

O critério diz "população já expurgada (ADR 0009)". ⚠️ **"Escopo vivo" e "já expurgada" não são o mesmo conjunto** — o expurgo corta por **status**, com o relógio só como rede de 24 h, e `PST`/`SUSP`/`INT` sobrevivem ao kickoff no passado de propósito.

| | linhas |
|---|---:|
| não expurgadas do board | **7.489** |
| escopo vivo (a linha de base) | **7.024** |
| no board e **fora** da linha de base | **465** (5 fixtures) |
| na linha de base e **expurgadas** | **0** |

Subconjunto **estrito**: o critério está cumprido (nada de expurgado entra), por um predicado mais estrito, e o preço está medido.

## As três descontinuidades

- **#91** (`887a1f9`, 25/08 16:31:32 UTC) — parte a série, e **só na `porta_nota`**. Sai como coluna `nota_valida_no_escopo`, decidida por um campo `depende_da_nota` e **nunca** casando contra o texto do rótulo.
- **`.25`** (#101, 21/08 19:05 UTC) — real contra os números *publicados*, **inexistente dentro da série**: o backfill do funil rodou 21:21, depois dele.
- **`origem = 'backfill'`** — 68,8% do histórico, **0%** do vivo.

## Reconciliação, uma vez

Universo **6.941 = 6.941** e saída **5 = 5**, porta a porta nos três mercados que as duas leem igual. As duas divergências são as estruturais declaradas de antemão: a cópia à mão inclui o empate (83) e exclui a "12" da DC (83) — blocos de mesmo tamanho e **conjuntos diferentes**, então os totais coincidem por acidente aritmético. A cópia à mão fica marcada, com os dois comandos que reproduzem a conferência: ela é a outra metade dela e some com a A5.

## O achado que virou issue própria

`porta_conjunto_completo` **não é a regra da ADR 0002** — é o `WHERE pin_n_outcomes >= N` anterior à #22. Medido: **19.449 linhas reprovam nela e passam no valor, e ZERO no sentido inverso**. O aninhamento existe ao **contrário** do que o cabeçalho do mart declara, e `valor_estimavel` tem marginal **zero** em todo mercado e escopo. Aqui é só rótulo — o predicado é a **#118**.

## Decisões de forma

- **Sem seed.** O append-only (ADR 0011) **é** o congelamento; o que a entrega grava é o **predicado de corte**, não uma cópia dos números.
- **Sem ADR.** O congelamento já tem a 0011 e a porta já tem a 0002.
- **Os números moram no doc, não no cabeçalho do `.sql`** — foi guardar número em cabeçalho que deixou a cópia à mão acumular três invalidações sem ninguém notar.
- **O último degrau da fila lê `passou_no_gate` do mart**, nunca a conjunção reescrita: o mart diz que ela é "jamais escrita à mão", e uma nona cópia numa análise é como a expressão de meia-linha chegou a quatro (#101/#114).

## Fica em aberto para o PM

Qual número a [A] cita: o **vivo** (83 fixtures, sem confundidor) ou o **histórico** (469, 5,8× as linhas, `porta_nota` majoritariamente pré-#91). Minha leitura está no doc — o vivo é a linha de base, o histórico é o contexto — e **os dois saem da mesma query, na mesma coluna `escopo`**.

Closes #106
Refs #15, #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016unvLVAGnCQPHqKi4Yp3mb
