### PR TITLE
analise(futebol): a remedição de churn D+7 — zero versão pós-apito acima da carência (#86)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -207,6 +207,27 @@ current row of a past fixture" is a different and dishonest thing)
 The product surface that shows, on a played fixture, what the Motor was saying about it.
 Its content is the **histórico no apito** — the promise the name already makes.
 
+**Versão pós-apito**:
+A row in `fact_value_opportunities_hist` whose `dbt_valid_from` is **later than the
+fixture's kickoff** — the Motor emitted a new take on an opportunity that had already
+expired. It is the unit the expurgo is measured in, and the only replayable one:
+`dbt_valid_from` is immutable, while `dbt_valid_to` is rewritten every time a newer
+version is born, so any "chave morta" count has to be taken on the day and cannot be
+reconstructed later.
+_Avoid_: counting them in one lump — see **as três faixas**
+
+**As três faixas** (of a versão pós-apito):
+The band the delay falls in decides who owns it, and only one of them is a defect.
+**0–10 h**, the status has not landed yet: `fact_fixtures` rebuilds once a day while the
+board rebuilds every odds cycle, so no carência can reach it — that is the task **[C]**
+dependency the ADR 0009 pre-declared. **10–24 h**, the price of
+`var expurgo_carencia_horas`, a product decision. **Above 24 h**, a defect: the carência
+lapsed and the expurgo did not fire. `PST`/`SUSP`/`INT` are excluded from the defect band
+for the same reason the expurgo spares them — a postponed fixture stays postponed for
+weeks and would otherwise indict the expurgo where it is obeying.
+_Avoid_: "zero versão pós-apito" as an acceptance target — only the above-24 h band has
+zero as an honest target, and #86 measured it
+
 **Evidência**:
 A fired premissa surfaced to the user as a "why" bullet, ordered by weight.
 

--- a/dbt_futebol/analyses/taskA_churn_pos_apito.sql
+++ b/dbt_futebol/analyses/taskA_churn_pos_apito.sql
@@ -8,11 +8,11 @@
     ────────────────────────────────────────────────────────────────────────────────
     POR QUE ESTE ARQUIVO EXISTE
 
-    O congelamento de 17/08 (ADR 0009, issue #80) publicou "15.452 versões / 210 chaves / 14.946
-    pós-apito" **sem guardar a query**. A #86 tinha de remedir "com a mesma query do congelamento"
-    e ela não existia em lugar nenhum do repositório — foi preciso RECONSTRUIR o critério e depois
-    provar que era o mesmo, reproduzindo os dois checkpoints congelados (ver a calibração abaixo).
-    Este arquivo existe para que a próxima remedição não pague isso de novo.
+    O congelamento de 17/08 (ADR 0009, issue #80) publicou as contagens do baseline **sem guardar
+    a query**. A #86 tinha de remedir "com a mesma query do congelamento" e ela não existia em
+    lugar nenhum do repositório — foi preciso RECONSTRUIR o critério e depois provar que era o
+    mesmo, reproduzindo os checkpoints congelados. Este arquivo existe para que a próxima
+    remedição não pague isso de novo.
 
     ────────────────────────────────────────────────────────────────────────────────
     O CRITÉRIO, em uma linha
@@ -27,15 +27,13 @@
 
          ⚠️ `dbt_valid_to` NÃO é imutável: ele é escrito quando a versão seguinte nasce (ou quando
          `invalidate_hard_deletes` fecha a chave). Toda contagem de "chave morta" do congelamento
-         de 17/08 — as 89, das quais 54 morreram depois do apito — é IRREPRODUTÍVEL por replay:
-         relendo o `hist` hoje com o teto de 17/08, as 210 chaves aparecem fechadas, porque elas
-         fecharam depois. Quem quiser essa métrica tem de medi-la no dia, não reconstruí-la — e é
-         por isso que ela não está entre as saídas deste arquivo.
+         de 17/08 é IRREPRODUTÍVEL por replay: relendo o `hist` hoje com o teto daquele dia, as
+         chaves aparecem fechadas, porque elas fecharam depois. Quem quiser essa métrica tem de
+         medi-la no dia, não reconstruí-la — e é por isso que ela não está entre as saídas daqui.
 
       2. `LEFT JOIN fact_fixtures`, nunca INNER. Fixture ausente é fail-open (ADR 0003): a
          comparação vira NULL, a versão não conta como pós-apito, e ela sai contada à parte
-         (`sem_kickoff`) em vez de sumir dentro do join. Nas duas medições deu 0 — o dia em que
-         der outra coisa, o número aparece em vez de calar.
+         (`sem_kickoff`) em vez de sumir dentro do join.
 
       3. `kickoff_utc` é lido AGORA, não no instante da versão. Jogo remarcado move o próprio
          apito, e uma versão pode trocar de lado da fronteira retroativamente. É o preço de o
@@ -45,22 +43,24 @@
     ────────────────────────────────────────────────────────────────────────────────
     A CALIBRAÇÃO — é ela que satisfaz o aceite "mesma query do congelamento"
 
-    O critério acima reproduz os DOIS checkpoints congelados, ao número:
+    O critério acima reproduz, ao número e com as faixas, os DOIS checkpoints congelados. Basta
+    mover os cortes abaixo:
 
-      · teto 2026-08-17 16:32:17.191019 UTC  →  15.452 versões / 210 chaves / 14.946 pós-apito
-        / média 668,2 h   (o congelamento da ADR 0009, issue #80)
-      · teto 2026-08-20 16:41:25 UTC         →  17.719 pós-apito
-        (o fatiamento por faixa publicado na #85 no dia do deploy)
+      · `corte_inicio` = época, `corte_fim` = 2026-08-17 16:32:17.191019 UTC
+        → o congelamento da ADR 0009, publicado no #80
+      · `corte_inicio` = época, `corte_fim` = 2026-08-20 16:41:25 UTC
+        → o fatiamento por faixa publicado no #85, no dia do deploy
 
-    O teto de 17/08 não foi escolhido a dedo: é a última versão do lote das 16:32 daquele dia, o
-    único instante em que o `hist` tem exatamente 15.452 linhas. Reproduzir DOIS pontos com um
-    critério de uma linha é o que torna a remedição comparável ao baseline em vez de uma métrica
-    nova. Para refazer a calibração, é só mover `corte_inicio`/`corte_fim` abaixo.
+    O teto de 17/08 não é escolha a dedo: é a última versão do lote das 16:32 daquele dia, o único
+    instante em que o `hist` bate exatamente a contagem publicada. **As contagens que os dois
+    tetos devolvem estão na seção do #86 do `TASKA_RESULTADOS.md`** — reproduzir DOIS pontos com
+    um critério de uma linha é o que torna a remedição comparável ao baseline em vez de uma
+    métrica nova.
 
     ────────────────────────────────────────────────────────────────────────────────
     AS TRÊS FAIXAS, e por que o corte é em 24 h
 
-    Contar "pós-apito" em bloco mistura três coisas com donos diferentes (pré-atribuição feita na
+    Contar "pós-apito" em bloco mistura três coisas com donos diferentes (pré-atribuição feita no
     #85 ANTES do deploy, justamente para esta medição atribuir em vez de investigar):
 
       0–10 h    o status ainda não chegou. `fact_fixtures` é reconstruída UMA VEZ POR DIA
@@ -78,6 +78,15 @@
     faixa `>= 24` acenderia vermelho na versão nascida no segundo exato da fronteira, que o mart
     ainda tinha o direito de emitir.
 
+    ⚠️ E `PST`/`SUSP`/`INT` SAEM DA FAIXA DE DEFEITO, pelo mesmo motivo que saem do expurgo: a
+    ADR 0009 os preserva **inclusive além da carência** ("kickoff no passado com jogo ainda por
+    acontecer é oportunidade legítima, e um corte por relógio a mataria"). Um jogo adiado fica
+    adiado por semanas e nasceria versão nova o tempo todo — contá-lo como defeito faria esta
+    medição acusar o expurgo exatamente onde ele está obedecendo. A lista vem de
+    `futebol_status_sobrevivem()`, o MESMO macro que o mart e a guarda 1 usam, nunca uma quarta
+    cópia à mão. Eles saem contados à parte (`acima_24h_sobrevivente`), não apagados: sumir com
+    eles esconderia um adiamento que virou entulho.
+
     ────────────────────────────────────────────────────────────────────────────────
     A DESCONTINUIDADE DO `.25` (#101), 2026-08-21 19:05:23 UTC
 
@@ -88,7 +97,9 @@
 
     ⚠️ `lotes_snapshot` e `dias_observados` saem junto das contagens, e não são enfeite: as duas
     fatias não têm o mesmo tamanho (a de antes do corte é de horas, a de depois é de dias). Sem
-    eles, "zero de um lado" se lê como efeito quando pode ser só janela curta.
+    eles, "zero de um lado" se lê como efeito quando pode ser só janela curta. `dias_observados` é
+    o vão entre o primeiro e o último LOTE do lado, não o comprimento do intervalo de corte — é a
+    janela em que houve reconstrução, que é o que dá chance a uma versão de nascer.
 
     ────────────────────────────────────────────────────────────────────────────────
     OS PARÂMETROS
@@ -96,6 +107,19 @@
     Trocar os três `set` abaixo e nada mais. Eles compilam para literais, então o SQL compilado é
     a rodada — carimbar o teto é o que torna a medição reproduzível, que é o vício que este
     arquivo existe para não repetir.
+
+      · `corte_inicio`  o piso da janela (na #86, o instante do deploy do #85)
+      · `corte_fim`     o teto (na #86, o instante da medição)
+      · `corte_25`      a descontinuidade do `.25`. É história, não parâmetro: só muda se alguém
+                        descobrir que o deploy foi outro.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    COMO RODAR
+
+        cd dbt_futebol
+        DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_churn_pos_apito
+        bq query --use_legacy_sql=false --format=csv \
+          < target/compiled/dbt_futebol/analyses/taskA_churn_pos_apito.sql
 
     Nada aqui escreve. É `compile` + `bq query`, nunca `dbt run` (a armadilha de ambiente da
     ADR 0009: `dev` e `prod` apontam para o mesmo dataset).
@@ -117,6 +141,9 @@ WITH versoes AS (
         {# NULL quando o fixture não existe (fail-open, ADR 0003) — e NULL não entra em faixa
            nenhuma, por isso `sem_kickoff` é contado à parte. #}
         TIMESTAMP_DIFF(h.dbt_valid_from, f.kickoff_utc, MINUTE) / 60 AS horas_apos_apito,
+        {# O mesmo `COALESCE(status, '')` do macro do expurgo: status nulo não é nenhum dos três
+           que sobrevivem, então ele CAI na faixa de defeito em vez de escapar dela por NULL. #}
+        COALESCE(f.status_short, '') IN ({{ futebol_status_sobrevivem() }}) AS status_sobrevive,
         IF(
             h.dbt_valid_from <= TIMESTAMP '{{ corte_25 }}',
             'A · antes do .25',
@@ -129,11 +156,17 @@ WITH versoes AS (
 
 ),
 
-{# Um bloco por lado do corte, mais o TOTAL da janela. #}
+{# Um bloco por lado do corte, mais o TOTAL da janela. O total sai de `ROLLUP` e não de um
+   segundo `SELECT`: as treze agregações copiadas divergiriam da primeira no primeiro refactor,
+   e este repositório já pagou por predicado copiado (a meia-linha chegou a quatro cópias, #101
+   e #114). `lado_do_corte` nunca é NULL de verdade — o `IF` acima só devolve dois literais —,
+   então o `COALESCE` só pode estar nomeando a linha do rollup. #}
 agregado AS (
 
     SELECT
-        lado_do_corte,
+        {# `v.` obrigatório: sem a qualificação, o `lado_do_corte` de dentro do COALESCE resolve
+           para o ALIAS de saída (ele mesmo) e a linha do rollup sai sem rótulo, em silêncio. #}
+        COALESCE(v.lado_do_corte, 'TOTAL da janela')                    AS lado_do_corte,
         COUNT(DISTINCT dbt_valid_from)                                  AS lotes_snapshot,
         ROUND(TIMESTAMP_DIFF(MAX(dbt_valid_from), MIN(dbt_valid_from), MINUTE) / 1440, 2)
                                                                         AS dias_observados,
@@ -144,29 +177,12 @@ agregado AS (
         COUNT(DISTINCT IF(horas_apos_apito > 0, opportunity_key, NULL)) AS chaves_pos_apito,
         COUNTIF(horas_apos_apito > 0  AND horas_apos_apito <= 10)       AS faixa_0_10h,
         COUNTIF(horas_apos_apito > 10 AND horas_apos_apito <= 24)       AS faixa_10_24h,
-        COUNTIF(horas_apos_apito > 24)                                  AS faixa_acima_24h,
+        COUNTIF(horas_apos_apito > 24 AND NOT status_sobrevive)         AS faixa_acima_24h,
+        COUNTIF(horas_apos_apito > 24 AND status_sobrevive)             AS acima_24h_sobrevivente,
         ROUND(AVG(IF(horas_apos_apito > 0, horas_apos_apito, NULL)), 1) AS media_h,
         ROUND(MAX(horas_apos_apito), 1)                                 AS max_h
-    FROM versoes
-    GROUP BY lado_do_corte
-
-    UNION ALL
-
-    SELECT
-        'TOTAL da janela',
-        COUNT(DISTINCT dbt_valid_from),
-        ROUND(TIMESTAMP_DIFF(MAX(dbt_valid_from), MIN(dbt_valid_from), MINUTE) / 1440, 2),
-        COUNT(*),
-        COUNT(DISTINCT opportunity_key),
-        COUNTIF(kickoff_utc IS NULL),
-        COUNTIF(horas_apos_apito > 0),
-        COUNT(DISTINCT IF(horas_apos_apito > 0, opportunity_key, NULL)),
-        COUNTIF(horas_apos_apito > 0  AND horas_apos_apito <= 10),
-        COUNTIF(horas_apos_apito > 10 AND horas_apos_apito <= 24),
-        COUNTIF(horas_apos_apito > 24),
-        ROUND(AVG(IF(horas_apos_apito > 0, horas_apos_apito, NULL)), 1),
-        ROUND(MAX(horas_apos_apito), 1)
-    FROM versoes
+    FROM versoes v
+    GROUP BY ROLLUP(v.lado_do_corte)
 
 ),
 
@@ -176,69 +192,83 @@ residuo AS (
 
     SELECT
         FORMAT('fixture %d · %s · %s', fixture_id, competition, COALESCE(status_short, 'NULL'))
-                                                        AS item,
-        STRING_AGG(DISTINCT lado_do_corte, ' + ')       AS lado_do_corte,
-        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M', ANY_VALUE(kickoff_utc)) AS kickoff_utc_fmt,
-        COUNT(*)                                        AS pos_apito,
-        COUNT(DISTINCT opportunity_key)                 AS chaves_pos_apito,
-        ROUND(MAX(horas_apos_apito), 1)                 AS max_h,
-        COUNTIF(horas_apos_apito > 24)                  AS faixa_acima_24h
+                                                                    AS item,
+        STRING_AGG(DISTINCT lado_do_corte, ' + ')                   AS lado_do_corte,
+        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M', ANY_VALUE(kickoff_utc))  AS kickoff_utc_fmt,
+        COUNT(*)                                                    AS pos_apito,
+        COUNT(DISTINCT opportunity_key)                             AS chaves_pos_apito,
+        COUNTIF(horas_apos_apito > 24 AND NOT status_sobrevive)     AS faixa_acima_24h,
+        COUNTIF(horas_apos_apito > 24 AND status_sobrevive)         AS acima_24h_sobrevivente,
+        ROUND(MAX(horas_apos_apito), 1)                             AS max_h
     FROM versoes
     WHERE horas_apos_apito > 0
     GROUP BY fixture_id, competition, status_short
 
 ),
 
-{# Saída alta e estreita: o bloco `agregado` responde o aceite, o bloco `residuo` nomeia quem
-   sobrou. As colunas que só um dos blocos tem saem NULL no outro, de propósito — inventar zero
-   ali faria a leitura confundir "não se aplica" com "medido e deu zero". #}
-tudo AS (
+{# Saída alta e estreita: o bloco `1` responde o aceite, o bloco `2` nomeia quem sobrou. Cada
+   bloco alinha as colunas com nome dentro do próprio CTE, e o `UNION ALL` junta dois `*` já
+   nomeados — é o padrão da casa (`taskA_linha_de_base_funil.sql`), e ele existe para que
+   reordenar uma coluna num bloco não desalinhe o outro em silêncio. As colunas que só um dos
+   blocos tem saem NULL no outro, de propósito: inventar zero ali faria a leitura confundir "não
+   se aplica" com "medido e deu zero". #}
+bloco_agregado AS (
 
     SELECT
-        '1 · agregado'      AS bloco,
-        lado_do_corte,
-        CAST(NULL AS STRING) AS item,
-        CAST(NULL AS STRING) AS kickoff_utc_fmt,
-        lotes_snapshot,
-        dias_observados,
-        versoes,
-        chaves,
-        sem_kickoff,
-        pos_apito,
-        chaves_pos_apito,
-        faixa_0_10h,
-        faixa_10_24h,
-        faixa_acima_24h,
-        media_h,
-        max_h
+        '1 · agregado'          AS bloco,
+        lado_do_corte           AS lado_do_corte,
+        CAST(NULL AS STRING)    AS item,
+        CAST(NULL AS STRING)    AS kickoff_utc_fmt,
+        lotes_snapshot          AS lotes_snapshot,
+        dias_observados         AS dias_observados,
+        versoes                 AS versoes,
+        chaves                  AS chaves,
+        sem_kickoff             AS sem_kickoff,
+        pos_apito               AS pos_apito,
+        chaves_pos_apito        AS chaves_pos_apito,
+        faixa_0_10h             AS faixa_0_10h,
+        faixa_10_24h            AS faixa_10_24h,
+        faixa_acima_24h         AS faixa_acima_24h,
+        acima_24h_sobrevivente  AS acima_24h_sobrevivente,
+        media_h                 AS media_h,
+        max_h                   AS max_h
     FROM agregado
 
-    UNION ALL
+),
+
+bloco_residuo AS (
 
     SELECT
-        '2 · residuo por fixture',
-        lado_do_corte,
-        item,
-        kickoff_utc_fmt,
-        CAST(NULL AS INT64),
-        CAST(NULL AS FLOAT64),
-        CAST(NULL AS INT64),
-        CAST(NULL AS INT64),
-        CAST(NULL AS INT64),
-        pos_apito,
-        chaves_pos_apito,
-        CAST(NULL AS INT64),
-        CAST(NULL AS INT64),
-        faixa_acima_24h,
-        CAST(NULL AS FLOAT64),
-        max_h
+        '2 · residuo por fixture' AS bloco,
+        lado_do_corte             AS lado_do_corte,
+        item                      AS item,
+        kickoff_utc_fmt           AS kickoff_utc_fmt,
+        CAST(NULL AS INT64)       AS lotes_snapshot,
+        CAST(NULL AS FLOAT64)     AS dias_observados,
+        CAST(NULL AS INT64)       AS versoes,
+        CAST(NULL AS INT64)       AS chaves,
+        CAST(NULL AS INT64)       AS sem_kickoff,
+        pos_apito                 AS pos_apito,
+        chaves_pos_apito          AS chaves_pos_apito,
+        CAST(NULL AS INT64)       AS faixa_0_10h,
+        CAST(NULL AS INT64)       AS faixa_10_24h,
+        faixa_acima_24h           AS faixa_acima_24h,
+        acima_24h_sobrevivente    AS acima_24h_sobrevivente,
+        CAST(NULL AS FLOAT64)     AS media_h,
+        max_h                     AS max_h
     FROM residuo
 
+),
+
+tudo AS (
+    SELECT * FROM bloco_agregado
+    UNION ALL
+    SELECT * FROM bloco_residuo
 )
 
 SELECT
     *,
-    {# o instante em que a rodada rodou — o teto está nos literais acima. #}
+    {# o instante em que a rodada rodou — o teto está nos literais do cabeçalho. #}
     CURRENT_TIMESTAMP() AS medido_em
 FROM tudo
 ORDER BY bloco, pos_apito DESC, lado_do_corte, item

--- a/dbt_futebol/analyses/taskA_churn_pos_apito.sql
+++ b/dbt_futebol/analyses/taskA_churn_pos_apito.sql
@@ -1,0 +1,244 @@
+/*
+    [A-86] A CHURN PÓS-APITO — quantas versões do `hist` nasceram DEPOIS do jogo.
+
+    ⚠️ OS NÚMEROS NÃO MORAM AQUI. Eles estão em `docs/TASKA_RESULTADOS.md`, seção do #86, com o
+    instante da medição e o teto da janela. Este cabeçalho carrega o CRITÉRIO e as ARMADILHAS —
+    o que muda quando a lógica muda, nunca quando o número muda.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    POR QUE ESTE ARQUIVO EXISTE
+
+    O congelamento de 17/08 (ADR 0009, issue #80) publicou "15.452 versões / 210 chaves / 14.946
+    pós-apito" **sem guardar a query**. A #86 tinha de remedir "com a mesma query do congelamento"
+    e ela não existia em lugar nenhum do repositório — foi preciso RECONSTRUIR o critério e depois
+    provar que era o mesmo, reproduzindo os dois checkpoints congelados (ver a calibração abaixo).
+    Este arquivo existe para que a próxima remedição não pague isso de novo.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    O CRITÉRIO, em uma linha
+
+        versão pós-apito  ⇔  h.dbt_valid_from > f.kickoff_utc
+
+    Três decisões dentro dele, e nenhuma é cosmética:
+
+      1. `dbt_valid_from` é IMUTÁVEL — é o instante em que o snapshot inseriu aquela versão, e
+         nada depois o reescreve. É por isso que a janela de qualquer remedição se escreve com
+         ele, e é por isso que a série inteira continua replayável a partir de hoje.
+
+         ⚠️ `dbt_valid_to` NÃO é imutável: ele é escrito quando a versão seguinte nasce (ou quando
+         `invalidate_hard_deletes` fecha a chave). Toda contagem de "chave morta" do congelamento
+         de 17/08 — as 89, das quais 54 morreram depois do apito — é IRREPRODUTÍVEL por replay:
+         relendo o `hist` hoje com o teto de 17/08, as 210 chaves aparecem fechadas, porque elas
+         fecharam depois. Quem quiser essa métrica tem de medi-la no dia, não reconstruí-la — e é
+         por isso que ela não está entre as saídas deste arquivo.
+
+      2. `LEFT JOIN fact_fixtures`, nunca INNER. Fixture ausente é fail-open (ADR 0003): a
+         comparação vira NULL, a versão não conta como pós-apito, e ela sai contada à parte
+         (`sem_kickoff`) em vez de sumir dentro do join. Nas duas medições deu 0 — o dia em que
+         der outra coisa, o número aparece em vez de calar.
+
+      3. `kickoff_utc` é lido AGORA, não no instante da versão. Jogo remarcado move o próprio
+         apito, e uma versão pode trocar de lado da fronteira retroativamente. É o preço de o
+         `hist` não carregar kickoff; declará-lo é mais barato que carimbar coluna nova em tabela
+         sincronizada, que a ADR 0009 recusou de propósito.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A CALIBRAÇÃO — é ela que satisfaz o aceite "mesma query do congelamento"
+
+    O critério acima reproduz os DOIS checkpoints congelados, ao número:
+
+      · teto 2026-08-17 16:32:17.191019 UTC  →  15.452 versões / 210 chaves / 14.946 pós-apito
+        / média 668,2 h   (o congelamento da ADR 0009, issue #80)
+      · teto 2026-08-20 16:41:25 UTC         →  17.719 pós-apito
+        (o fatiamento por faixa publicado na #85 no dia do deploy)
+
+    O teto de 17/08 não foi escolhido a dedo: é a última versão do lote das 16:32 daquele dia, o
+    único instante em que o `hist` tem exatamente 15.452 linhas. Reproduzir DOIS pontos com um
+    critério de uma linha é o que torna a remedição comparável ao baseline em vez de uma métrica
+    nova. Para refazer a calibração, é só mover `corte_inicio`/`corte_fim` abaixo.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    AS TRÊS FAIXAS, e por que o corte é em 24 h
+
+    Contar "pós-apito" em bloco mistura três coisas com donos diferentes (pré-atribuição feita na
+    #85 ANTES do deploy, justamente para esta medição atribuir em vez de investigar):
+
+      0–10 h    o status ainda não chegou. `fact_fixtures` é reconstruída UMA VEZ POR DIA
+                (`workflow-futebol-daily`, `0 9 * * *`) e o board a cada ciclo de odds, que não
+                toca fixtures. Entre o apito e as 09:00 UTC seguintes o status ainda não é `FT` e
+                a linha continua no board. Nenhuma carência alcança isto — a linha não passou de
+                24 h. Dono: **task [C]** (frequência da coleta de placar).
+      10–24 h   resíduo da carência. Função direta de `var expurgo_carencia_horas` (24, fixada
+                pela ADR 0009). Quem quiser derrubá-lo baixa a var. Dono: **decisão de produto**.
+      > 24 h    **defeito**. Passou da carência e o expurgo não pegou. É o único número cujo alvo
+                é zero de verdade, e o único que vira ticket de churn.
+
+    ⚠️ A fronteira é `> 24` e não `>= 24` de propósito: a carência do macro é
+    `TIMESTAMP_ADD(kickoff, INTERVAL 24 HOUR) < CURRENT_TIMESTAMP()`, estritamente maior. Uma
+    faixa `>= 24` acenderia vermelho na versão nascida no segundo exato da fronteira, que o mart
+    ainda tinha o direito de emitir.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    A DESCONTINUIDADE DO `.25` (#101), 2026-08-21 19:05:23 UTC
+
+    O conserto da `is_half_line` tirou a linha de quarto (`.25`) do board. Ele muda VOLUME, não
+    taxa de nascimento pós-apito: é monotônico (nenhum candidato anda de quarto para meia), então
+    nada passou a ser publicado que não era. As contagens absolutas de versão e de chave caem a
+    partir dali, e por isso toda saída deste arquivo sai FATIADA pelos dois lados do corte.
+
+    ⚠️ `lotes_snapshot` e `dias_observados` saem junto das contagens, e não são enfeite: as duas
+    fatias não têm o mesmo tamanho (a de antes do corte é de horas, a de depois é de dias). Sem
+    eles, "zero de um lado" se lê como efeito quando pode ser só janela curta.
+
+    ────────────────────────────────────────────────────────────────────────────────
+    OS PARÂMETROS
+
+    Trocar os três `set` abaixo e nada mais. Eles compilam para literais, então o SQL compilado é
+    a rodada — carimbar o teto é o que torna a medição reproduzível, que é o vício que este
+    arquivo existe para não repetir.
+
+    Nada aqui escreve. É `compile` + `bq query`, nunca `dbt run` (a armadilha de ambiente da
+    ADR 0009: `dev` e `prod` apontam para o mesmo dataset).
+*/
+
+{% set corte_inicio = "2026-08-20 16:41:25 UTC" %}   {# deploy do #85 em produção #}
+{% set corte_fim    = "2026-08-28 12:40:53 UTC" %}   {# o instante desta medição #}
+{% set corte_25     = "2026-08-21 19:05:23 UTC" %}   {# conserto do .25 (#101) — história, não parâmetro #}
+
+WITH versoes AS (
+
+    SELECT
+        h.opportunity_key,
+        h.fixture_id,
+        h.competition,
+        h.dbt_valid_from,
+        f.kickoff_utc,
+        f.status_short,
+        {# NULL quando o fixture não existe (fail-open, ADR 0003) — e NULL não entra em faixa
+           nenhuma, por isso `sem_kickoff` é contado à parte. #}
+        TIMESTAMP_DIFF(h.dbt_valid_from, f.kickoff_utc, MINUTE) / 60 AS horas_apos_apito,
+        IF(
+            h.dbt_valid_from <= TIMESTAMP '{{ corte_25 }}',
+            'A · antes do .25',
+            'B · depois do .25'
+        ) AS lado_do_corte
+    FROM {{ ref('fact_value_opportunities_hist') }} h
+    LEFT JOIN {{ ref('fact_fixtures') }} f USING (fixture_id)
+    WHERE h.dbt_valid_from >  TIMESTAMP '{{ corte_inicio }}'
+      AND h.dbt_valid_from <= TIMESTAMP '{{ corte_fim }}'
+
+),
+
+{# Um bloco por lado do corte, mais o TOTAL da janela. #}
+agregado AS (
+
+    SELECT
+        lado_do_corte,
+        COUNT(DISTINCT dbt_valid_from)                                  AS lotes_snapshot,
+        ROUND(TIMESTAMP_DIFF(MAX(dbt_valid_from), MIN(dbt_valid_from), MINUTE) / 1440, 2)
+                                                                        AS dias_observados,
+        COUNT(*)                                                        AS versoes,
+        COUNT(DISTINCT opportunity_key)                                 AS chaves,
+        COUNTIF(kickoff_utc IS NULL)                                    AS sem_kickoff,
+        COUNTIF(horas_apos_apito > 0)                                   AS pos_apito,
+        COUNT(DISTINCT IF(horas_apos_apito > 0, opportunity_key, NULL)) AS chaves_pos_apito,
+        COUNTIF(horas_apos_apito > 0  AND horas_apos_apito <= 10)       AS faixa_0_10h,
+        COUNTIF(horas_apos_apito > 10 AND horas_apos_apito <= 24)       AS faixa_10_24h,
+        COUNTIF(horas_apos_apito > 24)                                  AS faixa_acima_24h,
+        ROUND(AVG(IF(horas_apos_apito > 0, horas_apos_apito, NULL)), 1) AS media_h,
+        ROUND(MAX(horas_apos_apito), 1)                                 AS max_h
+    FROM versoes
+    GROUP BY lado_do_corte
+
+    UNION ALL
+
+    SELECT
+        'TOTAL da janela',
+        COUNT(DISTINCT dbt_valid_from),
+        ROUND(TIMESTAMP_DIFF(MAX(dbt_valid_from), MIN(dbt_valid_from), MINUTE) / 1440, 2),
+        COUNT(*),
+        COUNT(DISTINCT opportunity_key),
+        COUNTIF(kickoff_utc IS NULL),
+        COUNTIF(horas_apos_apito > 0),
+        COUNT(DISTINCT IF(horas_apos_apito > 0, opportunity_key, NULL)),
+        COUNTIF(horas_apos_apito > 0  AND horas_apos_apito <= 10),
+        COUNTIF(horas_apos_apito > 10 AND horas_apos_apito <= 24),
+        COUNTIF(horas_apos_apito > 24),
+        ROUND(AVG(IF(horas_apos_apito > 0, horas_apos_apito, NULL)), 1),
+        ROUND(MAX(horas_apos_apito), 1)
+    FROM versoes
+
+),
+
+{# O resíduo aberto por fixture. Se `faixa_acima_24h` for diferente de zero, é AQUI que se lê
+   QUAL jogo — para o ticket de churn nascer com nome, e não com adjetivo. #}
+residuo AS (
+
+    SELECT
+        FORMAT('fixture %d · %s · %s', fixture_id, competition, COALESCE(status_short, 'NULL'))
+                                                        AS item,
+        STRING_AGG(DISTINCT lado_do_corte, ' + ')       AS lado_do_corte,
+        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M', ANY_VALUE(kickoff_utc)) AS kickoff_utc_fmt,
+        COUNT(*)                                        AS pos_apito,
+        COUNT(DISTINCT opportunity_key)                 AS chaves_pos_apito,
+        ROUND(MAX(horas_apos_apito), 1)                 AS max_h,
+        COUNTIF(horas_apos_apito > 24)                  AS faixa_acima_24h
+    FROM versoes
+    WHERE horas_apos_apito > 0
+    GROUP BY fixture_id, competition, status_short
+
+),
+
+{# Saída alta e estreita: o bloco `agregado` responde o aceite, o bloco `residuo` nomeia quem
+   sobrou. As colunas que só um dos blocos tem saem NULL no outro, de propósito — inventar zero
+   ali faria a leitura confundir "não se aplica" com "medido e deu zero". #}
+tudo AS (
+
+    SELECT
+        '1 · agregado'      AS bloco,
+        lado_do_corte,
+        CAST(NULL AS STRING) AS item,
+        CAST(NULL AS STRING) AS kickoff_utc_fmt,
+        lotes_snapshot,
+        dias_observados,
+        versoes,
+        chaves,
+        sem_kickoff,
+        pos_apito,
+        chaves_pos_apito,
+        faixa_0_10h,
+        faixa_10_24h,
+        faixa_acima_24h,
+        media_h,
+        max_h
+    FROM agregado
+
+    UNION ALL
+
+    SELECT
+        '2 · residuo por fixture',
+        lado_do_corte,
+        item,
+        kickoff_utc_fmt,
+        CAST(NULL AS INT64),
+        CAST(NULL AS FLOAT64),
+        CAST(NULL AS INT64),
+        CAST(NULL AS INT64),
+        CAST(NULL AS INT64),
+        pos_apito,
+        chaves_pos_apito,
+        CAST(NULL AS INT64),
+        CAST(NULL AS INT64),
+        faixa_acima_24h,
+        CAST(NULL AS FLOAT64),
+        max_h
+    FROM residuo
+
+)
+
+SELECT
+    *,
+    {# o instante em que a rodada rodou — o teto está nos literais acima. #}
+    CURRENT_TIMESTAMP() AS medido_em
+FROM tudo
+ORDER BY bloco, pos_apito DESC, lado_do_corte, item

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -393,6 +393,11 @@ menos oportunidades de nascer versão nova. "Uma semana" aqui vale 162 chances, 
   esse número; é decisão de produto, não defeito.
 - **Zero acima de 24 h.** O expurgo faz exatamente o que a ADR 0009 desenhou.
 
+⚠️ **E o zero não é de raspão.** A versão mais atrasada da janela está em **16,28 h** — **7,72 h
+de folga** até a fronteira da carência —, e **nenhuma** das 45 passa de 20 h. Importa porque um
+resultado colado na fronteira mudaria de lado com uma remarcação de jogo ou um arredondamento;
+este não muda.
+
 ### Quem são as 45
 
 Oito fixtures, todos `FT`, todos com o atraso dentro das primeiras 16,3 h:

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -329,3 +329,194 @@ bq query --use_legacy_sql=false --format=csv \
 ```
 
 Nada em produção muda: é `compile` + `bq query`, nunca `dbt run`.
+
+---
+
+# Ticket #86 — A remedição de churn D+7
+
+**Análise:** `dbt_futebol/analyses/taskA_churn_pos_apito.sql`
+**Fonte:** `fact_value_opportunities_hist` × `fact_fixtures` (ADR 0009)
+**Deploy do expurgo (#85) em produção:** **2026-08-20 16:41:25 UTC**
+**Medição:** **2026-08-28 12:40:53 UTC** — **7,83 dias corridos** depois (a trava de relógio
+expirava em 27/08 16:41 UTC)
+
+## Veredito
+
+**O alvo literal do aceite — *zero versão nova pós-apito* — não foi atingido: sobraram 45, sobre
+9 chaves. O alvo que decide foi: das 45, ZERO nasceu depois da carência de 24 h.**
+
+A distinção não é conveniência retroativa. Ela foi pré-declarada na #85 **antes** do deploy,
+justamente para esta medição atribuir em vez de investigar: a versão que nasce nas primeiras 24 h
+depois do apito não está ao alcance do expurgo (o status ainda não chegou, ou a carência ainda não
+venceu). A que nasce **depois** das 24 h está, e é a única que seria defeito.
+
+| | Baseline (17/08) | Janela pós-deploy |
+|---|---|---|
+| Versões pós-apito **> 24 h** — *o número do aceite* | **14.674** | **0** |
+| Versões pós-apito, total | 14.946 | **45** |
+| …sobre quantas chaves | 172 | **9** (8 fixtures) |
+| % das versões da janela que são pós-apito | 96,7% | **9,0%** |
+| Versões pós-apito por dia | 709 | **5,8** |
+| Versões pós-apito por lote de snapshot | 53,4 | **0,28** |
+| Maior atraso observado | 1.409 h (59 dias) | **16,3 h** |
+
+## A janela, e o que ela contém
+
+| | |
+|---|---|
+| Piso | `dbt_valid_from > 2026-08-20 16:41:25 UTC` (o deploy) |
+| Teto | `dbt_valid_from <= 2026-08-28 12:40:53 UTC` (esta medição) |
+| Versões nascidas na janela | **498** |
+| Chaves | **48** |
+| Lotes de snapshot | **162** |
+| Versões sem `kickoff` (fixture ausente) | **0** |
+
+⚠️ **162 lotes em 7,8 dias não é o relógio, é o calendário de jogos.** A fase de `dbt run` do
+`workflow_futebol_odds.yml` tem gate `saved_count > 0`: o cron dispara a *coleta*, e o board só é
+reconstruído quando a coleta traz arquivo novo de odds. Dia sem jogo tem menos reconstruções — e
+menos oportunidades de nascer versão nova. "Uma semana" aqui vale 162 chances, não 672.
+
+## As três faixas — a atribuição, com número
+
+| Faixa após o apito | Baseline (17/08) | 20/08 (deploy) | **Janela pós-deploy** | Dono |
+|---|---|---|---|---|
+| 0–10 h — o status ainda não chegou | 83 | 121 | **43** | task **[C]** (coleta de placar) |
+| 10–24 h — resíduo da carência | 189 | 208 | **2** | decisão de produto (`expurgo_carencia_horas`) |
+| **> 24 h — defeito** | **14.674** | **17.390** | **0** | — |
+
+- As **43** de 0–10 h são a latência de `fact_fixtures`, que é reconstruída uma vez por dia
+  (`workflow-futebol-daily`, `0 9 * * *`) enquanto o board é reconstruído a cada ciclo de odds.
+  Entre o apito e as 09:00 UTC seguintes o status ainda não é `FT` e a linha continua no board.
+  **Nenhuma carência resolve** — a linha não passou de 24 h, então a rede de segurança não a
+  alcança por construção. É a dependência **[A]→[C]** que a ADR 0009 pré-declarou.
+- As **2** de 10–24 h são o preço corrente de `expurgo_carencia_horas = 24`. Baixar a var derruba
+  esse número; é decisão de produto, não defeito.
+- **Zero acima de 24 h.** O expurgo faz exatamente o que a ADR 0009 desenhou.
+
+### Quem são as 45
+
+Oito fixtures, todos `FT`, todos com o atraso dentro das primeiras 16,3 h:
+
+| Fixture | Competição | Kickoff (UTC) | Versões pós-apito | Chaves | Maior atraso |
+|---|---|---|---|---|---|
+| 1570348 | la_liga | 2026-08-23 17:30 | 26 | 2 | 6,5 h |
+| 1520835 | serie_b | 2026-08-25 22:30 | 5 | 1 | 2,0 h |
+| 1570345 | la_liga | 2026-08-21 19:00 | 4 | 1 | **16,3 h** |
+| 1570342 | la_liga | 2026-08-25 19:00 | 3 | 1 | 5,5 h |
+| 1623070 | copa_do_brasil | 2026-08-27 23:00 | 3 | 1 | 12,6 h |
+| 1520836 | serie_b | 2026-08-23 21:00 | 2 | 1 | 1,3 h |
+| 1547769 | libertadores | 2026-08-26 00:30 | 1 | 1 | 0,0 h |
+| 1570340 | la_liga | 2026-08-26 19:00 | 1 | 1 | 4,0 h |
+
+Um fixture responde por 26 das 45. O padrão é o esperado: jogo de fim de tarde/noite, cujo status
+só vira `FT` na varredura das 09:00 UTC do dia seguinte, continua recebendo preço enquanto a
+coleta de odds ainda o enxerga.
+
+## A descontinuidade do `.25` (#101), 2026-08-21 19:05:23 UTC
+
+O aceite exige as contagens absolutas dos dois lados do corte. Elas estão abaixo — **com os lotes
+e os dias de cada lado**, sem os quais a comparação seria entre 26 horas e uma semana:
+
+| | **A · antes do `.25`** | **B · depois do `.25`** |
+|---|---|---|
+| Intervalo | 20/08 16:41 → 21/08 19:05 | 21/08 19:05 → 28/08 12:40 |
+| Dias observados | 1,04 | 6,70 |
+| Lotes de snapshot | 24 | 138 |
+| Versões | **44** | **454** |
+| Chaves | **8** | **43** |
+| Versões pós-apito | **0** | **45** |
+| Chaves pós-apito | 0 | 9 |
+| 0–10 h / 10–24 h / **> 24 h** | 0 / 0 / **0** | 43 / 2 / **0** |
+| Apitos dentro do intervalo | **2** | **14** |
+
+⚠️ **O zero do lado A não é evidência sobre o `.25`, e não deve ser lido como tal.** O lado A tem
+26 horas, 24 lotes e **2 apitos**; o lado B tem quase sete dias, 138 lotes e 14. Com 2 jogos
+encerrando dentro do intervalo, "nenhuma versão pós-apito" é o que se esperaria de qualquer
+regime. O que os dois lados dizem juntos, e isso sim é o aceite: **`> 24 h` é zero dos dois
+lados**.
+
+O conserto do `.25` é monotônico — nenhum candidato anda de quarto para meia, então nada passou a
+ser publicado que não era. Ele muda **volume para baixo** (o board perde 37,7% das oportunidades
+de Handicap e Gols), não taxa de nascimento de versão pós-apito. É por isso que as contagens
+absolutas caem a partir de 21/08 19:05 e o veredito não se move.
+
+## O critério, e como ele foi provado ser o mesmo do congelamento
+
+```sql
+-- versão pós-apito ⇔
+h.dbt_valid_from > f.kickoff_utc
+FROM fact_value_opportunities_hist h
+LEFT JOIN fact_fixtures f USING (fixture_id)   -- LEFT, nunca INNER (fail-open, ADR 0003)
+```
+
+**O congelamento de 17/08 publicou os números sem guardar a query.** O critério acima foi
+reconstruído e depois **calibrado contra os dois checkpoints congelados**, que ele reproduz ao
+número — rodando o próprio arquivo de análise, só movendo o teto:
+
+| Teto | Reproduz | Publicado em |
+|---|---|---|
+| 2026-08-17 16:32:17.191019 UTC | 15.452 versões / 210 chaves / 14.946 pós-apito / média **668,2 h** | ADR 0009 e #80 |
+| 2026-08-20 16:41:25 UTC | 17.719 pós-apito, faixas **121 / 208 / 17.390** | #85, no dia do deploy |
+
+O teto de 17/08 não foi escolhido a dedo: é a última versão do lote das 16:32 daquele dia, o único
+instante em que o `hist` tem exatamente 15.452 linhas. Reproduzir **dois** pontos, faixas
+inclusive, é o que torna esta remedição comparável ao baseline em vez de uma métrica nova — e é o
+aceite "mesma query do congelamento", satisfeito por reprodução em vez de por afirmação.
+
+O SQL agora mora em `dbt_futebol/analyses/taskA_churn_pos_apito.sql`, para que a próxima remedição
+não pague a reconstrução de novo.
+
+## Três ressalvas do instrumento, declaradas
+
+1. **`dbt_valid_to` não é imutável.** Ele é reescrito quando a versão seguinte nasce. A linha do
+   baseline *"89 chaves mortas, 54 depois do apito, em média 464 h"* **não é replayável**: relendo
+   o `hist` hoje com o teto de 17/08, as 210 chaves aparecem fechadas, porque elas fecharam
+   depois. Quem quiser essa métrica tem de medi-la no dia. Só `dbt_valid_from` sustenta replay —
+   e é só com ele que a janela desta medição foi escrita.
+2. **`kickoff_utc` é lido no instante da medição, não no da versão.** Jogo remarcado move o próprio
+   apito e uma versão pode trocar de lado da fronteira retroativamente. O `hist` não carrega
+   kickoff, e carimbá-lo seria coluna nova em tabela sincronizada — o que a ADR 0009 recusou de
+   propósito.
+3. **A janela vale 162 lotes, não 672.** Ver o gate `saved_count > 0` acima.
+
+## Resíduo: o que vai para onde
+
+O aceite manda registrar o resíduo na **#78**. **Nada vai para lá, e o motivo é o resultado:** a
+#78 é a task de churn, e o único resíduo que seria churn — versão nascida **depois** da carência
+de 24 h — deu **zero**. Registrar lá as 45 seria mandar para a task errada um número que já tem
+dono declarado.
+
+- as **43** de 0–10 h são a **task [C]** (frequência da coleta de placar). Não há hoje ticket
+  aberto da [C] para recebê-las; o número fica aqui e na #86, e entra na [C] quando ela for
+  escrita — é insumo dela, não pendência da [A];
+- as **2** de 10–24 h são o preço de `expurgo_carencia_horas = 24`, fixada pela ADR 0009. Mexer
+  nela é decisão de produto;
+- as **0** acima de 24 h são o que a #78 receberia. Não há o que registrar.
+
+*(A #78 foi, aliás, **fechada em 26/08** pela A1/#103 — as duas premissas de odd que instabilizavam
+a nota saíram do Score. Mesmo que houvesse resíduo de churn, ele precisaria de casa nova.)*
+
+## Estado do produto no instante da medição
+
+| | |
+|---|---|
+| Linhas no board | **8** |
+| Chaves abertas no `hist` | **8** |
+| `hist` — total de versões | **18.819** (era 15.452 em 17/08: cresceu, não encolheu) |
+| Guarda 1 (`assert_board_sem_jogo_encerrado`) | **PASS** |
+| Guarda 2 (`assert_hist_aberto_existe_no_board`) | **PASS** |
+
+O `hist` maior é a outra metade da ADR 0009 funcionando: **expurgar não é apagar**. As 45 versões
+pós-apito desta janela estão todas lá, fechadas e datadas — é por isso que esta medição existe.
+
+## Como rerodar
+
+```bash
+cd dbt_futebol
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_churn_pos_apito
+bq query --use_legacy_sql=false --format=csv \
+  < target/compiled/dbt_futebol/analyses/taskA_churn_pos_apito.sql
+```
+
+Para remedir mais tarde, mover `corte_fim` no cabeçalho da análise. Para replayar um congelamento,
+mover os dois cortes. Nada em produção muda: é `compile` + `bq query`, nunca `dbt run`.

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -398,6 +398,15 @@ de folga** até a fronteira da carência —, e **nenhuma** das 45 passa de 20 h
 resultado colado na fronteira mudaria de lado com uma remarcação de jogo ou um arredondamento;
 este não muda.
 
+⚠️ **`PST`/`SUSP`/`INT` não entram na faixa de defeito**, pelo mesmo motivo que não entram no
+expurgo: a ADR 0009 os preserva **inclusive além da carência**. Jogo adiado fica adiado por
+semanas e nasceria versão nova o tempo todo — contá-lo como defeito faria esta medição acusar o
+expurgo justamente onde ele está obedecendo. Eles saem **contados à parte**, nunca apagados
+(coluna `acima_24h_sobrevivente`), e a lista vem de `futebol_status_sobrevivem()`, o mesmo macro
+do mart e da guarda 1. **Deu zero nos três cortes** — janela, 17/08 e 20/08 —, então a ressalva é
+de instrumento e não muda nenhum número desta seção: os 14.674 do baseline são todos defeito de
+verdade.
+
 ### Quem são as 45
 
 Oito fixtures, todos `FT`, todos com o atraso dentro das primeiras 16,3 h:
@@ -491,15 +500,19 @@ O aceite manda registrar o resíduo na **#78**. **Nada vai para lá, e o motivo 
 de 24 h — deu **zero**. Registrar lá as 45 seria mandar para a task errada um número que já tem
 dono declarado.
 
-- as **43** de 0–10 h são a **task [C]** (frequência da coleta de placar). Não há hoje ticket
-  aberto da [C] para recebê-las; o número fica aqui e na #86, e entra na [C] quando ela for
-  escrita — é insumo dela, não pendência da [A];
+- as **43** de 0–10 h são a **task [C]** (frequência da coleta de placar), e a #85 já as atribuiu
+  a ela **antes** do deploy: *"Quem move isso é a task [C], não este ticket nem a #78."* Elas não
+  ficam penduradas na [A] — são **insumo declarado da [C]**, com número e mecanismo, e este
+  documento é a fonte que ela lê. A [C] ainda não tem ticket aberto; abrir um para carregá-las é
+  ato da [C], não desta medição;
 - as **2** de 10–24 h são o preço de `expurgo_carencia_horas = 24`, fixada pela ADR 0009. Mexer
   nela é decisão de produto;
 - as **0** acima de 24 h são o que a #78 receberia. Não há o que registrar.
 
-*(A #78 foi, aliás, **fechada em 26/08** pela A1/#103 — as duas premissas de odd que instabilizavam
-a nota saíram do Score. Mesmo que houvesse resíduo de churn, ele precisaria de casa nova.)*
+*(A #78 foi, aliás, **fechada em 2026-08-17 20:59 UTC**, quando a causa raiz saiu do adjetivo: o
+`AVG()` do BigQuery não é bit-reproduzível entre execuções — a fusão das médias parciais de cada
+shard leva o último bit junto —, e são 6 premissas, não 1. Mesmo que houvesse resíduo de churn
+acima de 24 h, ele precisaria de casa nova.)*
 
 ## Estado do produto no instante da medição
 

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -501,10 +501,11 @@ de 24 h — deu **zero**. Registrar lá as 45 seria mandar para a task errada um
 dono declarado.
 
 - as **43** de 0–10 h são a **task [C]** (frequência da coleta de placar), e a #85 já as atribuiu
-  a ela **antes** do deploy: *"Quem move isso é a task [C], não este ticket nem a #78."* Elas não
-  ficam penduradas na [A] — são **insumo declarado da [C]**, com número e mecanismo, e este
-  documento é a fonte que ela lê. A [C] ainda não tem ticket aberto; abrir um para carregá-las é
-  ato da [C], não desta medição;
+  a ela **antes** do deploy: *"Quem move isso é a task [C], não este ticket nem a #78."* Elas
+  **não ficam penduradas aqui**: viraram **`data-engineering#60`**, com o número, a distribuição
+  por atraso e o custo da cadência medido (`/fixtures` não é paginado — 1 chamada por alvo, e
+  `FIXTURES_CURRENT` tem 14). Foi aberto lá porque a alavanca inteira é de ingestão: cron do
+  Scheduler, `FIXTURES_CURRENT` e workflows. Nada no `dbt_futebol` move este número;
 - as **2** de 10–24 h são o preço de `expurgo_carencia_horas = 24`, fixada pela ADR 0009. Mexer
   nela é decisão de produto;
 - as **0** acima de 24 h são o que a #78 receberia. Não há o que registrar.


### PR DESCRIPTION
## O que este PR entrega

A **remedição de churn D+7** da ADR 0009 — a prova, com número, de que o expurgo do board (#85)
matou a versão nascida depois do apito. Mede e nada mais: **nenhuma mudança de modelo, snapshot
ou workflow**, como o ticket exige.

- `dbt_futebol/analyses/taskA_churn_pos_apito.sql` — o critério, calibrado e parametrizado
- `docs/TASKA_RESULTADOS.md` — a seção do #86, com os números e o instante da rodada
- `dbt_futebol/CONTEXT.md` — glossário: "versão pós-apito" e "as três faixas", que a [C] herda

## O veredito

**O alvo literal do aceite ("zero versão nova pós-apito") não foi atingido: sobraram 45, sobre 9
chaves. O alvo que decide foi: das 45, ZERO nasceu depois da carência de 24 h — contra 14.674 no
baseline.**

| | Baseline (17/08) | Janela pós-deploy |
|---|---|---|
| Pós-apito **> 24 h** — *o número do aceite* | **14.674** | **0** |
| Pós-apito, total | 14.946 | **45** (9 chaves, 8 fixtures) |
| % das versões da janela | 96,7% | **9,0%** |
| Por dia | 709 | **5,8** |
| Maior atraso | 1.409 h | **16,3 h** (7,7 h de folga até a carência) |

Deploy do #85: **2026-08-20 16:41:25 UTC**. Medição: **2026-08-28 12:40:53 UTC** — **7,83 dias**.

As 45 caem inteiras nas duas faixas que a #85 pré-atribuiu **antes** do deploy: **43** em 0–10 h
(latência de `fact_fixtures`, que reconstrói 1×/dia — dono: task **[C]**) e **2** em 10–24 h
(preço de `expurgo_carencia_horas = 24` — decisão de produto). **Nada vai para a #78**: o único
resíduo que seria churn é o de > 24 h, e ele é zero.

## O congelamento de 17/08 não tinha query — agora tem

O baseline foi publicado sem guardar o SQL. O critério foi reconstruído e **calibrado contra os
dois checkpoints congelados, que ele reproduz ao número**, faixas inclusive:

| Teto | Reproduz |
|---|---|
| 2026-08-17 16:32:17.191019 UTC | 15.452 / 210 / 14.946 pós-apito / média **668,2 h** |
| 2026-08-20 16:41:25 UTC | 17.719 pós-apito, faixas **121 / 208 / 17.390** |

É o aceite "mesma query do congelamento" satisfeito por reprodução, não por afirmação — e o SQL
agora mora em `analyses/`, para a próxima remedição não pagar a reconstrução de novo.

## A descontinuidade do `.25` (#101)

Sai fatiada, com os lotes e os dias de cada lado: **> 24 h é zero dos dois**. O documento diz
explicitamente que **o zero do lado A não é evidência sobre o `.25`** — são 26 h, 24 lotes e
2 apitos contra 6,7 dias, 138 lotes e 14.

## Verificação

- `dbt parse` limpo
- `dbt test --select tag:guarda` → **45/45 PASS** (guardas 1 e 2 do expurgo inclusas)
- Análise rodada por `compile` + `bq query`, nunca `dbt run` (armadilha de ambiente da ADR 0009)

**Não gera deriva de imagem:** os três arquivos tocados estão fora das paths de procedência —
`analyses/`, `docs/` e `CONTEXT.md` são exatamente as três exclusões que o cabeçalho do
`scripts/procedencia.sh` nomeia, de propósito ("hashear a pasta inteira produziria ~28 alarmes
falsos por mês"). **Sem rebuild depois do merge.**

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTnLDMmnTqwZZwycqB3DT9
