### PR TITLE
docs(adr): a partição de uma digital de insumo é o fecho da computação (emenda à 0007)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -486,6 +486,19 @@ meia-linha, so the published edge there describes a bet nobody can place. The te
 wrong (#101, #113).
 _Avoid_: "linha inteira" for .25/.75 — a linha cheia is .0, and it pushes differently
 
+**Fecho de uma linha** (closure):
+Everything a single output row is a function of. It is the only honest partition for an
+**impressão digital de insumo** — the fingerprint a guard uses to decide which rows are still
+comparable against a frozen baseline. A partition coarser than the closure is not merely loose,
+it is **false**: it declares rows comparable whose input moved outside the cut, so the guard
+reports a defect where there is behaviour. Measured case (#91 → 26/08): `pit_escopo: todas` made
+a PIT row a function of the team's history in *every* competition, while the Costura A kept
+fingerprinting by `(competition_id, season)` — Brasileirão 2026 matched byte for byte and still
+diverged in 60 rows, because all 20 of its teams also play Libertadores and Copa do Brasil. The
+rule that follows: **any change of axis is a candidate to change the closure**, and "what does
+this row now depend on?" belongs in the checklist of whoever changes it. Emenda to ADR 0007.
+_Avoid_: partição (bare — ambiguous with the BigQuery partition of a table)
+
 **Célula de medição**:
 One combination of escopo and recorte under which the whole premissa layer is rematerialised
 and remeasured. Two cells are comparable only if computed in the same run over the same frozen

--- a/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
+++ b/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
@@ -15,6 +15,12 @@ status: accepted
 > tudo abaixo continua em vigor, inclusive a Costura A. No commit que vira o default, a Costura A
 > (`tests/assert_taskf_pit_default_igual_baseline`) é **recongelada** — a saída que o cabeçalho
 > dela já nomeia.
+>
+> ⚠️ **RECONGELAR NÃO BASTOU, e esta emenda estava incompleta** — ver a emenda de 2026-08-26 no
+> fim deste arquivo. Virar o default para `todas` mudou o FECHO da conta do PIT, e a partição da
+> impressão digital da Costura A continuou sendo `(competition_id, season)`. O recongelamento de
+> 25/08 deixou a guarda verde por algumas horas; em 26/08 ela estava vermelha de novo, sobre
+> movimento legítimo.
 
 A task [F] precisa saber o que cada premissa vira quando o PIT do time deixa de ser
 contado dentro da competição. Trocar só o `min_jogos` não responde isso: as flags das premissas
@@ -125,3 +131,100 @@ primeiro jogo de Copa do Brasil de um time passa a carregar até 17 partidas de 
 Sudamericana até 25. Guard vermelho por desenho é guard que se exclui da linha de comando, e aí a
 célula roda sem guarda de look-ahead — o defeito que contaminou a medição que a [F] existe para
 refazer. A única exclusão que a medição precisa é a Costura A, que é default-only por definição.
+
+---
+
+## Emenda de 2026-08-26 — a partição da impressão digital é o FECHO da computação, e a #91 mudou o fecho
+
+A Costura A (`tests/assert_taskf_pit_default_igual_baseline`) compara só as partições cujo
+**insumo** está idêntico ao do congelamento, e particiona esse insumo por `(competition_id,
+season)`. O `taskf_fingerprint_insumo_pit` declara a premissa que sustenta esse recorte:
+
+> O recorte por (competition_id, season) é sólido porque **no caminho DEFAULT** a linha de uma
+> âncora em (C,S) é função só dos fixtures de (C,S) e das standings de (C,S) […] **Sob
+> `pit_escopo=todas` isso deixa de valer** — e é aí que a guarda deve mesmo falhar, porque a var
+> saiu do default.
+
+**A #91 tornou `todas` o default.** A premissa foi falsificada pela própria mudança que a emenda
+de 19/08 acima anuncia, e nem aquela emenda nem o recongelamento de 25/08 recalcularam o recorte.
+O resultado é uma guarda que acende sobre movimento legítimo e ficaria vermelha para sempre — o
+destino que este repositório documenta em todo lugar como "guarda permanentemente vermelha morre
+ignorada", só que na versão lenta.
+
+**Medido em 26/08:** o Brasileirão 2026 **casou** na digital (380 fixtures, `fp_fixtures` byte a
+byte igual ao baseline) e ainda assim divergiu em **60 linhas**. Os **20** times dele também jogam
+em Libertadores (13/2026) e Copa do Brasil (73/2026), duas das seis partições que se moveram. Sob
+`todas`, a linha de um jogo do Brasileirão lê o histórico do time em **toda** competição — então
+ela se move com a digital da própria competição intacta.
+
+### A regra que fica
+
+**A partição de uma impressão digital de insumo tem de ser o FECHO da computação que ela protege.**
+Partição mais grossa que o fecho não fica frouxa — fica **mentirosa**: ela declara comparáveis
+linhas cujo insumo mudou fora do recorte, e a guarda passa a acusar defeito onde há
+comportamento. E o inverso também vale: mudar o fecho sem recalcular a partição é uma quebra
+**muda**, porque o sintoma aparece dias depois e se parece com deriva de dados.
+
+Toda mudança de eixo — de escopo, de recorte, de fonte — é candidata a mudar o fecho, e a
+pergunta *"isto muda de que a linha depende?"* passa a ser parte do checklist de quem a faz.
+
+### O recorte novo: por LINHA
+
+Sob `todas`, a linha em (fixture F de C/S, time T) é função de **(a)** os fixtures de T com
+`kickoff < kickoff(F)`, em toda competição, e **(b)** as standings correntes de (C,S). O fecho é,
+portanto, **a própria linha** — e o baseline ganha uma coluna `fp_insumo_linha` gravada no
+congelamento, que a guarda recomputa e compara.
+
+As três alternativas foram medidas sobre o baseline de 21.078 linhas, e não estimadas:
+
+| recorte | cobertura em 26/08 | trajetória |
+|---|---|---|
+| por `(competition_id, season)` — o de hoje | 88,1% | **mentirosa**: inclui as linhas que não deveriam ser comparáveis |
+| por **time** (digital do histórico global de T) | 57,1% | **erode até zero** |
+| por **linha** (o fecho exato) | **68,2%** — 14.366 linhas, 25 de 37 partições | **não erode; cresce** |
+
+⚠️ **Por que "por time" é a armadilha, e não a resposta óbvia.** Ela *parece* o fecho, mas
+digitaliza o histórico inteiro do time — **incluindo jogos posteriores à linha**, que a linha não
+lê. O Palmeiras jogar amanhã invalidaria a linha dele de 2024. O fecho exato é per-linha porque a
+conta é per-linha, e é exatamente isso que o torna estável: o passado de uma linha de 2024 não se
+move quando um jogo de 2026 acontece. A cobertura por linha **sobe** com o tempo, porque temporada
+encerrada fica encerrada.
+
+### O que a emenda NÃO muda
+
+**O piso de cobertura fica em 0,5** (`taskf_cobertura_minima`) e ganha sentido novo. Ele existia
+para pegar a erosão estrutural de um recorte que encolhia sozinho; sob o recorte por linha a
+cobertura não encolhe por conta própria, então ele passa a ser guarda de **vacuidade**: se cair, é
+porque o passado está sendo reescrito em massa — achado, não desgaste. Recalibrá-lo agora seria
+calibrar contra uma trajetória que ninguém mediu.
+
+**A guarda continua em `tag:taskf`, fora do agendado.** Ela cobre o caminho que produção serve,
+o que é argumento para promovê-la — mas o precedente da **#33** manda o contrário: guarda com
+baseline permanente não entra na tag. Baseline permanente precisa de curadoria humana, e guarda
+que precisa de curadoria dentro do agendado vira ruído no resumo diário. O que ela ganha em troca
+é voltar a ficar **verde**, que é a condição para alguém olhar para ela de novo.
+
+**A guarda não se aposenta.** Desde a #91 o default É o caminho de produção, então a pergunta
+"a saída do default mudou sozinha?" vale mais agora do que quando a guarda foi escrita.
+
+### O recongelamento é obrigatório, e no mesmo commit
+
+`fp_insumo_linha` não existe no baseline de hoje. Mudar o que entra no `FARM_FINGERPRINT` sem
+recongelar faz **nenhuma** partição casar — e aí a guarda não fica vermelha, fica **VAZIA**, que
+é pior. O `taskf_fingerprint_insumo_pit` já escreve essa regra; a #91 já pagou o preço de não a
+seguir. O recongelamento sai de **produção** (`--target prod`), nunca do `futebol_taskF`: congelar
+do dataset de medição carimbaria o baseline com fatos parados — a lição da seção #82 do
+`docs/TASKF_RESULTADOS.md`.
+
+E o reparo **não invalida a âncora da remedição (#82)**: o `fp_insumo_pit` não é lido por nenhum
+modelo de premissa, nem pelo `task01_base`, nem pelo de-vig. Ele não está na lista de "o que
+invalida esta âncora", e por isso este trabalho entra **antes** da remedição sem forçar
+re-medição.
+
+### As duas falsificações
+
+1. **a de sempre** — célula fora do default deixa a guarda vermelha por desenho
+   (`--vars '{pit_escopo: da_competicao, pit_recorte: temporada}'`);
+2. **a nova, e é ela que prova o reparo** — rodar a guarda com o recorte novo **sem** recongelar
+   o baseline tem de dar **vazia**, nenhuma linha casando. Ver a falha acontecer de propósito é o
+   que impede alguém de produzi-la por acidente depois.


### PR DESCRIPTION
A emenda que fecha o grilling de 26/08 sobre a Costura A (`assert_taskf_pit_default_igual_baseline`),
e o verbete de vocabulário que ela gera. **Só markdown — nenhum modelo, macro ou teste muda aqui.**

O reparo em si é a issue #123.

## O que a emenda registra

A Costura A está vermelha com 60 linhas, e **não é regressão**. O `taskf_fingerprint_insumo_pit`
declara por escrito a premissa do recorte dele — *"sob `pit_escopo=todas` isso deixa de valer"* —
e a **#91 tornou `todas` o default**. Nem a emenda de 19/08 desta mesma ADR nem o recongelamento
de 25/08 recalcularam o recorte.

Medido em 26/08: o **Brasileirão 2026 casou** na digital (380 fixtures, `fp_fixtures` byte a byte
igual ao baseline) e ainda assim divergiu em **60 linhas** — porque os **20** times dele também
jogam Libertadores e Copa do Brasil, duas das seis partições que se moveram.

## A regra que fica

**A partição de uma impressão digital de insumo tem de ser o FECHO da computação que ela protege.**
Partição mais grossa que o fecho não fica frouxa — fica **mentirosa**: declara comparáveis linhas
cujo insumo mudou fora do recorte. E mudar o fecho sem recalcular a partição é quebra **muda**, que
aparece dias depois parecendo deriva de dados.

## Os números que sustentam o recorte novo

Medidos sobre as 21.078 linhas do baseline, não estimados:

| recorte | cobertura | trajetória |
|---|---|---|
| por `(competition_id, season)` — o de hoje | 88,1% | **mentirosa** |
| por time | 57,1% | erode até zero |
| **por linha** (o fecho exato) | **68,2%** | **não erode; cresce** |

O recorte "por time" é a armadilha: parece o fecho, mas digitaliza jogos **posteriores** à linha,
que a linha não lê — o Palmeiras jogar amanhã invalidaria a linha dele de 2024.

## As nove decisões do grilling

1. as 60 linhas são artefato do recorte, não regressão;
2. a guarda **se repara** — desde a #91 ela cobre o caminho de produção, então vale mais agora;
3. recorte **por linha** (`fp_insumo_linha` no baseline);
4. piso fica em **0,5**, com sentido novo (vacuidade, não erosão);
5. **recongelar de produção no mesmo commit** — sem isso a guarda fica *vazia*, não vermelha;
6. continua **`tag:taskf`**, pelo precedente da #33;
7. entra **antes da remedição** e **não invalida a âncora da #82**;
8. duas falsificações, uma delas nova (recorte novo sem recongelar tem de dar vazia);
9. registro como **emenda à ADR 0007** — a premissa dela é que foi corrigida, não uma decisão nova.
