### PR TITLE
feat(futebol): o denominador da nota é medido e congelado em seed (#105)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -48,8 +48,30 @@ observed p95, measured once over a **declared window** and **frozen**. Its job i
 100 mean the same thing on every lado — the top of the scale anchored at a common
 quantile. It is deliberately not the sum of the weights, which never occurs, and not
 recomputed at runtime: a denominator that moves makes the régua mean a different thing
-each day and kills every historical comparison.
+each day and kills every historical comparison. Since #105 it is a concrete artefact: the
+seed `futebol_p95_nota_contexto`, eleven rows carrying the p95, the window it was measured
+over, the date of the measurement and where each number came from.
 _Avoid_: teto (bare — ambiguous with the sum of the pesos)
+
+**Lado**:
+The side actually backed, and the axis the denominator is keyed on — eleven (mercado, lado)
+pairs, derived in one place (`macros/futebol_lado.sql`). It is **not** the `outcome`: on the
+Handicap the outcome is Home/Away while the lado is Favorito/Azarao/Pick, read off the sign
+of the handicap from the backed side's point of view, and the two have disjoint premissa
+sets (Σ40 against Σ30). On the Dupla Chance 1X and X2 collapse into `unico`, because the
+four premissas apply to both saídas.
+_Avoid_: outcome/saída as a synonym (they coincide on three markets out of five, which is
+exactly what makes the confusion survive)
+
+**Nota normalizada**:
+The nota de contexto divided by its lado's frozen p95, 0–100 (#105, ADR 0005):
+`score_normalizado` in `fact_value_funnel`. It exists so that 100 means the same thing on
+every lado. Absolute, never a percentile within the lado. ~5% of each lado's lines land on
+100 **by construction** — that is the quantile, not an error — and a zero denominator (the
+1X2 draw, the Handicap pick) resolves to an explicit zero, never a `SAFE_DIVIDE` NULL that
+would let the line leave without passing and without being marked.
+_Avoid_: calling it the Score — the board still reads `score` and the régua of 40 until the
+flip at the end of the [A]
 
 **Premissa**:
 A boolean context signal computed from the data, carrying a point weight. Fired

--- a/dbt_futebol/analyses/taskA_a6_p95.sql
+++ b/dbt_futebol/analyses/taskA_a6_p95.sql
@@ -1,0 +1,187 @@
+{#
+    A6 — O DENOMINADOR CONGELADO: o p95 da nota de contexto por (mercado, lado).
+
+    Esta análise MEDE o número que vai ao seed `futebol_p95_nota_contexto`. Ela roda uma vez,
+    o resultado é copiado para o CSV à mão, e a partir daí quem manda é o CSV — recalcular o
+    denominador em runtime é falha de aceite da issue #105: um denominador que se move faz a
+    régua significar coisa diferente a cada dia e mata toda comparação histórica.
+
+    Rodar com:
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_a6_p95
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/taskA_a6_p95.sql
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    O UNIVERSO: candidatos, lidos do funil — nunca o board
+
+    O board é o que já passou nas oito portas. Medir o p95 sobre ele mediria a distribuição
+    do que sobreviveu à régua de 40, que é a própria coisa que o denominador existe para
+    reescalar: o denominador sairia calibrado para manter em cima quem já estava em cima.
+    O funil guarda o universo inteiro, rejeitados inclusive (ADR 0006/0011), e é dele que a
+    medição sai.
+
+    ⚠️ UMA JANELA POR CANDIDATO. O funil guarda até QUATRO linhas por candidato (daily,
+    t24h, t1h, t15m) e a nota de contexto é a MESMA nas quatro — desde a #103 nenhuma
+    premissa lê movimento de odd, então nada nela depende da janela. Contando as quatro, o
+    jogo precificado cedo pesaria até 4× no percentil, e o p95 descreveria "quem foi
+    precificado por mais tempo" em vez de "quanta evidência acende". `janela_e_corrente`
+    fixa uma, e é a regra que a guarda de deriva repete.
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    A ROTA: premissas RECOMPUTADAS, não lidas do registro — e em todos os cinco mercados
+
+    O funil é append-only e congelado no apito (#96, ADR 0011): a linha de jogo já apitado
+    não é reescrita por build nenhum. Ele também não guarda `evidencias[]` (ADR 0011). Junte
+    isso à #103, que tirou `linha_subindo`/`linha_descendo` do Gols e derrubou os tetos de
+    56/52 para 50/46, e o resultado é que qualquer janela do funil que inclua candidato
+    anterior ao deploy da A1 mistura DUAS ESCALAS DO GOLS — e não há como separá-las depois,
+    porque não dá para saber, numa linha congelada, se as duas premissas de movimento
+    acenderam.
+
+    Por isso a nota de contexto aqui é RECOMPUTADA: o universo (quais candidatos existiram,
+    e quando) vem do funil, e os pontos vêm dos cinco modelos de premissa como eles estão
+    HOJE. É o padrão da `taskA_a40_transporte.sql`, e é o que a issue #105 autoriza
+    explicitamente — inclusive a recomputar os cinco mercados em vez de só o Gols, desde que
+    dito e não implícito. Está dito: **os onze lados vêm de recomputação**, e o seed carrega
+    `origem = 'recomputacao'` nos onze. Os outros quatro mercados não precisariam (a A1 só
+    mexeu na escala do Gols), mas uma medição com duas procedências obrigaria toda leitura
+    futura a saber qual linha veio de onde.
+
+    ⚠️ LIMITE CONHECIDO, e é o preço de não esperar: premissa recomputada está sujeita à
+    irreprodutibilidade da #78 — premissa que acende em número diferente de linhas a cada
+    build, com o insumo congelado. É a razão de o funil existir. A alternativa era declarar
+    a janela começando no deploy da #103 e esperar semanas de coleta, adiando a A6 e, com
+    ela, a #106 e a #107.
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    A QUANTIDADE MEDIDA: a nota de contexto, não `pts_premissas`
+
+    Numerador e denominador têm de ser a mesma coisa. A nota normalizada divide
+    `GREATEST(pts_premissas − penalidades_de_contexto, 0)` — que é `futebol_nota_contexto()`,
+    a coluna que a #103 pôs no funil — e é o p95 DELA que o seed congela.
+
+    ⚠️ Os números 44 (Gols Over) e 26 (Handicap favorito) da tabela da ADR 0005 são
+    ILUSTRAÇÃO PRÉ-A1, medidos noutra escala do Gols e sobre a soma de pesos. Não são o
+    esperado desta medição, e divergir deles não é defeito.
+
+    Os três tetos que a tabela de origem errava entram corrigidos, e saem conferidos na
+    coluna `teto_catalogo` abaixo: Resultado Fora é 47 (o `pts_mando` do visitante vale 4),
+    Empate é 0, e o "Não" do Ambos Marcam é 28 (12+10+6).
+#}
+
+WITH universo AS (
+    SELECT
+        f.fixture_id,
+        f.market,
+        f.outcome,
+        f.line_key,
+        f.line_value,
+        f.kickoff_utc,
+        {{ futebol_lado('f.market', 'f.outcome', 'f.line_value') }} AS lado
+    FROM {{ ref('fact_value_funnel') }} f
+    -- uma janela por candidato — ver o ⚠️ do cabeçalho.
+    WHERE f.janela_e_corrente
+),
+
+-- ============================================================================
+-- A RECOMPUTAÇÃO. O universo (esquerda) vem do funil; os pontos (direita) vêm dos cinco
+-- modelos de premissa como eles estão hoje. As chaves de junção são as MESMAS que o
+-- `fact_value_funnel` usa em cada ramo — copiá-las diferente aqui mediria outra coisa.
+-- ============================================================================
+recomputado AS (
+    SELECT u.*, p.pts_premissas, p.penalidades_1x2_pts AS penalidades_especificas_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_1x2') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[1] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_ou_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_ou') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+     AND COALESCE(CAST(p.line_value AS STRING), 'NONE') = u.line_key
+    WHERE u.market = '{{ futebol_mercados_pontuados()[5] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_ah_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_ah') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+     AND COALESCE(CAST(p.line_value AS STRING), 'NONE') = u.line_key
+    WHERE u.market = '{{ futebol_mercados_pontuados()[4] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_btts_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_btts') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[8] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_dc_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_dc') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[12] }}'
+),
+
+com_nota AS (
+    SELECT
+        r.*,
+        -- a MESMA composição que o funil grava, do mesmo macro. As duas colunas de que ele
+        -- depende chegam acima com o nome que ele espera.
+        {{ futebol_nota_contexto() }} AS nota_contexto
+    FROM recomputado r
+    -- saída fora do catálogo (a "12" da DC) resolve o lado para NULL e sai da medição.
+    WHERE r.lado IS NOT NULL
+),
+
+medido AS (
+    SELECT DISTINCT
+        market,
+        lado,
+        {{ futebol_p95('nota_contexto') }} OVER (PARTITION BY market, lado) AS p95,
+        COUNT(*)                OVER (PARTITION BY market, lado) AS n_candidatos,
+        COUNTIF(nota_contexto IS NOT NULL)
+                                OVER (PARTITION BY market, lado) AS n_avaliados,
+        MAX(nota_contexto)      OVER (PARTITION BY market, lado) AS maximo_observado,
+        AVG(nota_contexto)      OVER (PARTITION BY market, lado) AS media_observada,
+        COUNTIF(nota_contexto = 0)
+                                OVER (PARTITION BY market, lado) AS n_em_zero,
+        MIN(DATE(kickoff_utc))  OVER (PARTITION BY market, lado) AS janela_inicio,
+        MAX(DATE(kickoff_utc))  OVER (PARTITION BY market, lado) AS janela_fim
+    FROM com_nota
+)
+
+SELECT
+    market,
+    lado,
+    p95,
+    -- o teto do catálogo, escrito à mão, para conferir de olho quem SATURA (p95 = teto) e
+    -- quem não chega perto. Os três valores que a tabela de origem errava estão aqui
+    -- corrigidos: 1X2 Away 47, 1X2 Draw 0, BTTS No 28.
+    CASE market || '/' || lado
+        WHEN '{{ futebol_mercados_pontuados()[1] }}/Home'     THEN 51
+        WHEN '{{ futebol_mercados_pontuados()[1] }}/Away'     THEN 47
+        WHEN '{{ futebol_mercados_pontuados()[1] }}/Draw'     THEN 0
+        WHEN '{{ futebol_mercados_pontuados()[5] }}/Over'     THEN 50
+        WHEN '{{ futebol_mercados_pontuados()[5] }}/Under'    THEN 46
+        WHEN '{{ futebol_mercados_pontuados()[4] }}/Favorito' THEN 40
+        WHEN '{{ futebol_mercados_pontuados()[4] }}/Azarao'   THEN 30
+        WHEN '{{ futebol_mercados_pontuados()[4] }}/Pick'     THEN 0
+        WHEN '{{ futebol_mercados_pontuados()[8] }}/Yes'      THEN 34
+        WHEN '{{ futebol_mercados_pontuados()[8] }}/No'       THEN 28
+        WHEN '{{ futebol_mercados_pontuados()[12] }}/unico'   THEN 34
+    END AS teto_catalogo,
+    n_candidatos,
+    n_avaliados,
+    n_em_zero,
+    maximo_observado,
+    ROUND(media_observada, 2) AS media_observada,
+    -- quanto a nota normalizada mudaria a média deste lado — a amplitude que a ADR 0005
+    -- diz que cai de 3,8× para 2,1×, e que NÃO some.
+    ROUND(SAFE_DIVIDE(media_observada, p95) * 100, 1) AS media_normalizada,
+    janela_inicio,
+    janela_fim
+FROM medido
+ORDER BY market, lado

--- a/dbt_futebol/dbt_project.yml
+++ b/dbt_futebol/dbt_project.yml
@@ -50,9 +50,11 @@ vars:
   # acender. 20% é o ponto de partida: abaixo disso a nota publicada se move menos do que
   # a granularidade grossa do catálogo já a move sozinha (o azarão do Handicap tem 3
   # premissas e 8 notas possíveis no total, então o p95 dele anda em degraus largos).
-  # Quando o denominador congelado é ZERO — o empate do 1X2 e o Pick do Handicap, que não
-  # têm lado apostado — a fração não existe e a regra é outra, escrita na guarda: acende
-  # se QUALQUER premissa acender ali.
+  # ⚠️ Esta var governa SÓ o ramo da deriva relativa. Quando o denominador congelado é ZERO
+  # — o empate do 1X2 e o Pick do Handicap, que não têm lado apostado — a fração não existe
+  # e a regra é outra, escrita na guarda: ali a cobrança é de PRESENÇA (o MÁXIMO vivo maior
+  # que zero), não passa por esta tolerância nem pelas duas condições abaixo, e acende com
+  # uma linha só.
   p95_deriva_tolerancia_rel: 0.20
 
   # Sobre quantos dias de kickoff o p95 vivo é recalculado. Janela ROLANTE de propósito:
@@ -60,10 +62,13 @@ vars:
   p95_deriva_janela_dias: 30
 
   # Piso de amostra por lado. Abaixo dele a guarda SE ABSTÉM daquele lado em vez de acender
-  # — um p95 de 30 linhas salta de degrau sozinho e produziria vermelho sem defeito. O
-  # ponto cego é declarado: lado de baixo volume (o BTTS tem ~476 candidatos em dois meses
-  # e meio) pode ficar sem vigilância numa janela magra, e a deriva dele só aparece quando
-  # o volume voltar.
+  # — um p95 de 30 linhas salta de degrau sozinho e produziria vermelho sem defeito.
+  #
+  # O 200 tem margem medida: numa janela rolante de 30 dias (26/08) o lado mais magro é o do
+  # Resultado e o do Ambos Marcam, com 325 candidatos cada — um por fixture, contra ~5.800 do
+  # Handicap e ~6.400 do Gols, que têm um por LINHA. Margem de 1,6×, e os onze lados são
+  # cobráveis. O ponto cego que sobra está declarado no cabeçalho da guarda: uma parada de
+  # duas semanas leva esses dois mercados abaixo do piso e a abstenção é MUDA enquanto durar.
   p95_deriva_min_linhas: 200
 
 

--- a/dbt_futebol/dbt_project.yml
+++ b/dbt_futebol/dbt_project.yml
@@ -31,6 +31,41 @@ clean-targets:
 vars:
   expurgo_carencia_horas: 24
 
+  # ============================================================================
+  # A GUARDA DE DERIVA DO DENOMINADOR CONGELADO (#105, ADR 0005).
+  #
+  # O p95 por (mercado, lado) é medido uma vez e congelado em seed. Número congelado
+  # ENVELHECE EM SILÊNCIO: toda mexida no catálogo de premissas, toda liga nova e toda
+  # remoção como a das premissas de movimento de linha desloca a distribuição, e o
+  # denominador continua lá — certo no dia em que foi medido e cada vez menos certo depois.
+  # Estes três parâmetros são a distância declarada a partir da qual isso vira vermelho.
+  #
+  # ⚠️ São VAR e não literal na guarda pela mesma razão da carência do expurgo: o número
+  # certo é calibração, e calibração se remede (a tolerância da [F] já saiu de 0,5 para
+  # 0,25 pp uma vez). Mudar aqui é mudar o arquivo e redeployar a imagem, de propósito —
+  # a severidade de uma guarda não é knob de execução.
+  # ============================================================================
+
+  # Quanto o p95 VIVO pode se afastar do congelado, em fração dele, antes de a guarda
+  # acender. 20% é o ponto de partida: abaixo disso a nota publicada se move menos do que
+  # a granularidade grossa do catálogo já a move sozinha (o azarão do Handicap tem 3
+  # premissas e 8 notas possíveis no total, então o p95 dele anda em degraus largos).
+  # Quando o denominador congelado é ZERO — o empate do 1X2 e o Pick do Handicap, que não
+  # têm lado apostado — a fração não existe e a regra é outra, escrita na guarda: acende
+  # se QUALQUER premissa acender ali.
+  p95_deriva_tolerancia_rel: 0.20
+
+  # Sobre quantos dias de kickoff o p95 vivo é recalculado. Janela ROLANTE de propósito:
+  # é ela que faz a guarda descrever a distribuição de HOJE, que é a coisa que envelhece.
+  p95_deriva_janela_dias: 30
+
+  # Piso de amostra por lado. Abaixo dele a guarda SE ABSTÉM daquele lado em vez de acender
+  # — um p95 de 30 linhas salta de degrau sozinho e produziria vermelho sem defeito. O
+  # ponto cego é declarado: lado de baixo volume (o BTTS tem ~476 candidatos em dois meses
+  # e meio) pode ficar sem vigilância numa janela magra, e a deriva dele só aparece quando
+  # o volume voltar.
+  p95_deriva_min_linhas: 200
+
 
 models:
   dbt_futebol:

--- a/dbt_futebol/docs/adr/0005-a-nota-e-absoluta-e-o-denominador-e-congelado.md
+++ b/dbt_futebol/docs/adr/0005-a-nota-e-absoluta-e-o-denominador-e-congelado.md
@@ -93,3 +93,63 @@ decisão uma dependência da [A] na [C] que não estava registrada em lugar nenh
 E o denominador é medido **depois** da A1, não antes. A A1 tira as premissas de movimento de
 linha do Gols: o teto vai de 56/52 para 50/46 e o p95 anda junto. Qualquer p95 medido antes
 disso descreve uma escala que não vai existir.
+
+## Emenda (2026-08-26, #105): o denominador medido
+
+A decisão acima foi tomada com números de ILUSTRAÇÃO, medidos antes da A1 e sobre a soma de
+pesos. A medição que congelou o seed rodou depois — `analyses/taskA_a6_p95.sql`, sobre os
+candidatos do funil (uma janela por candidato), com as premissas **recomputadas** nos cinco
+mercados e a nota de contexto pós-A1 como quantidade medida. Janela de kickoff 16/06 a 31/08
+de 2026, medida em 26/08.
+
+| mercado | lado | p95 | teto do catálogo | candidatos |
+| --- | --- | ---: | ---: | ---: |
+| Resultado | Home | 33 | 51 | 476 |
+| Resultado | Away | 22 | 47 | 476 |
+| Resultado | Draw | **0** | 0 | 476 |
+| Gols | Over | 44 | 50 | 9.854 |
+| Gols | Under | 36 | 46 | 9.405 |
+| Handicap | Favorito | 24 | 40 | 8.744 |
+| Handicap | Azarão | **30** | 30 | 8.608 |
+| Handicap | Pick | **0** | 0 | 952 |
+| Ambos Marcam | Sim | 28 | 34 | 476 |
+| Ambos Marcam | Não | **28** | 28 | 476 |
+| Dupla Chance | único | 28 | 34 | 952 |
+
+O que a medição confirmou e o que ela corrigiu:
+
+**Os dois lados que saturam são os previstos.** O azarão do Handicap e o "Não" do Ambos
+Marcam têm p95 igual ao próprio teto — os dois com três premissas cada. É o mesmo fato que
+a decisão nomeia como "não cria resolução", agora medido.
+
+**O `Pick` do Handicap entrou junto com o empate.** A decisão só nomeia o empate do 1X2
+porque foi o caso que apareceu na medição de origem. O handicap de linha zero tem a mesma
+estrutura — nenhuma premissa se aplica, porque todas são `is_favorito AND ...` ou
+`is_azarao AND ...` — e são 952 candidatos reais, não um caso de canto. Entra no seed com o
+mesmo zero explícito, e o `CASE` do modelo não distingue os dois.
+
+**A amplitude cai mais do que a decisão previa, e o topo se move.** Sobre os nove lados com
+lado apostado, a média em fração do próprio teto ia de 16,5% (Resultado fora) a 49,7%
+(azarão do Handicap) — **3,0×**. Depois da normalização pelo p95, de 33,2 a 49,7 — **1,5×**,
+e não os 2,1× projetados. O azarão do Handicap continua em primeiro, mas cravado em 49,7 e
+quatro pontos acima do segundo (a Dupla Chance, 45,6), não vinte. A conclusão qualitativa da
+decisão não muda — uma régua única continua sendo réguas diferentes —, mas o número dela sim,
+e o certo é o medido.
+
+**A recomputação é fiel ao registro.** Sobre exatamente as mesmas linhas do funil escritas
+depois da A1, a nota recomputada e a nota registrada divergem em **zero** de 6.713 linhas de
+Handicap e Gols. É o que autoriza a rota da recomputação sem que ela vire uma escala
+paralela — e não elimina o limite conhecido da #78, que é sobre builds diferentes.
+
+**A tolerância de 20% da guarda não é frouxa.** Recalculando o p95 sobre uma janela rolante
+de 30 dias de verdade, os onze lados batem com o congelado; o maior desvio é o "Sim" do
+Ambos Marcam, com 26 contra 28 — 7%.
+
+⚠️ E uma cegueira nova, que a medição descobriu e a guarda declara: no dia do deploy as
+únicas linhas com nota de contexto preenchida são as de jogo ainda por vir, porque o
+append-only não reescreve o passado. A amostra viva nasce com seis dias de rodada, não com
+trinta, e nela o favorito do Handicap dava p95 30 contra os 24 da janela inteira — 25% de
+distância, guarda vermelha, e nada de errado com o denominador. Por isso a metade da DERIVA
+só passa a cobrar quando a janela está cheia até o fundo: **ela fica dormente por ~30 dias
+depois do deploy**. A metade da COBERTURA — o lado que existe e não tem denominador — morde
+desde o primeiro build.

--- a/dbt_futebol/macros/futebol_lado.sql
+++ b/dbt_futebol/macros/futebol_lado.sql
@@ -1,0 +1,98 @@
+{#-
+  O LADO APOSTADO, declarado num lugar só (issue #105, ADR 0005).
+
+  É a chave — junto com o `market` — do denominador congelado da nota normalizada. São
+  **onze pares** de (mercado, lado), e a enumeração é a mesma que a `taskA_a40_transporte.sql`
+  usou para medir a normalização por lado; reusá-la byte a byte é o que faz o seed medido lá
+  descrever o mesmo eixo que o modelo aplica aqui.
+
+    1X2       Home · Draw · Away          (3)
+    Gols      Over · Under                (2)
+    Handicap  Favorito · Azarao · Pick    (3)
+    BTTS      Yes · No                    (2)
+    DC        unico                       (1)
+
+  ⚠️ POR QUE O `outcome` NÃO SERVE SOZINHO, e é o motivo de este macro existir. No Handicap
+  o `outcome` é Home/Away e o LADO é favorito/azarão: `line_value` vem na ótica do MANDANTE
+  e é o MESMO para os dois lados ("Home −1.5" e "Away −1.5" são o par complementar), então o
+  handicap na ótica do lado apostado é `IF(side = 'Home', line, -line)` e o SINAL dele é que
+  diz quem dá e quem recebe. Os conjuntos de premissa dos dois são disjuntos (Σ40 contra
+  Σ30) — normalizar os dois pelo mesmo denominador seria dividir por uma escala que metade
+  das linhas não tem.
+
+  ⚠️ A DUPLA CHANCE COLAPSA EM UM LADO SÓ, e não por preguiça: o
+  `int_futebol_premissas_dc` não tem premissa por lado ("as quatro se aplicam às duas
+  saídas"), então 1X e X2 dividem o MESMO teto (Σ34) e a MESMA distribuição de pontos.
+  Dois denominadores ali seriam duas medições do mesmo número, cada uma com metade da
+  amostra.
+
+  ⚠️ O `Pick` do Handicap (linha 0) entra na enumeração pelo mesmo motivo que o `Draw` do
+  1X2: nenhuma premissa dispara — todas são `is_favorito AND ...` ou `is_azarao AND ...`, e
+  as duas flags são FALSE quando o handicap é zero. Teto de premissa zero, p95 zero,
+  denominador zero. A ADR 0005 nomeia só o empate porque foi o caso que apareceu na
+  medição; a aritmética é a mesma, e o seed carrega os dois com zero explícito.
+
+  ⚠️ FAIL-CLOSED, igual ao `futebol_market_slug`: saída fora do catálogo resolve para NULL
+  — a "12" da Dupla Chance, e qualquer `outcome` que o de-vig emita e o Motor não pontue.
+  NULL aqui é o que mantém a linha FORA da medição do p95 e fora da cobrança da guarda de
+  cobertura, que é exatamente onde ela deve estar: a decisão de não pontuar a "12" é nossa
+  e já está carimbada na `porta_saida_catalogada`. Um lado inventado por acidente casaria
+  com nenhuma linha do seed, e o modelo o trataria como denominador ausente.
+
+  Os três argumentos são expressões já qualificadas pelo chamador (ex.: `f.market`), porque
+  os consumidores juntam as tabelas com aliases diferentes.
+-#}
+{% macro futebol_lado(market_col, outcome_col, line_col) -%}
+    CASE {{ market_col }}
+        WHEN '{{ futebol_mercados_pontuados()[1] }}' THEN
+            IF({{ outcome_col }} IN ('Home', 'Draw', 'Away'), {{ outcome_col }}, NULL)
+        WHEN '{{ futebol_mercados_pontuados()[5] }}' THEN
+            IF({{ outcome_col }} IN ('Over', 'Under'), {{ outcome_col }}, NULL)
+        WHEN '{{ futebol_mercados_pontuados()[8] }}' THEN
+            IF({{ outcome_col }} IN ('Yes', 'No'), {{ outcome_col }}, NULL)
+        WHEN '{{ futebol_mercados_pontuados()[12] }}' THEN
+            IF({{ outcome_col }} IN ('1X', 'X2'), 'unico', NULL)
+        WHEN '{{ futebol_mercados_pontuados()[4] }}' THEN
+            CASE
+                WHEN {{ outcome_col }} NOT IN ('Home', 'Away') THEN NULL
+                -- o handicap na ótica do lado apostado; `line_value` vem na do mandante.
+                WHEN IF({{ outcome_col }} = 'Home', {{ line_col }}, -{{ line_col }}) < 0 THEN 'Favorito'
+                WHEN IF({{ outcome_col }} = 'Home', {{ line_col }}, -{{ line_col }}) > 0 THEN 'Azarao'
+                -- linha 0: ninguém dá e ninguém recebe. Nenhuma premissa dispara.
+                WHEN IF({{ outcome_col }} = 'Home', {{ line_col }}, -{{ line_col }}) = 0 THEN 'Pick'
+                -- handicap ausente: não dá para dizer o lado, e inventá-lo é pior.
+                ELSE NULL
+            END
+    END
+{%- endmacro %}
+
+
+{#-
+  O p95 OBSERVADO, declarado num lugar só (issue #105, ADR 0005).
+
+  É a função de agregação que a `taskA_a6_p95.sql` usa para MEDIR o número que vai ao seed
+  e que a `assert_p95_nota_contexto_nao_derivou.sql` usa para RECALCULAR o p95 vivo e
+  comparar com ele.
+
+  ⚠️ POR QUE MACRO. Duas expressões de percentil diferentes fabricam deriva que não existe:
+  `APPROX_QUANTILES` é aproximado por construção e num lado com poucos valores possíveis ele
+  salta de degrau; medir com uma e vigiar com a outra deixaria a guarda vermelha sem que
+  nada tivesse mudado no catálogo. Com um macro só, medição e guarda não têm como discordar.
+
+  ⚠️ `PERCENTILE_DISC` e não `PERCENTILE_CONT`, e é o que "p95 **observado**" quer dizer: a
+  nota de contexto é INT64 e só assume as somas de peso que o catálogo permite (o azarão do
+  Handicap tem 8 notas possíveis no total). O `PERCENTILE_CONT` interpolaria entre duas
+  delas e devolveria um denominador que nenhuma linha jamais alcança — o mesmo defeito do
+  teto estrutural que a ADR 0005 rejeitou, chegando pelo outro lado.
+
+  ⚠️ NULL não conta. Linha sem premissa a avaliar (`pts_premissas` NULL, a "12" da DC) sai
+  do percentil em vez de entrar como zero — é a mesma distinção da ADR 0003, e é o padrão
+  de `PERCENTILE_DISC` no BigQuery.
+
+  Sai como função de JANELA (é o que o BigQuery oferece), então o chamador precisa do
+  `OVER (PARTITION BY ...)` e de um `DISTINCT`/agregação por cima. Os dois consumidores
+  fazem exatamente isso.
+-#}
+{% macro futebol_p95(coluna) -%}
+    PERCENTILE_DISC({{ coluna }}, 0.95)
+{%- endmacro %}

--- a/dbt_futebol/macros/futebol_score_normalizado.sql
+++ b/dbt_futebol/macros/futebol_score_normalizado.sql
@@ -1,0 +1,59 @@
+{#-
+  A NOTA NORMALIZADA, declarada num lugar só (issue #105, ADR 0005).
+
+  É a nota de contexto reescalada pelo denominador congelado do lado, em 0–100:
+
+      LEAST(100, ROUND(nota_contexto / p95 × 100))
+
+  O serviço dela é fazer o 100 significar a MESMA COISA nos onze lados — o topo da escala
+  ancorado no mesmo quantil. Sem ela, a nota é dividida por uma soma de pesos que nunca
+  ocorre, e quanto mais premissa um mercado tem, mais baixa é a nota dele: o mercado onde
+  se investiu mais modelagem é o mais punido.
+
+  ⚠️ SEM ARGUMENTO, pela mesma razão do `futebol_nota_contexto()`: argumento é porta de
+  entrada. `futebol_score_normalizado('score')` devolveria a nota COM PREÇO reescalada sem
+  que uma linha deste arquivo mudasse. As duas colunas de que ele depende chegam com nome
+  fixo — `nota_contexto`, que o funil grava, e `p95`, que vem do seed
+  `futebol_p95_nota_contexto`.
+
+  ⚠️ A NOTA É ABSOLUTA, e nunca percentil dentro do lado (ADR 0005). Dividir por um número
+  CONGELADO é o que a torna absoluta: o denominador não sabe quantas linhas boas o lado teve
+  hoje. A alternativa relativa garantiria volume de publicação independente de qualidade,
+  contradiria a degradação graciosa e envenenaria o funil — a rejeição passaria a ser X% por
+  construção. O preço, declarado em voz alta: **os mercados publicam em taxas diferentes, e
+  isso é consequência, não defeito.**
+
+  As três decisões que a ordem do `CASE` codifica, de cima para baixo:
+
+  1. ⚠️ `nota_contexto` NULL ⇒ NULL, e é o PRIMEIRO ramo. É a saída que não tem premissa a
+     avaliar — a "12" da Dupla Chance —, e zero ali diria "foi avaliada e tirou zero", que é
+     outra coisa (ADR 0003). É o mesmo que o `score` e a `nota_contexto` já fazem, e as oito
+     portas absorvem o NULL individualmente.
+
+  2. ⚠️ DENOMINADOR ZERO ⇒ ZERO, escrito como zero EXPLÍCITO e **não** como `SAFE_DIVIDE`.
+     O `SAFE_DIVIDE` devolveria NULL, a comparação com a régua também viraria NULL, e a
+     linha sairia sem passar e sem ser marcada — descarte silencioso é exatamente o que a
+     ADR 0006 proíbe. São os dois lados sem lado apostado: o empate do 1X2 e o `Pick` do
+     Handicap. O ramo cobre também o denominador AUSENTE (lado que não está no seed): a
+     linha vira zero e reprova visivelmente, em vez de virar NULL e sumir — e quem acende
+     nesse caso é a guarda de cobertura, não este `CASE`.
+
+  3. ⚠️ CLAMP EM 100 EXPLÍCITO. Com o p95 no denominador, ~5% das linhas de cada lado ficam
+     acima de 100 POR CONSTRUÇÃO — não é erro, é o quantil. Sem o `LEAST` a nota do topo do
+     Gols passaria de 100 e a régua deixaria de ser 0–100.
+
+  ⚠️ O `CAST(... AS INT64)` fica DENTRO do `LEAST`, e não fora: `ROUND` devolve FLOAT64 no
+  BigQuery, e `LEAST(100, <FLOAT64>)` promoveria o 100 a FLOAT64 — a coluna sairia
+  `54.0` em vez de `54` e toda comparação com a régua passaria a ser entre float e inteiro.
+
+  O que esta normalização NÃO compra está na ADR 0005 e no PR: ela não iguala a média, não
+  cria resolução (o azarão do Handicap e o "Não" do BTTS têm 3 premissas e 8 notas possíveis
+  cada — isso é granularidade de catálogo e pertence à [B]) e não cria sinal.
+-#}
+{% macro futebol_score_normalizado() -%}
+    CASE
+        WHEN nota_contexto IS NULL      THEN NULL
+        WHEN p95 IS NULL OR p95 <= 0    THEN 0
+        ELSE LEAST(100, CAST(ROUND(nota_contexto / p95 * 100) AS INT64))
+    END
+{%- endmacro %}

--- a/dbt_futebol/models/marts/_fact_value_funnel.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel.yml
@@ -66,6 +66,31 @@ models:
           - accepted_values:
               arguments:
                 values: ['Home', 'Draw', 'Away', 'Over', 'Under', 'Yes', 'No', '1X', '12', 'X2']
+      - name: lado
+        description: >
+          O LADO APOSTADO (#105, ADR 0005) — o eixo do denominador congelado, e o que o
+          `outcome` sozinho não diz. São ONZE pares de (mercado, lado), derivados num lugar
+          só por `macros/futebol_lado.sql`, lido também pela medição que produziu o seed e
+          pela guarda que o vigia.
+
+          ⚠️ No Handicap ele NÃO é o `outcome`. `line_value` vem na ótica do MANDANTE e é o
+          mesmo para Home e Away (par complementar), então o handicap na ótica do lado
+          apostado é `IF(side = 'Home', line, -line)` e o SINAL dele separa `Favorito` de
+          `Azarao` — conjuntos de premissa disjuntos, Σ40 contra Σ30. Handicap zero é
+          `Pick`: nenhuma premissa se aplica.
+
+          ⚠️ Na Dupla Chance 1X e X2 colapsam em `unico`, porque as quatro premissas se
+          aplicam às duas saídas — dois denominadores ali seriam duas medições do mesmo
+          número, cada uma com metade da amostra.
+
+          ⚠️ NULL na saída não catalogada (a "12"), pelo mesmo fail-closed do
+          `futebol_market_slug`. É o NULL que a mantém fora da cobrança de cobertura da
+          guarda — a decisão de não pontuá-la já está carimbada na `porta_saida_catalogada`.
+
+          ⚠️ NULL TAMBÉM, e para sempre, nas linhas de jogo que já tinham apitado quando
+          esta entrega subiu: a coluna chega por `append_new_columns` e o funil não
+          reescreve o passado (ADR 0011). Por isso a guarda DERIVA o lado do macro em vez
+          de ler esta coluna.
       - name: line_value
         description: "NULL no 1X2, BTTS e Dupla Chance; a linha L (1.5/2.5/...) no Gols O/U; o handicap na ótica do mandante (o mesmo p/ Home e Away) no Handicap asiático."
       - name: line_key
@@ -199,6 +224,46 @@ models:
           ⚠️ FICA FORA do payload da `assert_funil_paridade_com_board` de propósito: é
           coluna do funil e o board não a tem. Comparar o que só existe de um lado
           deixaria a guarda vermelha por desenho.
+      - name: score_normalizado
+        description: >
+          A NOTA NORMALIZADA (#105, ADR 0005): a `nota_contexto` dividida pelo p95
+          OBSERVADO do `lado`, em 0–100 —
+          `LEAST(100, ROUND(nota_contexto / p95 × 100))`. O serviço dela é fazer o 100
+          significar a MESMA COISA nos onze lados: sem ela, a nota é dividida por uma soma
+          de pesos que nunca ocorre, e quanto mais premissa um mercado tem, mais baixa é a
+          nota dele — o mercado onde se investiu mais modelagem é o mais punido.
+
+          O denominador vem do seed versionado `futebol_p95_nota_contexto`, medido UMA VEZ
+          sobre uma janela declarada e congelado. Recalcular em runtime faria a régua
+          significar coisa diferente a cada dia e mataria toda comparação histórica.
+
+          ⚠️ A nota é ABSOLUTA — quanta evidência acendeu —, nunca percentil dentro do
+          lado. A alternativa relativa foi rejeitada porque garante volume de publicação
+          independente de qualidade, contradiz a degradação graciosa e envenena o funil (a
+          rejeição passaria a ser X% por construção). O preço, declarado em voz alta: **os
+          mercados publicam em taxas diferentes, e isso é consequência, não defeito.**
+
+          ⚠️ ~5% das linhas de cada lado batem em 100 POR CONSTRUÇÃO. O denominador é o
+          quantil 95; o `LEAST(100, ...)` as trava ali, e isso não é erro.
+
+          ⚠️ DENOMINADOR ZERO ⇒ ZERO EXPLÍCITO, nunca `SAFE_DIVIDE`. São os dois lados sem
+          lado apostado — o empate do 1X2 e o `Pick` do Handicap. O `SAFE_DIVIDE`
+          devolveria NULL, a comparação com a régua também viraria NULL, e a linha sairia
+          sem passar e sem ser marcada: descarte silencioso é o que a ADR 0006 proíbe. O
+          mesmo ramo cobre o denominador AUSENTE (lado fora do seed) — a linha vira zero e
+          reprova visivelmente, e quem acende é a guarda de cobertura.
+
+          ⚠️ NULL, e não zero, onde não houve premissa a avaliar (a "12" da DC), pelo mesmo
+          motivo que o `score` e a `nota_contexto` (ADR 0003). E NULL para sempre nas
+          linhas já congeladas antes desta entrega, como a `nota_contexto`.
+
+          ⚠️ NÃO é o número do board, e não é o gate. O board segue no `score` e na régua
+          de 40 até a virada, no fim da [A]. Fica FORA do payload da
+          `assert_funil_paridade_com_board` pelo mesmo motivo que a `nota_contexto`.
+
+          A aritmética mora em `macros/futebol_score_normalizado.sql`, sem argumento, pela
+          mesma razão do macro da nota de contexto; o unit test
+          `funil_nota_normalizada_pelo_p95_congelado` a percorre inteira.
       - name: pts_premissas
         description: "NULL, e não zero, onde não houve premissa a avaliar. Zero seria \"foi avaliada e tirou zero\", que é outra coisa (ADR 0003)."
       - name: premissas_sem_dado

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -122,6 +122,17 @@ unit_tests:
 
       # O funil junta `fact_fixtures` SÓ pelo kickoff (ADR 0011, D10 — o status muda
       # depois do apito e uma linha congelada com o status de antes mentiria).
+      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
+      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
+      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
+      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
+      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
+      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
+      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
+      # mudar o resultado esperado de teste nenhum.
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
       - input: ref('fact_fixtures')
         format: sql
         rows: |
@@ -205,6 +216,17 @@ unit_tests:
         rows: []
       - input: ref('int_futebol_corroboracao')
         rows: []
+      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
+      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
+      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
+      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
+      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
+      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
+      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
+      # mudar o resultado esperado de teste nenhum.
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
       - input: ref('fact_fixtures')
         format: sql
         rows: |
@@ -269,6 +291,17 @@ unit_tests:
         rows: []
       - input: ref('int_futebol_corroboracao')
         rows: []
+      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
+      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
+      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
+      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
+      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
+      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
+      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
+      # mudar o resultado esperado de teste nenhum.
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
       - input: ref('fact_fixtures')
         format: sql
         rows: |
@@ -360,6 +393,17 @@ unit_tests:
         rows: []
       - input: ref('int_futebol_corroboracao')
         rows: []
+      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
+      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
+      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
+      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
+      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
+      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
+      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
+      # mudar o resultado esperado de teste nenhum.
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
       - input: ref('fact_fixtures')
         format: sql
         rows: |
@@ -446,6 +490,18 @@ unit_tests:
       # gravado —, então o mock é vazio e serve só para satisfazer a exigência.
       - input: this
         rows: []
+
+      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
+      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
+      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
+      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
+      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
+      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
+      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
+      # mudar o resultado esperado de teste nenhum.
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
 
       # O 32 NÃO tem linha aqui, de propósito: é o fixture ausente.
       - input: ref('fact_fixtures')
@@ -536,6 +592,17 @@ unit_tests:
                  CAST(NULL AS FLOAT64) AS line_value, 15 AS pts_corroboracao,
                  TRUE AS modelo_api_concorda, TRUE AS linha_sharp_confirma
 
+      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
+      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
+      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
+      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
+      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
+      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
+      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
+      # mudar o resultado esperado de teste nenhum.
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
       - input: ref('fact_fixtures')
         format: sql
         rows: |
@@ -549,3 +616,127 @@ unit_tests:
         - {fixture_id: 3, market: 'match_winner',     outcome: 'Draw', score: 20, nota_contexto: 0}
         - {fixture_id: 4, market: 'double_chance',    outcome: '12',   score: ,   nota_contexto: }
         - {fixture_id: 5, market: 'goals_over_under', outcome: 'Over', score: 32, nota_contexto: 2}
+
+  # ---------------------------------------------------------------------------
+  # 7. A ARITMÉTICA DA NOTA NORMALIZADA (#105, ADR 0005).
+  #
+  # É o teste que nenhuma contagem sobre produção conseguiria fazer. Num funil real,
+  # "a nota nunca passa de 100" é compatível tanto com o clamp funcionando quanto com
+  # nenhuma linha ter chegado perto do p95; "a nota do empate é zero" é compatível
+  # tanto com o zero explícito antes da divisão quanto com um `SAFE_DIVIDE` devolvendo
+  # NULL que ninguém leu. Só linha construída separa as duas.
+  #
+  # Os cinco casos que o aceite da issue pede, mais três que a mesma aritmética exige:
+  #   1  pontos IGUAIS ao p95              -> 100
+  #   2  pontos na METADE do p95           -> 50
+  #   3  pontos ACIMA do p95               -> 100, e não 137 (clamp explícito)
+  #   4  arredondamento                    -> 25/40 = 62,5 -> 63, inteiro
+  #   5  penalidade MAIOR que os pontos    -> 0, e não negativo
+  #   6  p95 = 0 com pontos = 0            -> 0, sem divisão por zero e sem NULL
+  #   7  p95 = 0 com pontos > 0            -> 0, e é o ramo do zero explícito sozinho
+  #   8  sem premissa a avaliar            -> NULL, e não 0 (ADR 0003)
+  #
+  # O par 9/10 é o eixo do LADO, e é o que prova que a normalização não é por mercado:
+  # dois candidatos do Handicap com os MESMOS 20 pontos e a mesma linha (−1.5), um pelo
+  # Home e outro pelo Away. O Home dá o handicap (Favorito, p95 40 -> 50) e o Away o
+  # recebe (Azarão, p95 20 -> 100). Sob um denominador por mercado os dois sairiam
+  # iguais, e o teste ficaria verde com o eixo errado.
+  #
+  # ⚠️ O caso 7 é MOCK DELIBERADAMENTE IRREAL: em produção nenhuma premissa do Handicap
+  # dispara com a linha 0 (todas são `is_favorito AND ...` ou `is_azarao AND ...`).
+  # Ele existe para isolar o ramo do denominador zero do caso em que a nota já seria
+  # zero de qualquer jeito — que é justamente o confundidor do caso 6.
+  # ---------------------------------------------------------------------------
+  - name: funil_nota_normalizada_pelo_p95_congelado
+    model: fact_value_funnel
+    overrides:
+      macros:
+        is_incremental: false
+    description: >
+      Dez candidatos que percorrem a aritmética inteira da `score_normalizado`: o teto,
+      a metade, o clamp em 100, o arredondamento, o piso em zero, os dois ramos de
+      denominador zero, a saída sem premissa a avaliar (NULL) e o par que prova que o
+      eixo da normalização é o LADO e não o mercado.
+    given:
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # -- 1: pontos IGUAIS ao p95 do lado (40) -> 100.
+          - {fixture_id: 1, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 2: METADE do p95 -> 50.
+          - {fixture_id: 2, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 3: ACIMA do p95 (55 de 40 = 137,5) -> 100. É o que ~5% das linhas de cada
+          # lado fazem POR CONSTRUÇÃO, porque o denominador é o quantil 95.
+          - {fixture_id: 3, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 4: 25 de 40 = 62,5 -> 63, INTEIRO. Se o CAST saísse de dentro do LEAST a
+          # coluna viraria FLOAT64 e sairia 62.5.
+          - {fixture_id: 4, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Home', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 5: PENALIDADE MAIOR QUE OS PONTOS. Gols na linha extrema: 5 − 10 = −5, e o
+          # piso da nota de contexto o leva a 0. A normalizada é 0, nunca −13.
+          - {fixture_id: 5, competition: 'brasileirao', season: 2026, market_id: 5, outcome_side: 'Over', line_value: 0.5, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 1.20, best_book: 'Bet365', avg_odd: 1.18, n_casas: 5, prob_justa_fechamento: 0.85, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 6: DENOMINADOR ZERO com pontos zero — o empate do 1X2, que é o caso real.
+          - {fixture_id: 6, competition: 'brasileirao', season: 2026, market_id: 1, outcome_side: 'Draw', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 3.50, best_book: 'Bet365', avg_odd: 3.30, n_casas: 5, prob_justa_fechamento: 0.30, pin_n_outcomes: 3, n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 7: DENOMINADOR ZERO com pontos > 0 — o Pick do Handicap (linha 0), com
+          # premissa fabricada. Isola o ramo do zero do caso 6.
+          - {fixture_id: 7, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Home', line_value: 0.0, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 1.95, best_book: 'Bet365', avg_odd: 1.90, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 8: A "12" da Dupla Chance. Sem premissa a avaliar -> nota de contexto NULL
+          # -> normalizada NULL. Zero diria "foi avaliada e tirou zero" (ADR 0003).
+          - {fixture_id: 8, competition: 'brasileirao', season: 2026, market_id: 12, outcome_side: '12', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 1.50, best_book: 'Bet365', avg_odd: 1.45, n_casas: 5, prob_justa_fechamento: 0.60, pin_n_outcomes: , n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 9 e 10: O EIXO DO LADO. Mesmos 20 pontos, mesma linha (−1.5), lados
+          # opostos: o Home dá o handicap (Favorito, p95 40) e o Away o recebe (Azarão,
+          # p95 20). 50 contra 100.
+          - {fixture_id: 9, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Home', line_value: -1.5, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 2.10, best_book: 'Bet365', avg_odd: 2.00, n_casas: 5, prob_justa_fechamento: 0.48, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 10, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Away', line_value: -1.5, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 1.80, best_book: 'Bet365', avg_odd: 1.75, n_casas: 5, prob_justa_fechamento: 0.55, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      - input: ref('int_futebol_premissas_1x2')
+        format: sql
+        rows: |
+          SELECT 1 AS fixture_id, 'Home' AS outcome, 40 AS pts_premissas,
+                 0 AS premissas_sem_dado, 0 AS penalidades_1x2_pts
+          UNION ALL SELECT 2, 'Home', 20, 0, 0
+          UNION ALL SELECT 3, 'Home', 55, 0, 0
+          UNION ALL SELECT 4, 'Home', 25, 0, 0
+          -- o empate: zero de premissa e os −10 do `pick_empate`.
+          UNION ALL SELECT 6, 'Draw', 0, 0, 10
+
+      - input: ref('int_futebol_premissas_ou')
+        format: sql
+        rows: |
+          SELECT 5 AS fixture_id, 'Over' AS outcome, 0.5 AS line_value,
+                 5 AS pts_premissas, 0 AS premissas_sem_dado, 10 AS penalidades_ou_pts
+
+      - input: ref('int_futebol_premissas_ah')
+        format: sql
+        rows: |
+          SELECT 7 AS fixture_id, 'Home' AS outcome, 0.0 AS line_value,
+                 20 AS pts_premissas, 0 AS premissas_sem_dado, 0 AS penalidades_ah_pts
+          UNION ALL SELECT  9, 'Home', -1.5, 20, 0, 0
+          UNION ALL SELECT 10, 'Away', -1.5, 20, 0, 0
+
+      # A "12" (fixture 8) NÃO tem linha aqui, de propósito: é o que a torna a saída
+      # sem premissa a avaliar.
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
+
+      - input: ref('fact_fixtures')
+        rows: []
+
+    expect:
+      rows:
+        - {fixture_id: 1,  lado: 'Home',     nota_contexto: 40, score_normalizado: 100}
+        - {fixture_id: 2,  lado: 'Home',     nota_contexto: 20, score_normalizado: 50}
+        - {fixture_id: 3,  lado: 'Home',     nota_contexto: 55, score_normalizado: 100}
+        - {fixture_id: 4,  lado: 'Home',     nota_contexto: 25, score_normalizado: 63}
+        - {fixture_id: 5,  lado: 'Over',     nota_contexto: 0,  score_normalizado: 0}
+        - {fixture_id: 6,  lado: 'Draw',     nota_contexto: 0,  score_normalizado: 0}
+        - {fixture_id: 7,  lado: 'Pick',     nota_contexto: 20, score_normalizado: 0}
+        - {fixture_id: 8,  lado: ,           nota_contexto: ,   score_normalizado: }
+        - {fixture_id: 9,  lado: 'Favorito', nota_contexto: 20, score_normalizado: 50}
+        - {fixture_id: 10, lado: 'Azarao',   nota_contexto: 20, score_normalizado: 100}

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -26,6 +26,21 @@ version: 2
 # ⚠️ As linhas do de-vig são MOCKS, não amostras: algumas combinações não ocorrem em
 # produção de propósito, porque isolar uma porta às vezes exige quebrar a implicação
 # que a liga a outra. Onde isso acontece está dito na linha.
+#
+# ⚠️ O DENOMINADOR CONGELADO (#105) entra em TODO teste daqui, pelo mesmo motivo que o
+# `is_incremental`: o funil passou a `ref()` o seed `futebol_p95_nota_contexto`, e o dbt
+# exige fixture para todo `ref` do modelo. Os sete usam o MESMO arquivo sintético,
+# `tests/fixtures/p95_nota_contexto_sintetico.csv` — p95 40 nos lados com lado apostado, 20
+# no azarão do Handicap e os dois zeros estruturais (o empate do 1X2 e o `Pick` do
+# Handicap).
+#
+# O 20 do azarão não é decoração: é ele que torna o eixo do LADO falsificável. Com 40 em
+# todos, dois candidatos de mesmos pontos e lados diferentes sairiam iguais e o teste ficaria
+# verde mesmo se a normalização fosse por MERCADO.
+#
+# ⚠️ O fixture NÃO acompanha o seed de produção, e é o ponto de ser sintético: recongelar o
+# denominador — que é uma remedição, e vai acontecer — não pode mudar o resultado esperado
+# de teste nenhum. Números redondos porque a aritmética tem de ser legível a olho.
 # ==============================================================================
 unit_tests:
 
@@ -122,14 +137,7 @@ unit_tests:
 
       # O funil junta `fact_fixtures` SÓ pelo kickoff (ADR 0011, D10 — o status muda
       # depois do apito e uma linha congelada com o status de antes mentiria).
-      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
-      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
-      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
-      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
-      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
-      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
-      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
-      # mudar o resultado esperado de teste nenhum.
+      # o denominador congelado (#105) — ver o ⚠️ do cabeçalho sobre o fixture sintético.
       - input: ref('futebol_p95_nota_contexto')
         format: csv
         fixture: p95_nota_contexto_sintetico
@@ -216,14 +224,7 @@ unit_tests:
         rows: []
       - input: ref('int_futebol_corroboracao')
         rows: []
-      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
-      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
-      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
-      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
-      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
-      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
-      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
-      # mudar o resultado esperado de teste nenhum.
+      # o denominador congelado (#105) — ver o ⚠️ do cabeçalho sobre o fixture sintético.
       - input: ref('futebol_p95_nota_contexto')
         format: csv
         fixture: p95_nota_contexto_sintetico
@@ -291,14 +292,7 @@ unit_tests:
         rows: []
       - input: ref('int_futebol_corroboracao')
         rows: []
-      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
-      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
-      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
-      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
-      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
-      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
-      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
-      # mudar o resultado esperado de teste nenhum.
+      # o denominador congelado (#105) — ver o ⚠️ do cabeçalho sobre o fixture sintético.
       - input: ref('futebol_p95_nota_contexto')
         format: csv
         fixture: p95_nota_contexto_sintetico
@@ -393,14 +387,7 @@ unit_tests:
         rows: []
       - input: ref('int_futebol_corroboracao')
         rows: []
-      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
-      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
-      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
-      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
-      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
-      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
-      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
-      # mudar o resultado esperado de teste nenhum.
+      # o denominador congelado (#105) — ver o ⚠️ do cabeçalho sobre o fixture sintético.
       - input: ref('futebol_p95_nota_contexto')
         format: csv
         fixture: p95_nota_contexto_sintetico
@@ -491,14 +478,7 @@ unit_tests:
       - input: this
         rows: []
 
-      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
-      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
-      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
-      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
-      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
-      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
-      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
-      # mudar o resultado esperado de teste nenhum.
+      # o denominador congelado (#105) — ver o ⚠️ do cabeçalho sobre o fixture sintético.
       - input: ref('futebol_p95_nota_contexto')
         format: csv
         fixture: p95_nota_contexto_sintetico
@@ -592,14 +572,7 @@ unit_tests:
                  CAST(NULL AS FLOAT64) AS line_value, 15 AS pts_corroboracao,
                  TRUE AS modelo_api_concorda, TRUE AS linha_sharp_confirma
 
-      # O DENOMINADOR CONGELADO (#105). Fixture SINTÉTICO, compartilhado por todos os
-      # testes deste arquivo: p95 40 nos lados com lado apostado, 20 no azarão do
-      # Handicap (para que o eixo do LADO seja falsificável — dois candidatos de mesmos
-      # pontos e lados diferentes têm de sair com notas diferentes) e os dois zeros
-      # estruturais, o empate do 1X2 e o Pick do Handicap. Números redondos de propósito:
-      # a aritmética da nota normalizada tem de ser legível a olho no teste que a mede.
-      # O fixture NÃO acompanha o seed de produção — recongelar o denominador não pode
-      # mudar o resultado esperado de teste nenhum.
+      # o denominador congelado (#105) — ver o ⚠️ do cabeçalho sobre o fixture sintético.
       - input: ref('futebol_p95_nota_contexto')
         format: csv
         fixture: p95_nota_contexto_sintetico

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -5,7 +5,7 @@
     on_schema_change='append_new_columns',
     full_refresh=false,
     cluster_by=['competition', 'fixture_id'],
-    description='O FUNIL DE AVALIAÇÃO (#95/#96, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011): materialização INCREMENTAL por merge no grão (fixture_id, market, outcome, line_key, janela). A linha é escrita e atualizada enquanto o kickoff do fixture está no FUTURO e nenhuma escrita acontece depois dele — o funil deixa de ser uma foto do que o código de hoje diria e passa a ser registro do que o Motor disse. `full_refresh=false` no config porque a fase de RECOVERY do workflow_futebol_odds roda o mesmo --select com --full-refresh: sem isso, a primeira recuperação de deriva apagaria o histórico inteiro. Toda linha carrega `gravado_em` e `origem`: `backfill` no build que cria a tabela (recalculado com o código de hoje, e é a única parte que NÃO é registro de época) e `corrente` em toda escrita incremental. Jogo adiado (PST/SUSP) cujo kickoff volta para o futuro VOLTA a ser gravável — o filtro lê o kickoff corrente, não o da escrita anterior. Fixture ausente em fact_fixtures (kickoff NULL) é FAIL-OPEN: continua gravável para sempre, porque perdê-lo quebraria a reconciliação (ADR 0003). NÃO HÁ EXPURGO DO FUNIL (~45 mil linhas/mês; a política se revisita se a tabela passar de 10 milhões de linhas). NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil). A NOTA DE CONTEXTO (#103, ADR 0012): a coluna `nota_contexto` é a nota depois que o preço sai dela — pts_premissas menos as penalidades de CONTEXTO (pick_empate −10, desfalque_proprio −15, linha_extrema −10, handicap_alto −12), com GREATEST(..., 0) —, e nada mais: sem pts_valor, sem corroboração e sem as quatro penalidades de odd. Ela nasce AO LADO do `score`, que continua sendo o do board: nesta entrega o produto não muda de gate nem de número, e existe UMA virada só, no fim da [A]. A composição mora em macros/futebol_nota_contexto.sql (num lugar só, consumida pelo funil e pela guarda de reconstrução, nunca copiada); duas guardas a protegem — assert_nota_contexto_sem_preco (sentinela da decisão: falha se qualquer componente de preço aparecer no texto da composição) e assert_funil_nota_contexto_reconstroi (a coluna gravada bate com a recomposta). NULL onde não houve premissa a avaliar (a "12" da DC), pelo mesmo motivo que o score (ADR 0003). ⚠️ A coluna chega por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar: as linhas de jogo já apitado antes do deploy da A1 ficam com nota_contexto NULL para sempre, e isso é o append-only funcionando (ADR 0011), não defeito — a guarda de reconstrução é escopada a elas de propósito.'
+    description='O FUNIL DE AVALIAÇÃO (#95/#96, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011): materialização INCREMENTAL por merge no grão (fixture_id, market, outcome, line_key, janela). A linha é escrita e atualizada enquanto o kickoff do fixture está no FUTURO e nenhuma escrita acontece depois dele — o funil deixa de ser uma foto do que o código de hoje diria e passa a ser registro do que o Motor disse. `full_refresh=false` no config porque a fase de RECOVERY do workflow_futebol_odds roda o mesmo --select com --full-refresh: sem isso, a primeira recuperação de deriva apagaria o histórico inteiro. Toda linha carrega `gravado_em` e `origem`: `backfill` no build que cria a tabela (recalculado com o código de hoje, e é a única parte que NÃO é registro de época) e `corrente` em toda escrita incremental. Jogo adiado (PST/SUSP) cujo kickoff volta para o futuro VOLTA a ser gravável — o filtro lê o kickoff corrente, não o da escrita anterior. Fixture ausente em fact_fixtures (kickoff NULL) é FAIL-OPEN: continua gravável para sempre, porque perdê-lo quebraria a reconciliação (ADR 0003). NÃO HÁ EXPURGO DO FUNIL (~45 mil linhas/mês; a política se revisita se a tabela passar de 10 milhões de linhas). NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil). A NOTA DE CONTEXTO (#103, ADR 0012): a coluna `nota_contexto` é a nota depois que o preço sai dela — pts_premissas menos as penalidades de CONTEXTO (pick_empate −10, desfalque_proprio −15, linha_extrema −10, handicap_alto −12), com GREATEST(..., 0) —, e nada mais: sem pts_valor, sem corroboração e sem as quatro penalidades de odd. Ela nasce AO LADO do `score`, que continua sendo o do board: nesta entrega o produto não muda de gate nem de número, e existe UMA virada só, no fim da [A]. A composição mora em macros/futebol_nota_contexto.sql (num lugar só, consumida pelo funil e pela guarda de reconstrução, nunca copiada); duas guardas a protegem — assert_nota_contexto_sem_preco (sentinela da decisão: falha se qualquer componente de preço aparecer no texto da composição) e assert_funil_nota_contexto_reconstroi (a coluna gravada bate com a recomposta). NULL onde não houve premissa a avaliar (a "12" da DC), pelo mesmo motivo que o score (ADR 0003). ⚠️ A coluna chega por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar: as linhas de jogo já apitado antes do deploy da A1 ficam com nota_contexto NULL para sempre, e isso é o append-only funcionando (ADR 0011), não defeito — a guarda de reconstrução é escopada a elas de propósito. A NOTA NORMALIZADA (#105, ADR 0005): as colunas `lado` e `score_normalizado`. `lado` é o eixo do denominador — os ONZE pares de (mercado, lado) que `futebol_lado()` enumera, e no Handicap ele NÃO é o outcome (é o sinal do handicap na ótica do lado apostado: Favorito/Azarao/Pick), enquanto na Dupla Chance 1X e X2 colapsam em `unico` porque as quatro premissas se aplicam às duas saídas. `score_normalizado` é a nota de contexto dividida pelo p95 OBSERVADO daquele lado, congelado no seed versionado `futebol_p95_nota_contexto` (medido uma vez, sobre janela declarada — recalcular em runtime faria a régua significar coisa diferente a cada dia). A nota é ABSOLUTA — quanta evidência acendeu —, nunca percentil dentro do lado: o preço declarado é que os mercados publicam em taxas diferentes, e isso é consequência, não defeito. Clamp em 100 EXPLÍCITO, porque com o p95 no denominador ~5% das linhas de cada lado ficam acima de 100 por construção. Denominador zero (o empate do 1X2 e o Pick do Handicap, que não têm lado apostado) resolve para ZERO explícito e nunca por SAFE_DIVIDE: o NULL faria a comparação com a régua virar NULL e a linha sairia sem passar e sem ser marcada. Denominador AUSENTE (lado fora do seed) cai no mesmo ramo — o join é LEFT para que a linha nunca suma — e quem acende é assert_p95_nota_contexto_nao_derivou, que cobra tanto a COBERTURA dos onze lados quanto a DERIVA do p95 vivo contra o congelado. A aritmética mora em macros/futebol_score_normalizado.sql, sem argumento, pela mesma razão do macro da nota de contexto. O BOARD NÃO MUDA: ele segue no `score` e no gate de 40, e a virada é uma só, no fim da [A]. ⚠️ As duas colunas chegam por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar — linha de jogo já apitado antes do deploy fica com elas NULL para sempre, e isso é o append-only funcionando.'
 ) }}
 
 -- ============================================================================
@@ -60,6 +60,14 @@ prem_btts AS (
 
 prem_dc AS (
     SELECT * FROM {{ ref('int_futebol_premissas_dc') }}
+),
+
+-- O DENOMINADOR CONGELADO (#105, ADR 0005): o p95 observado da nota de contexto por
+-- (mercado, lado), medido uma vez sobre uma janela declarada e congelado em seed
+-- versionado. É seed e não query de propósito — recalcular em runtime faria a régua
+-- significar coisa diferente a cada dia e mataria toda comparação histórica.
+denominador AS (
+    SELECT market, lado, p95 FROM {{ ref('futebol_p95_nota_contexto') }}
 ),
 
 -- SÓ O KICKOFF, e o status DE PROPÓSITO fora (ADR 0011, D10). O kickoff é o que o
@@ -406,6 +414,36 @@ unioned AS (
 -- No board esta linha nem existia; só aqui ela precisa de um valor, e nenhum número
 -- seria honesto.
 -- ============================================================================
+-- ============================================================================
+-- O LADO APOSTADO e o DENOMINADOR dele (#105, ADR 0005). Precisam vir ANTES da nota,
+-- porque é o `p95` que a normalização divide.
+--
+-- ⚠️ `LEFT`, e não `INNER`. Lado fora do seed — ou saída não catalogada, cujo lado é
+-- NULL por desenho — não pode sumir do funil: sumiço é o que a ADR 0006 proíbe, e é a
+-- coisa inteira que esta tabela existe para impedir. O `p95` chega NULL, a normalização
+-- o trata como denominador ausente (nota zero, explícita), e quem acende é a guarda
+-- `assert_p95_nota_contexto_nao_derivou`, que cobra a cobertura dos onze lados.
+--
+-- O lado sai de `futebol_lado()` — num lugar só, lido também pela medição que produziu o
+-- seed e pela guarda que o vigia. No Handicap ele NÃO é o `outcome`: é o sinal do
+-- handicap na ótica do lado apostado, e os conjuntos de premissa de favorito e azarão são
+-- disjuntos (Σ40 contra Σ30).
+-- ============================================================================
+com_lado AS (
+    SELECT
+        u.*,
+        {{ futebol_lado('u.market', 'u.outcome', 'u.line_value') }} AS lado
+    FROM unioned u
+),
+
+com_denominador AS (
+    SELECT c.*, d.p95
+    FROM com_lado c
+    LEFT JOIN denominador d
+        ON  d.market = c.market
+       AND  d.lado   = c.lado
+),
+
 scored AS (
     SELECT
         *,
@@ -429,7 +467,27 @@ scored AS (
         -- O predicado mora em `futebol_linha_meia.sql`, e não aqui, porque foi copiá-lo
         -- byte a byte do board que trouxe o defeito do `.25` para esta tabela (#101).
         {{ futebol_e_linha_meia('line_value') }} AS is_half_line
-    FROM unioned
+    FROM com_denominador
+),
+
+-- ============================================================================
+-- A NOTA NORMALIZADA (#105, ADR 0005): a de contexto reescalada pelo p95 congelado do
+-- lado, para que o 100 signifique a mesma coisa nos onze lados. Nasce AO LADO das outras
+-- duas — o board segue no `score` e no gate de hoje, e a virada é uma só, no fim da [A].
+--
+-- A aritmética mora em `futebol_score_normalizado.sql`, num lugar só e sem argumento,
+-- pelo mesmo motivo do macro da nota de contexto: argumento é porta de entrada para
+-- reescalar a nota COM preço dentro. As duas colunas de que ele depende chegam com o nome
+-- que ele espera — `nota_contexto`, da CTE acima, e `p95`, do seed.
+--
+-- ⚠️ CTE PRÓPRIA, e não mais uma linha da `scored`: no BigQuery um apelido do SELECT não
+-- é visível para as outras expressões do MESMO SELECT, e `nota_contexto` é apelido de lá.
+-- ============================================================================
+com_nota_normalizada AS (
+    SELECT
+        *,
+        {{ futebol_score_normalizado() }} AS score_normalizado
+    FROM scored
 ),
 
 -- ============================================================================
@@ -468,7 +526,7 @@ com_portas AS (
         COALESCE(
             market <> '{{ futebol_mercados_pontuados()[12] }}' OR best_odd >= 1.25,
             FALSE)                                          AS porta_odd_dc
-    FROM scored
+    FROM com_nota_normalizada
 ),
 
 -- ============================================================================
@@ -502,6 +560,12 @@ SELECT
     fixture_id,
     market,
     outcome,
+    -- O LADO APOSTADO (#105, ADR 0005) — o eixo do denominador congelado, e o que o
+    -- `outcome` sozinho não diz. No Handicap Home/Away não separa quem dá e quem recebe o
+    -- handicap, e os conjuntos de premissa dos dois são disjuntos; na Dupla Chance 1X e X2
+    -- dividem as quatro premissas e colapsam em `unico`. NULL na saída não catalogada (a
+    -- "12"), pelo mesmo fail-closed do `futebol_market_slug`.
+    lado,
     line_value,
     -- A CHAVE DO MERGE, e ela existe por um motivo mecânico: `line_value` é NULL no 1X2,
     -- no BTTS e na Dupla Chance, e num MERGE ... ON, NULL nunca casa com NULL. Com
@@ -574,6 +638,18 @@ SELECT
     -- medição da [A]. NULL — e não zero — onde não houve premissa a avaliar, pelo mesmo
     -- motivo que o `score` (ADR 0003).
     nota_contexto,
+    -- A NOTA NORMALIZADA (#105, ADR 0005). A de contexto dividida pelo p95 CONGELADO do
+    -- lado, em 0–100, para que o 100 signifique a mesma coisa nos onze lados. Absoluta —
+    -- quanta evidência acendeu —, nunca percentil dentro do lado.
+    --
+    -- ⚠️ ~5% das linhas de cada lado batem em 100 POR CONSTRUÇÃO: o denominador é o
+    -- quantil 95, o `LEAST(100, ...)` as trava ali, e isso não é erro.
+    -- ⚠️ Denominador zero (empate do 1X2, Pick do Handicap) ⇒ ZERO explícito, nunca NULL:
+    -- NULL faria a comparação com a régua virar NULL e a linha sairia sem passar e sem ser
+    -- marcada, que é o descarte silencioso que a ADR 0006 proíbe. NULL aqui só onde não
+    -- houve premissa a avaliar, como no `score` e na `nota_contexto` (ADR 0003).
+    -- ⚠️ NÃO é o número do board. O board segue no `score` e no gate de 40 até a virada.
+    score_normalizado,
     -- quantas premissas aplicáveis à linha não puderam ser avaliadas por falta de
     -- insumo (#41). Não entra na nota: é o que a nota NÃO pôde levar em conta.
     premissas_sem_dado,

--- a/dbt_futebol/seeds/_futebol_p95_nota_contexto.yml
+++ b/dbt_futebol/seeds/_futebol_p95_nota_contexto.yml
@@ -1,0 +1,112 @@
+version: 2
+
+# ==============================================================================
+# O DENOMINADOR CONGELADO DA NOTA NORMALIZADA (#105, ADR 0005).
+#
+# Uma linha por (mercado, lado) — os ONZE pares que `futebol_lado()` enumera —, com o
+# p95 observado da nota de contexto, a JANELA em que ele foi medido, a DATA da medição
+# e a PROCEDÊNCIA de cada número.
+#
+# ⚠️ ESTE ARQUIVO É A FONTE, e é assim de propósito. Recalcular o p95 em runtime é falha
+# de aceite da issue: um denominador que se move faz a régua significar coisa diferente a
+# cada dia e mata toda comparação histórica. Quem quiser um número novo REMEDE (roda a
+# `analyses/taskA_a6_p95.sql`), edita este CSV e o número entra por commit — com data,
+# com autor e com revisão, que é o que "congelado em seed versionado" quer dizer.
+#
+# ⚠️ ELE ENVELHECE EM SILÊNCIO. Toda mexida no catálogo de premissas, toda liga nova e
+# toda remoção como a das premissas de movimento de linha desloca a distribuição, e o
+# número continua aqui — certo no dia em que foi medido e cada vez menos certo depois.
+# Quem avisa é a `assert_p95_nota_contexto_nao_derivou`, que recalcula o p95 VIVO e fica
+# vermelha quando ele se afasta daqui além da tolerância declarada em `dbt_project.yml`.
+#
+# ⚠️ OS DOIS ZEROS SÃO EXPLÍCITOS, e não linhas faltando. O empate do 1X2 e o `Pick` do
+# Handicap (linha 0) não têm lado apostado: nenhuma premissa dispara, o teto é zero e o
+# p95 é zero. Linha ausente e linha com zero resolvem para a MESMA nota (o modelo trata
+# denominador ausente e denominador zero como nota zero, nunca como NULL), mas só a linha
+# presente diz que alguém mediu e o zero é o resultado. É a mesma razão de a "12" da
+# Dupla Chance ser linha carimbada no funil em vez de sumiço (ADR 0006).
+# ==============================================================================
+seeds:
+  - name: futebol_p95_nota_contexto
+    description: >
+      O p95 observado da nota de contexto por (mercado, lado) — o denominador da
+      `score_normalizado` do `fact_value_funnel`. Medido UMA VEZ sobre uma janela
+      declarada e congelado aqui (#105, ADR 0005). Onze linhas, uma por par de mercado e
+      lado, incluindo os dois lados sem lado apostado (empate do 1X2 e Pick do Handicap)
+      com zero explícito. A medição que o produziu está em `analyses/taskA_a6_p95.sql`.
+    config:
+      # os tipos vão declarados, e não inferidos: um `p95` que chegasse STRING faria a
+      # divisão do funil falhar no build, e um `janela_inicio` STRING faria toda leitura
+      # de janela comparar texto.
+      column_types:
+        market: STRING
+        lado: STRING
+        p95: INT64
+        janela_inicio: DATE
+        janela_fim: DATE
+        medido_em: DATE
+        origem: STRING
+        n_candidatos: INT64
+    columns:
+      - name: market
+        description: o nome público do mercado, o mesmo que `futebol_mercados_pontuados()` emite.
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['match_winner', 'asian_handicap', 'goals_over_under', 'btts', 'double_chance']
+      - name: lado
+        description: >
+          o lado apostado, como `futebol_lado()` o deriva. No Handicap ele NÃO é o
+          `outcome` (Home/Away) e sim o sinal do handicap na ótica do lado —
+          Favorito/Azarao/Pick; na Dupla Chance 1X e X2 colapsam em `unico`, porque as
+          quatro premissas se aplicam às duas saídas.
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Home', 'Draw', 'Away', 'Over', 'Under', 'Favorito', 'Azarao', 'Pick', 'Yes', 'No', 'unico']
+      - name: p95
+        description: >
+          o percentil 95 OBSERVADO da nota de contexto neste lado, em pontos. É
+          `PERCENTILE_DISC` — um valor que linhas reais alcançam —, e por construção ~5%
+          das linhas do lado ficam ACIMA dele: é o quantil, não erro, e é o `LEAST(100,
+          ...)` do funil que as trava em 100.
+        tests:
+          - not_null
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+      - name: janela_inicio
+        description: primeiro dia de kickoff da janela sobre a qual o p95 foi medido.
+        tests:
+          - not_null
+      - name: janela_fim
+        description: >
+          último dia de kickoff da janela. Pode estar no FUTURO: o universo do funil são
+          CANDIDATOS, e candidato de jogo que ainda não aconteceu é candidato igual.
+        tests:
+          - not_null
+      - name: medido_em
+        description: o dia em que a medição rodou. Não é a janela — é a idade do número.
+        tests:
+          - not_null
+      - name: origem
+        description: >
+          de onde veio o número. `recomputacao` = as premissas foram recalculadas sobre o
+          histórico com o código de hoje (padrão da `taskA_a40_transporte.sql`);
+          `registro` = lidas como o Motor as gravou no funil. Recomputação NÃO é registro
+          do que o Motor disse, e a distinção existe pelo mesmo motivo que o carimbo
+          `origem` do próprio funil. Premissa recomputada está sujeita à
+          irreprodutibilidade da #78.
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['recomputacao', 'registro']
+      - name: n_candidatos
+        description: >
+          quantos candidatos entraram no percentil (uma janela por candidato). É o que
+          diz se o número tem lastro: 476 no 1X2 e no BTTS (um por fixture), ~9 mil no
+          Gols e no Handicap (um por linha).
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ['market', 'lado']

--- a/dbt_futebol/seeds/_futebol_p95_nota_contexto.yml
+++ b/dbt_futebol/seeds/_futebol_p95_nota_contexto.yml
@@ -53,7 +53,8 @@ seeds:
         tests:
           - not_null
           - accepted_values:
-              values: ['match_winner', 'asian_handicap', 'goals_over_under', 'btts', 'double_chance']
+              arguments:
+                values: ['match_winner', 'asian_handicap', 'goals_over_under', 'btts', 'double_chance']
       - name: lado
         description: >
           o lado apostado, como `futebol_lado()` o deriva. No Handicap ele NÃO é o
@@ -63,7 +64,8 @@ seeds:
         tests:
           - not_null
           - accepted_values:
-              values: ['Home', 'Draw', 'Away', 'Over', 'Under', 'Favorito', 'Azarao', 'Pick', 'Yes', 'No', 'unico']
+              arguments:
+                values: ['Home', 'Draw', 'Away', 'Over', 'Under', 'Favorito', 'Azarao', 'Pick', 'Yes', 'No', 'unico']
       - name: p95
         description: >
           o percentil 95 OBSERVADO da nota de contexto neste lado, em pontos. É
@@ -73,7 +75,8 @@ seeds:
         tests:
           - not_null
           - dbt_utils.expression_is_true:
-              expression: ">= 0"
+              arguments:
+                expression: ">= 0"
       - name: janela_inicio
         description: primeiro dia de kickoff da janela sobre a qual o p95 foi medido.
         tests:
@@ -99,7 +102,8 @@ seeds:
         tests:
           - not_null
           - accepted_values:
-              values: ['recomputacao', 'registro']
+              arguments:
+                values: ['recomputacao', 'registro']
       - name: n_candidatos
         description: >
           quantos candidatos entraram no percentil (uma janela por candidato). É o que
@@ -109,4 +113,5 @@ seeds:
           - not_null
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns: ['market', 'lado']
+          arguments:
+            combination_of_columns: ['market', 'lado']

--- a/dbt_futebol/seeds/futebol_p95_nota_contexto.csv
+++ b/dbt_futebol/seeds/futebol_p95_nota_contexto.csv
@@ -1,0 +1,12 @@
+market,lado,p95,janela_inicio,janela_fim,medido_em,origem,n_candidatos
+asian_handicap,Azarao,30,2026-06-16,2026-08-31,2026-08-26,recomputacao,8608
+asian_handicap,Favorito,24,2026-06-16,2026-08-31,2026-08-26,recomputacao,8744
+asian_handicap,Pick,0,2026-06-16,2026-08-31,2026-08-26,recomputacao,952
+btts,No,28,2026-06-16,2026-08-31,2026-08-26,recomputacao,476
+btts,Yes,28,2026-06-16,2026-08-31,2026-08-26,recomputacao,476
+double_chance,unico,28,2026-06-16,2026-08-31,2026-08-26,recomputacao,952
+goals_over_under,Over,44,2026-06-16,2026-08-31,2026-08-26,recomputacao,9854
+goals_over_under,Under,36,2026-06-16,2026-08-31,2026-08-26,recomputacao,9405
+match_winner,Away,22,2026-06-16,2026-08-31,2026-08-26,recomputacao,476
+match_winner,Draw,0,2026-06-16,2026-08-31,2026-08-26,recomputacao,476
+match_winner,Home,33,2026-06-16,2026-08-31,2026-08-26,recomputacao,476

--- a/dbt_futebol/tests/assert_p95_nota_contexto_nao_derivou.sql
+++ b/dbt_futebol/tests/assert_p95_nota_contexto_nao_derivou.sql
@@ -57,17 +57,49 @@
 --   `kickoff_utc >= hoje − p95_deriva_janela_dias` — a janela rolante propriamente dita.
 --
 -- ⚠️ DENOMINADOR ZERO TEM REGRA PRÓPRIA, e não é `SAFE_DIVIDE`. O empate do 1X2 e o `Pick`
--- do Handicap estão congelados em zero porque nenhuma premissa se aplica a eles. A
--- distância relativa dividiria por zero e um `SAFE_DIVIDE` devolveria NULL — a guarda
--- ficaria CEGA exatamente nos dois lados onde a mudança é mais barata de detectar. A regra
--- é binária: com zero congelado, acende se o p95 vivo for MAIOR que zero. Premissa que
--- passa a acender no empate é mudança de catálogo, e é o sinal que esta guarda existe para
--- dar.
+-- do Handicap estão congelados em zero porque nenhuma premissa se APLICA a eles — no 1X2 o
+-- empate não tem lado apostado, e no Handicap todas as premissas são `is_favorito AND ...`
+-- ou `is_azarao AND ...`, e as duas flags são FALSE na linha 0. A distância relativa
+-- dividiria por zero e um `SAFE_DIVIDE` devolveria NULL — a guarda ficaria CEGA exatamente
+-- nos dois lados onde a mudança é mais barata de detectar.
+--
+-- A regra é de PRESENÇA: com zero congelado, acende se o MÁXIMO vivo for maior que zero.
+-- Uma premissa que passa a acender no empate é mudança de catálogo, e é o sinal que esta
+-- guarda existe para dar.
+--
+-- ⚠️ MÁXIMO, e não o p95 — a distinção não é cosmética. `PERCENTILE_DISC(..., 0.95)` só sai
+-- de zero depois que MAIS DE 5% das linhas do lado acendem; até lá uma mudança de catálogo
+-- que fizesse premissa disparar em 3% dos empates passaria calada. Como ali nenhuma
+-- premissa PODE acender, o máximo não tem falso positivo a temer: uma linha basta, e uma
+-- linha é o que se quer ver.
+--
+-- ⚠️ E este ramo NÃO passa pelas condições de cobrança abaixo. Presença não é percentil:
+-- não precisa de piso de amostra para ser estável nem de janela cheia para ser comparável.
+-- Gatear ambos os ramos junto adiaria em trinta dias o único sinal que a guarda dá de
+-- graça — e, no `Pick`, o piso de 200 sobre 648 linhas por janela chegaria a calá-lo numa
+-- parada de calendário.
 --
 -- ⚠️ O PISO DE AMOSTRA É ABSTENÇÃO, e está declarado. Abaixo de `p95_deriva_min_linhas` o
 -- lado não é cobrado: um p95 de trinta linhas anda de degrau sozinho e produziria vermelho
 -- sem defeito. O preço é lado de baixo volume ficar sem vigilância numa janela magra —
 -- dito aqui, e não escondido num `HAVING`.
+--
+-- A MARGEM ESTÁ MEDIDA, e é o que impede o piso de virar cegueira permanente. Numa janela
+-- rolante de 30 dias (medida em 26/08), o lado mais magro é o do Resultado e o do Ambos
+-- Marcam, com 325 candidatos cada — um por fixture, contra ~5.800 do Handicap e ~6.400 do
+-- Gols, que têm um por LINHA. Com o piso em 200 a margem é de 1,6×, e os onze lados são
+-- cobráveis.
+--
+-- ⚠️ Não confundir a margem com o `n_candidatos` do seed: lá são 476, sobre a janela INTEIRA
+-- de 2,5 meses, e ela não é uniforme — o começo é backfill esparso. Dividir 476 por 76 dias
+-- daria ~188 e concluiria que o Resultado e o BTTS nunca são cobrados; o número que vale é
+-- o da janela rolante, que é 325.
+--
+-- ⚠️ O QUE ISSO AINDA DEIXA PASSAR: quinze dias de parada (data FIFA, virada de temporada)
+-- levam esses dois mercados abaixo de 200 e a deriva deles fica sem vigilância enquanto
+-- durar. É abstenção temporária e se cura sozinha quando o calendário volta — mas ela é
+-- MUDA, e é a razão de estar escrita aqui: quem estranhar a guarda quieta num mercado
+-- confere `n_vivo` na saída dela antes de concluir que o denominador está certo.
 --
 -- ⚠️ A JANELA PRECISA ESTAR CHEIA ATÉ O FUNDO, e esta é a terceira condição de cobrança —
 -- a que a medição desta entrega descobriu, e não é teórica. No dia do deploy as ÚNICAS
@@ -114,6 +146,10 @@ vivo AS (
         market,
         lado,
         {{ futebol_p95('nota_contexto') }} OVER (PARTITION BY market, lado) AS p95_vivo,
+        -- o MÁXIMO, e não o p95, é o que o ramo do denominador ZERO cobra: ali a pergunta
+        -- é "acendeu ALGUMA premissa?", e o p95 só enxergaria isso depois de 5% das linhas
+        -- do lado acenderem. Ver o ⚠️ do cabeçalho.
+        MAX(nota_contexto)                 OVER (PARTITION BY market, lado) AS max_vivo,
         COUNT(*)                           OVER (PARTITION BY market, lado) AS n_vivo,
         -- a idade da linha mais VELHA da amostra viva. É o que diz se a janela está cheia
         -- até o fundo — ver o ⚠️ do cabeçalho sobre janela rasa.
@@ -136,6 +172,7 @@ confronto AS (
         c.medido_em,
         c.janela_congelada_ate,
         v.p95_vivo,
+        v.max_vivo,
         COALESCE(v.n_vivo, 0)             AS n_vivo,
         COALESCE(v.profundidade_dias, 0)  AS profundidade_dias
     FROM congelado c
@@ -166,6 +203,7 @@ SELECT
     lado,
     p95_congelado,
     p95_vivo,
+    max_vivo,
     n_vivo,
     profundidade_dias,
     ROUND(distancia_rel, 4) AS distancia_rel,
@@ -181,7 +219,9 @@ SELECT
     END AS diagnostico
 FROM veredito
 WHERE sem_denominador
-   OR (cobravel AND p95_congelado = 0 AND p95_vivo > 0)
+   -- o ramo do ZERO não passa pelo `cobravel`: ele não é percentil, é presença, e não tem
+   -- de esperar amostra nem janela cheia para cobrar. Ver o ⚠️ do cabeçalho.
+   OR (p95_congelado = 0 AND max_vivo > 0)
    OR (cobravel AND p95_congelado > 0
        AND distancia_rel > {{ var('p95_deriva_tolerancia_rel') }})
 ORDER BY market, lado

--- a/dbt_futebol/tests/assert_p95_nota_contexto_nao_derivou.sql
+++ b/dbt_futebol/tests/assert_p95_nota_contexto_nao_derivou.sql
@@ -1,0 +1,187 @@
+{{ config(tags=['guarda'], severity='error') }}
+-- GUARDA DO DENOMINADOR CONGELADO (#105, ADR 0005). Duas cobranças, uma tabela:
+--
+--   COBERTURA  todo (mercado, lado) que aparece no funil tem linha no seed;
+--   DERIVA     o p95 VIVO de cada lado não se afastou do congelado além da tolerância.
+--
+-- ⚠️ POR QUE `severity='error'`, e está no aceite da issue: `dbt test` sai com 0 quando
+-- tudo que falhou é `warn`. Guarda `warn` neste projeto é comentário, não guarda.
+--
+-- ⚠️ O PONTO CEGO QUE NÃO É NOSSO (ADR 0005): teste em dbt hoje não alarma sozinho. O que
+-- lê o vermelho é a fase `tag:guarda` do workflow, e o resumo diário depende da subtask C4.
+--
+-- ==========================================================================
+-- 1. COBERTURA — o lado que existe e não tem denominador
+--
+-- Sem esta metade, um lado novo (mercado novo, saída nova no catálogo) entraria no funil,
+-- não casaria com nenhuma linha do seed, o `p95` chegaria NULL e a normalização o trataria
+-- como denominador ausente: nota ZERO. A linha reprovaria a régua para sempre, em silêncio
+-- e com aparência de linha ruim. É o mesmo defeito que a ADR 0006 nomeia, chegando pela
+-- porta do join em vez da porta do `WHERE`.
+--
+-- O join do modelo é LEFT justamente para que a linha não SUMA; é aqui que ela acende.
+-- Cobrado só sobre lado NÃO NULO: a "12" da Dupla Chance resolve o lado para NULL por
+-- desenho (fail-closed do `futebol_lado()`), e a decisão de não pontuá-la já está
+-- carimbada na `porta_saida_catalogada`.
+--
+-- ==========================================================================
+-- 2. DERIVA — o número congelado que envelheceu
+--
+-- O p95 vivo é recalculado do MESMO jeito que a medição o mediu, e as três regras que
+-- fazem os dois comparáveis moram em macro ou em var, nunca copiadas aqui:
+--
+--   · a MESMA função de percentil (`futebol_p95()`), porque duas expressões diferentes
+--     fabricam deriva que não existe — `APPROX_QUANTILES` é aproximado por construção e
+--     num lado com poucos valores possíveis ele salta de degrau sozinho;
+--   · o MESMO lado (`futebol_lado()`), DERIVADO aqui e não lido da coluna `lado` do funil.
+--     Não é desconfiança do modelo — os dois leem o mesmo macro. É que a coluna também
+--     chegou por `append_new_columns`: a linha escrita entre o deploy da #103 e o desta
+--     entrega tem `nota_contexto` preenchida e `lado` NULL, e ler a coluna a jogaria fora
+--     da amostra justamente na janela mais recente que a guarda existe para vigiar;
+--   · a MESMA regra de UMA JANELA POR CANDIDATO (`janela_e_corrente`). O funil guarda até
+--     quatro linhas por candidato e a nota de contexto é a mesma nas quatro; contando as
+--     quatro, o jogo precificado cedo pesaria até 4× e o p95 descreveria "quem foi
+--     precificado por mais tempo".
+--
+-- ⚠️ A JANELA VIVA É ROLANTE, e é ela que faz a guarda falar de HOJE. Duas linhas a
+-- definem, e as duas são necessárias:
+--
+--   `nota_contexto IS NOT NULL` — é o carimbo de que a linha foi escrita pelo código
+--   PÓS-A1. A coluna chegou por `append_new_columns`, e sob o append-only (#96, ADR 0011)
+--   toda linha de jogo apitado antes daquele deploy ficou com ela NULL para sempre. Sem
+--   este filtro a guarda misturaria as DUAS escalas do Gols — a de antes da #103, com as
+--   premissas de movimento de linha e o clamp em 55, e a de depois — e nasceria vermelha
+--   descrevendo uma escala que não existe mais. É o mesmo escopo, e pelo mesmo motivo, que
+--   a `assert_funil_nota_contexto_reconstroi` já usa.
+--
+--   `kickoff_utc >= hoje − p95_deriva_janela_dias` — a janela rolante propriamente dita.
+--
+-- ⚠️ DENOMINADOR ZERO TEM REGRA PRÓPRIA, e não é `SAFE_DIVIDE`. O empate do 1X2 e o `Pick`
+-- do Handicap estão congelados em zero porque nenhuma premissa se aplica a eles. A
+-- distância relativa dividiria por zero e um `SAFE_DIVIDE` devolveria NULL — a guarda
+-- ficaria CEGA exatamente nos dois lados onde a mudança é mais barata de detectar. A regra
+-- é binária: com zero congelado, acende se o p95 vivo for MAIOR que zero. Premissa que
+-- passa a acender no empate é mudança de catálogo, e é o sinal que esta guarda existe para
+-- dar.
+--
+-- ⚠️ O PISO DE AMOSTRA É ABSTENÇÃO, e está declarado. Abaixo de `p95_deriva_min_linhas` o
+-- lado não é cobrado: um p95 de trinta linhas anda de degrau sozinho e produziria vermelho
+-- sem defeito. O preço é lado de baixo volume ficar sem vigilância numa janela magra —
+-- dito aqui, e não escondido num `HAVING`.
+--
+-- ⚠️ A JANELA PRECISA ESTAR CHEIA ATÉ O FUNDO, e esta é a terceira condição de cobrança —
+-- a que a medição desta entrega descobriu, e não é teórica. No dia do deploy as ÚNICAS
+-- linhas com `nota_contexto` preenchida são as de jogo ainda por vir: o append-only não
+-- reescreve o passado, então a amostra viva nasce com SEIS DIAS de rodada, não com trinta.
+-- Medido em 26/08, o favorito do Handicap dava p95 30 nesses seis dias contra 24 na janela
+-- inteira — 25% de distância, guarda vermelha, e nada de errado com o denominador. Sobre
+-- uma janela rolante de 30 dias de verdade os onze lados batem (o maior desvio é 7%, o
+-- "Sim" do BTTS), que é o que diz que a tolerância de 20% não é frouxa.
+--
+-- `profundidade_dias >= p95_deriva_janela_dias` exige que a linha mais velha da amostra
+-- esteja no fundo da janela antes de qualquer cobrança de deriva. Consequência declarada:
+-- **a metade da DERIVA fica dormente por ~30 dias depois do deploy**, enquanto o funil
+-- acumula linhas pós-A1. A metade da COBERTURA não espera nada e morde desde o primeiro
+-- build — que é a que importa no dia 0, porque é ela que pega o lado sem denominador.
+
+WITH congelado AS (
+    SELECT
+        market,
+        lado,
+        p95        AS p95_congelado,
+        medido_em,
+        janela_fim AS janela_congelada_ate
+    FROM {{ ref('futebol_p95_nota_contexto') }}
+),
+
+-- as linhas vivas: uma por candidato, escritas pelo código pós-A1, dentro da janela
+-- rolante. O lado sai do MESMO macro que o modelo e a medição usam.
+vivo_linhas AS (
+    SELECT
+        f.market,
+        {{ futebol_lado('f.market', 'f.outcome', 'f.line_value') }} AS lado,
+        f.nota_contexto,
+        f.kickoff_utc
+    FROM {{ ref('fact_value_funnel') }} f
+    WHERE f.janela_e_corrente
+      AND f.nota_contexto IS NOT NULL
+      AND f.kickoff_utc >= TIMESTAMP_SUB(
+              CURRENT_TIMESTAMP(), INTERVAL {{ var('p95_deriva_janela_dias') }} DAY)
+),
+
+vivo AS (
+    SELECT DISTINCT
+        market,
+        lado,
+        {{ futebol_p95('nota_contexto') }} OVER (PARTITION BY market, lado) AS p95_vivo,
+        COUNT(*)                           OVER (PARTITION BY market, lado) AS n_vivo,
+        -- a idade da linha mais VELHA da amostra viva. É o que diz se a janela está cheia
+        -- até o fundo — ver o ⚠️ do cabeçalho sobre janela rasa.
+        DATE_DIFF(CURRENT_DATE(),
+                  MIN(DATE(kickoff_utc)) OVER (PARTITION BY market, lado),
+                  DAY)                     AS profundidade_dias
+    FROM vivo_linhas
+    -- saída não catalogada (a "12") tem lado NULL por desenho e não é cobrada.
+    WHERE lado IS NOT NULL
+),
+
+-- FULL OUTER: o lado sem denominador entra pela direita vazia (cobertura), e o
+-- denominador sem lado vivo entra pela esquerda vazia (abstenção, não falha — lado que
+-- não teve jogo na janela não derivou, só não foi medido).
+confronto AS (
+    SELECT
+        COALESCE(c.market, v.market) AS market,
+        COALESCE(c.lado,   v.lado)   AS lado,
+        c.p95_congelado,
+        c.medido_em,
+        c.janela_congelada_ate,
+        v.p95_vivo,
+        COALESCE(v.n_vivo, 0)             AS n_vivo,
+        COALESCE(v.profundidade_dias, 0)  AS profundidade_dias
+    FROM congelado c
+    FULL OUTER JOIN vivo v
+        ON  v.market = c.market
+       AND  v.lado   = c.lado
+),
+
+veredito AS (
+    SELECT
+        *,
+        (p95_congelado IS NULL) AS sem_denominador,
+        -- só há o que cobrar com denominador congelado, amostra suficiente E janela cheia
+        -- até o fundo. As três condições, e as três declaradas no cabeçalho.
+        (p95_congelado IS NOT NULL
+         AND n_vivo >= {{ var('p95_deriva_min_linhas') }}
+         AND profundidade_dias >= {{ var('p95_deriva_janela_dias') }}) AS cobravel,
+        -- a distância, em fração do congelado. NULL quando o congelado é zero — e é por
+        -- isso que o zero tem ramo próprio no `WHERE` lá embaixo, em vez de cair aqui.
+        IF(p95_congelado > 0,
+           ABS(p95_vivo - p95_congelado) / p95_congelado,
+           NULL) AS distancia_rel
+    FROM confronto
+)
+
+SELECT
+    market,
+    lado,
+    p95_congelado,
+    p95_vivo,
+    n_vivo,
+    profundidade_dias,
+    ROUND(distancia_rel, 4) AS distancia_rel,
+    {{ var('p95_deriva_tolerancia_rel') }} AS tolerancia_rel,
+    medido_em,
+    janela_congelada_ate,
+    CASE
+        WHEN sem_denominador
+            THEN 'lado presente no funil e ausente do seed futebol_p95_nota_contexto — o p95 chega NULL, a nota normalizada vira zero e a linha reprova a régua em silêncio; medir o lado (analyses/taskA_a6_p95.sql) e acrescentá-lo ao seed'
+        WHEN p95_congelado = 0
+            THEN 'lado congelado em ZERO (sem lado apostado) passou a ter premissa acendendo — mudança de catálogo: remedir o p95 e recongelar o seed'
+        ELSE 'p95 vivo se afastou do congelado além da tolerância declarada — o denominador envelheceu (catálogo, liga nova ou premissa removida); remedir com analyses/taskA_a6_p95.sql e recongelar o seed, com janela e data novas'
+    END AS diagnostico
+FROM veredito
+WHERE sem_denominador
+   OR (cobravel AND p95_congelado = 0 AND p95_vivo > 0)
+   OR (cobravel AND p95_congelado > 0
+       AND distancia_rel > {{ var('p95_deriva_tolerancia_rel') }})
+ORDER BY market, lado

--- a/dbt_futebol/tests/fixtures/p95_nota_contexto_sintetico.csv
+++ b/dbt_futebol/tests/fixtures/p95_nota_contexto_sintetico.csv
@@ -1,0 +1,12 @@
+market,lado,p95,janela_inicio,janela_fim,medido_em,origem,n_candidatos
+match_winner,Home,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+match_winner,Away,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+match_winner,Draw,0,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+goals_over_under,Over,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+goals_over_under,Under,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+asian_handicap,Favorito,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+asian_handicap,Azarao,20,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+asian_handicap,Pick,0,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+btts,Yes,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+btts,No,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000
+double_chance,unico,40,2026-01-01,2026-01-31,2026-02-01,recomputacao,1000


### PR DESCRIPTION
A nota de contexto era dividida por uma soma de pesos **que nunca ocorre**, e a interação punia justamente o mercado onde se investiu mais modelagem: somar cresce reto conforme se acrescenta premissa, acender junto cresce muito mais devagar. Medida em fração do próprio teto, a nota média ia de **16,5%** no Resultado fora a **49,7%** no azarão do Handicap — **3,0×**.

Esta entrega põe no denominador o **p95 observado por (mercado, lado)**, medido uma vez sobre janela declarada e **congelado em seed versionado**. `score_normalizado` nasce como coluna do funil, ao lado da nota de contexto. Depois do rescale a amplitude é **1,5×**.

## O denominador medido

Janela de kickoff **16/06 → 31/08/2026**, medida em **26/08**, sobre os **candidatos do funil** (uma janela por candidato — nunca o board, que mediria só o que já passava), com as premissas **recomputadas**.

| mercado | lado | p95 | teto | candidatos |
|---|---|---:|---:|---:|
| Resultado | Home | 33 | 51 | 476 |
| Resultado | Away | 22 | 47 | 476 |
| Resultado | Draw | **0** | 0 | 476 |
| Gols | Over | 44 | 50 | 9.854 |
| Gols | Under | 36 | 46 | 9.405 |
| Handicap | Favorito | 24 | 40 | 8.744 |
| Handicap | Azarão | **30** | 30 | 8.608 |
| Handicap | Pick | **0** | 0 | 952 |
| Ambos Marcam | Sim | 28 | 34 | 476 |
| Ambos Marcam | Não | **28** | 28 | 476 |
| Dupla Chance | único | 28 | 34 | 952 |

**Os dois lados que saturam são os previstos** — o azarão do Handicap e o "Não" do BTTS, os dois com três premissas. É o mesmo fato que a ADR nomeia como "não cria resolução", agora medido.

**Os três tetos da tabela de origem entraram corrigidos**: Resultado Fora é 47 (o `pts_mando` do visitante vale 4), Empate é 0, Ambos Marcam "Não" é 28 (12+10+6).

**O `Pick` do Handicap entrou junto com o empate.** O ticket só nomeia o empate do 1X2, mas o handicap de linha zero tem a mesma estrutura — nenhuma premissa se aplica, porque todas são `is_favorito AND ...` ou `is_azarao AND ...`, e as duas flags são FALSE na linha 0 — e são **952 candidatos reais**, não caso de canto. Entra com o mesmo zero explícito.

## Por que recomputar, e não ler o registro

O funil é append-only e congelado no apito, não guarda `evidencias[]`, e a A1 (#103) mudou a escala do Gols (tetos 56/52 → 50/46). Qualquer janela do funil anterior ao deploy da A1 **mistura duas escalas do Gols**, e não há como separá-las depois: numa linha congelada não dá para saber se as duas premissas de movimento acenderam.

Os **cinco** mercados vêm recomputados, não só o Gols — medição com duas procedências obrigaria toda leitura futura a saber qual linha veio de onde. O seed carrega `origem = 'recomputacao'` nas onze linhas.

Fica registrado o limite: premissa recomputada está sujeita à irreprodutibilidade da #78. Contra isso, o que foi medido: sobre **exatamente as mesmas linhas** do funil escritas depois da A1, a nota recomputada e a registrada divergem em **zero de 6.713**.

## O que a decisão NÃO compra

- **Não iguala a média.** A amplitude cai de 3,0× para 1,5× e o azarão do Handicap continua em primeiro, cravado em 49,7 — quatro pontos acima do segundo (a Dupla Chance, 45,6). *A ADR projetava 2,1× e 59 pontos; aqueles números eram ilustração pré-A1 e a emenda registra que o medido os supersede.*
- **Não cria resolução.** O azarão do Handicap e o "Não" do BTTS têm 3 premissas e **8 notas possíveis cada**. Isso é granularidade de catálogo e pertence à **[B]**.
- **Não cria sinal.** Nenhuma aposta fica melhor; o ganho é de coerência da régua.
- **Os mercados publicam em taxas diferentes.** É consequência de a nota ser **absoluta**, não defeito: a alternativa relativa garantiria volume de publicação independente de qualidade, contradiria a degradação graciosa e envenenaria o funil (a rejeição passaria a ser X% por construção).

**O board não muda**: segue no `score` e no gate de 40. A virada é uma só, no fim da [A].

## A guarda, e a cegueira que ela declara

`assert_p95_nota_contexto_nao_derivou` (`tag:guarda`, `severity='error'` — `dbt test` sai com 0 quando tudo que falhou é `warn`). Duas cobranças:

- **Cobertura** — lado presente no funil e ausente do seed. Morde desde o **primeiro build**.
- **Deriva** — o p95 vivo se afastou do congelado além de 20%.

⚠️ **A metade da deriva fica dormente por ~30 dias depois do deploy**, e isso a medição descobriu na prática: no dia do deploy as únicas linhas com nota de contexto preenchida são as de jogo por vir, porque o append-only não reescreve o passado. A amostra viva nasce com **seis dias de rodada**, e nela o favorito do Handicap dá p95 30 contra 24 da janela inteira — 25%, guarda vermelha, e nada de errado com o denominador. Por isso ela só cobra quando a janela está cheia até o fundo.

Sobre uma janela rolante de 30 dias **de verdade** os onze lados batem com o congelado; o maior desvio é o "Sim" do BTTS, com 26 contra 28 — **7%**. É o que diz que a tolerância de 20% não é frouxa.

O piso de amostra de 200 linhas tem margem medida: o lado mais magro (Resultado e BTTS, um candidato por *fixture*) tem **324 candidatos/30 dias**, contra ~6 mil do Handicap e do Gols, que têm um por *linha*. O que sobra de cego está escrito no cabeçalho: quinze dias de parada levam esses dois mercados abaixo do piso, e a abstenção é **muda** enquanto durar.

## O segundo commit: o que a revisão de código achou

**O ramo do denominador zero não fazia o que estava escrito.** O comentário prometia "acende se qualquer premissa acender ali"; o código cobrava `p95_vivo > 0`, e `PERCENTILE_DISC(..., 0.95)` só sai de zero depois que **mais de 5%** das linhas do lado acendem. Uma mudança de catálogo que fizesse premissa disparar em 3% dos empates passava calada — no lado onde a detecção é mais barata do sistema inteiro. Virou cobrança de **presença** (`max_vivo > 0`), fora das condições de amostra e janela: presença não é percentil.

Também: o piso de amostra estava descrito por aritmética (os revisores dividiram 476 por 76 dias e concluíram que 5 dos 11 lados nunca seriam cobrados — a janela do seed não é uniforme, o começo é backfill esparso), agora está descrito por medição; e os testes do seed usavam o estilo plano de argumento contra as 111 ocorrências do aninhado no resto do projeto — eram as 5 deprecations que o `dbt parse` vinha reportando.

## Validação

Sem tocar produção e sem `dbt run` local — o job de odds mexe na mesma tabela a cada 15 minutos.

- `dbt parse`, `dbt compile` e `bq query --dry_run` do funil: válidos, parse **limpo**.
- `dbt seed` do denominador: 11 linhas, aditivo, tabela nova.
- **45 guardas** verdes · **317** do resto (WARN=11, **ERROR=0**) · **19 unit tests** verdes. Os 11 warnings são a linha de base do projeto (testes com `severity: warn` documentado em staging e nas *relationships* de `dim_players`/`dim_teams`); tudo que entra aqui é error-severity e passou.
- **Guarda falsificada nos quatro ramos**, contra produção: cobertura (tirando uma linha do seed), deriva (baixando a tolerância), denominador zero por fora do gate de amostra (`n_vivo=91`, `profundidade_dias=1`) e — o que prova a correção do segundo commit — premissa acesa em 1% dos empates, com `p95_vivo = 0` e `max_vivo = 5`, que é exatamente a linha que a regra antiga deixava passar.
- **Unit test falsificado** duas vezes: sem o `LEAST` e trocando o zero explícito por `SAFE_DIVIDE`, fica vermelho nos dois.

## ⚠️ Deploy — a ordem importa, e há um passo no outro repo

Seed novo + guarda nova sobem juntos, então os dois passos deixam de ser comutativos.

1. **`data-engineering` primeiro**: mergear a fase `dbt seed` do `workflow_futebol.yml` e `./scripts/deploy_workflows.sh futebol`. **`dbt run` não constrói seed**, e até esta entrega nenhum workflow do futebol tinha fase de seed — sem esse passo o CSV versionado nunca chega ao BigQuery e o funil normaliza por um denominador velho, em silêncio. Verificado que `dbt seed --select <inexistente>` sai com **exit 0**, então workflow-primeiro é no-op inofensivo na imagem velha.
2. mergear aqui e `./build-and-push.sh dbt_futebol`.
3. `./scripts/checa_deriva.sh dbt_futebol`, de uma árvore com `HEAD == origin/master`.
4. conferir no **log** do job, nunca pelo exit code: `Done. PASS=... ERROR=0`.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SmXqWuzjmEjDx2RP6dbr4
