### PR TITLE
fix(futebol): a digital do insumo do PIT passa a ser o fecho da linha (#123)

### DIFF
--- a/dbt_futebol/CONTEXT.md
+++ b/dbt_futebol/CONTEXT.md
@@ -540,6 +540,11 @@ fingerprinting by `(competition_id, season)` — Brasileirão 2026 matched byte 
 diverged in 60 rows, because all 20 of its teams also play Libertadores and Copa do Brasil. The
 rule that follows: **any change of axis is a candidate to change the closure**, and "what does
 this row now depend on?" belongs in the checklist of whoever changes it. Emenda to ADR 0007.
+⚠️ A closure is **read off the SQL, never guessed**. Writing #123's fingerprint turned up three
+inputs the grelha's enumeration had missed — the prior fixtures of the *whole* (C,S) (a group
+rival's corrected score moves T's `rank` without touching a single game of T), the (C,S) squad
+(`n_teams`), and the deliberate *exclusion* of the anchor's own score. Erring finer than the
+closure only costs coverage; erring coarser is the lie the term exists to name.
 _Avoid_: partição (bare — ambiguous with the BigQuery partition of a table)
 
 **Célula de medição**:

--- a/dbt_futebol/analyses/taskf_congela_baseline.sql
+++ b/dbt_futebol/analyses/taskf_congela_baseline.sql
@@ -1,18 +1,16 @@
 /*
-    [F-1] Congela o BASELINE da Costura A — a saída do int_futebol_team_form_pit ANTES de a var
-    de escopo/recorte entrar no modelo.
+    [F-1] Congela o BASELINE da Costura A — a saída de PRODUÇÃO do int_futebol_team_form_pit, e a
+    impressão digital do insumo que a produziu.
 
-    Por que existe: a ADR 0007 deixa no código de produção uma var que produção nunca usa. A
-    promessa que a acompanha é "o default preserva o comportamento de hoje". Este congelamento é
-    o lado esquerdo da igualdade que transforma essa promessa em fato verificável — o direito é
-    tests/assert_taskf_pit_default_igual_baseline.sql.
+    O lado esquerdo da igualdade que a guarda tests/assert_taskf_pit_default_igual_baseline.sql
+    verifica do lado direito: a saída não se mexe nas linhas cujo insumo não se mexeu.
 
     ⚠️ NÃO É PASSO DE ROTINA. Re-congelar sem uma mudança de comportamento que o justifique apaga
     a guarda: o baseline passaria a sair do mesmo código que ele deveria auditar, e a Costura A
     ficaria verde por construção. Re-congelar é decisão de quem revisa, no mesmo commit da
     mudança que a justifica — nunca um passo executado porque a guarda ficou vermelha.
 
-    RODADO DUAS VEZES, e a segunda mudou o sentido da guarda:
+    RODADO TRÊS VEZES, e cada uma está registrada porque cada uma mudou o que a guarda quer dizer:
 
       2026-08-12 12:22 UTC, commit a3b954e, 21.054 linhas, 37 partições — do `futebol_taskF`,
       célula `base`. Congelava "o default preserva o comportamento de antes das vars".
@@ -24,19 +22,38 @@
       sobre o caminho que o board de fato serve. O baseline anterior ficou preservado nas cópias
       `baseline_*_pre91` do mesmo dataset.
 
-    Três tabelas, todas FORA do dbt de propósito — nenhuma é modelo, então nenhum `dbt run` as
+      2026-08-28 14:25:03 UTC, carimbo 687950f, 21.374 linhas (#123) — **de PRODUÇÃO**, mesmo
+      sentido, RECORTE NOVO. A digital do insumo deixou de ser por (competition_id, season) e passou
+      a ser por LINHA (fixture_id, team_id), porque a partição parou de ser o fecho da conta quando
+      a #91 virou o default para `todas`. Sem este recongelamento no mesmo commit, nenhuma linha
+      casaria contra a digital antiga e a guarda não ficaria vermelha: ficaria VAZIA.
+
+      A defasagem T0→T1 (ver o aviso mais abaixo) foi de 24 minutos: a materialização de produção
+      do `int_futebol_team_form_pit` é de 14:01:12 UTC, com as mesmas 21.374 linhas. A guarda,
+      rodada em seguida, ficou VERDE com cobertura 1,0 — 21.374 de 21.374.
+
+    ─────────────────────────────────────────────────────────────────────────────────────────────
+    Tabelas gravadas, todas FORA do dbt de propósito — nenhuma é modelo, então nenhum `dbt run` as
     reconstrói:
 
       baseline_int_futebol_team_form_pit  a saída congelada, sem dbt_loaded_at (que muda a cada
                                           build por construção e não é comportamento).
-      baseline_pit_fingerprint            impressão digital do INSUMO por (competition_id,
-                                          season), emitida pela macro taskf_fingerprint_insumo_pit
-                                          — a MESMA que o teste usa. O contrato congelado dela
-                                          está no cabeçalho da macro; as duas pontas leem de lá
-                                          justamente para não haver duas cópias que precisam ficar
-                                          idênticas para sempre.
+
+      baseline_pit_fingerprint_linha      impressão digital do INSUMO por (fixture_id, team_id),
+                                          emitida pela macro taskf_fingerprint_insumo_pit — a
+                                          MESMA que a guarda usa. O contrato congelado dela está no
+                                          cabeçalho da macro; as duas pontas leem de lá justamente
+                                          para não haver duas cópias que precisam ficar idênticas
+                                          para sempre.
+
       baseline_pit_meta                   quando, de qual commit, quantas linhas.
 
+    ⚠️ `baseline_pit_fingerprint` (a digital ANTIGA, por partição) não é mais escrita nem lida.
+    A tabela fica no dataset como registro histórico, pelo mesmo precedente das cópias
+    `baseline_*_pre91` — o que sai é a declaração dela em sources.yml, porque source que ninguém lê
+    é convite a alguém voltar a lê-la.
+
+    ─────────────────────────────────────────────────────────────────────────────────────────────
     ⚠️ COMO RODAR: `--target prod`, NÃO `--target taskF`. As três tabelas de baseline moram no
     `futebol_taskF` porque são artefato da medição (os nomes acima são literais e não seguem o
     target), mas o que elas congelam tem de sair de PRODUÇÃO. Congelar a partir do `futebol_taskF`
@@ -49,13 +66,24 @@
     reconstrução local dela. Confira antes que ela é pós-deploy da mudança que justifica o
     recongelamento (`futebol.__TABLES__.last_modified_time` contra o carimbo do Cloud Run job).
 
+    ⚠️ DEFASAGEM ENTRE OS DOIS LADOS DO CONGELAMENTO. A saída congelada é a materialização de
+    produção (instante T0, do último `dbt run` agendado); a digital é calculada AGORA, das fontes
+    vivas (instante T1). Linha cujo insumo se mexeu dentro de [T0, T1] congela com o par
+    desencontrado e fica vermelha até alguém recongelar. Por isso: congelar logo depois de uma
+    execução agendada, rodar a guarda nos minutos seguintes, e recongelar se aparecerem
+    divergências — é a mesma disciplina do congelamento de 25/08.
+
       DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target prod \
-        --select taskf_congela_baseline --vars '{freeze_git_sha: <sha da imagem em produção>}'
+        --select taskf_congela_baseline --vars '{freeze_git_sha: <sha da imagem em producao>}'
       bq query --use_legacy_sql=false --project_id=smartbetting-dados \
         < target/compiled/dbt_futebol/analyses/taskf_congela_baseline.sql
 
     O `freeze_git_sha` é o `PROCEDENCIA_SHA` do job — o commit que PRODUZIU a tabela —, nunca o
     `git rev-parse HEAD` local: de um worktree ele carimba um commit que nem está no master.
+
+      gcloud run jobs describe dbt-futebol --region us-east1 \
+        --format="value(spec.template.spec.template.spec.containers[0].env)" | tr ';' '\n' \
+        | grep PROCEDENCIA_SHA
 
     Depois, a verificação que fecha o passo:
 
@@ -70,9 +98,9 @@ SELECT * EXCEPT (dbt_loaded_at)
 FROM {{ ref('int_futebol_team_form_pit') }};
 
 
-CREATE OR REPLACE TABLE `smartbetting-dados.futebol_taskF.baseline_pit_fingerprint` AS
+CREATE OR REPLACE TABLE `smartbetting-dados.futebol_taskF.baseline_pit_fingerprint_linha` AS
 WITH {{ taskf_fingerprint_insumo_pit() }}
-SELECT * FROM fp_insumo_pit;
+SELECT * FROM fp_insumo_por_linha;
 
 
 CREATE OR REPLACE TABLE `smartbetting-dados.futebol_taskF.baseline_pit_meta` AS
@@ -80,4 +108,7 @@ SELECT
     CURRENT_TIMESTAMP()                          AS congelado_em,
     '{{ var("freeze_git_sha", "desconhecido") }}' AS git_sha,
     (SELECT COUNT(*) FROM {{ source('futebol_taskF', 'baseline_int_futebol_team_form_pit') }}) AS n_linhas,
-    (SELECT COUNT(*) FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }})           AS n_particoes;
+    -- ⚠️ Era `n_particoes` até a #123, quando a digital passou a ser por linha. O nome mudou junto
+    -- com o grão: uma coluna chamada "partições" contando linhas é a mesma classe de rótulo
+    -- mentiroso que o recorte antigo era.
+    (SELECT COUNT(*) FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint_linha') }})     AS n_linhas_digital;

--- a/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
+++ b/dbt_futebol/analyses/taskf_monotonicidade_escopo.sql
@@ -73,18 +73,20 @@
 
 WITH {{ taskf_fingerprint_insumo_pit() }},
 
--- As partições cujo insumo não se mexeu desde o congelamento. Mesma restrição da Costura A, pelo
+-- As LINHAS cujo insumo não se mexeu desde o congelamento. Mesma restrição da Costura A, pelo
 -- mesmo motivo, e emitida pela mesma macro.
-particoes_casadas AS (
-    SELECT b.competition_id, b.season
-    FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }} b
-    JOIN fp_insumo_pit a
-        ON  a.competition_id = b.competition_id
-        AND a.season         = b.season
-    WHERE a.n_fixtures    = b.n_fixtures
-      AND a.fp_fixtures   = b.fp_fixtures
-      AND a.n_grupos      = b.n_grupos
-      AND a.fp_standings IS NOT DISTINCT FROM b.fp_standings
+--
+-- ⚠️ #123: era por (competition_id, season) e passou a ser por (fixture_id, team_id), porque a
+-- partição deixou de ser o fecho da conta quando a #91 virou o default para `pit_escopo: todas`.
+-- Aqui a mudança é mecânica — o veredito desta análise não muda de sentido, só fica restrito ao
+-- recorte honesto.
+linhas_casadas AS (
+    SELECT b.fixture_id, b.team_id
+    FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint_linha') }} b
+    JOIN fp_insumo_por_linha a
+        ON  a.fixture_id = b.fixture_id
+        AND a.team_id    = b.team_id
+    WHERE a.fp_insumo_linha = b.fp_insumo_linha
 ),
 
 cel_base AS (
@@ -113,12 +115,12 @@ emparelhado AS (
 -- O lado `base` do carimbo contra o baseline gravado antes de as vars existirem.
 base_casada AS (
     SELECT fixture_id, team_id, played_total
-    FROM cel_base JOIN particoes_casadas USING (competition_id, season)
+    FROM cel_base JOIN linhas_casadas USING (fixture_id, team_id)
 ),
 baseline_casado AS (
     SELECT fixture_id, team_id, played_total
     FROM {{ source('futebol_taskF', 'baseline_int_futebol_team_form_pit') }}
-    JOIN particoes_casadas USING (competition_id, season)
+    JOIN linhas_casadas USING (fixture_id, team_id)
 ),
 contra_baseline AS (
     SELECT

--- a/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
+++ b/dbt_futebol/docs/adr/0007-a-medicao-de-escopo-roda-em-dataset-proprio.md
@@ -170,10 +170,33 @@ pergunta *"isto muda de que a linha depende?"* passa a ser parte do checklist de
 
 ### O recorte novo: por LINHA
 
-Sob `todas`, a linha em (fixture F de C/S, time T) é função de **(a)** os fixtures de T com
-`kickoff < kickoff(F)`, em toda competição, e **(b)** as standings correntes de (C,S). O fecho é,
-portanto, **a própria linha** — e o baseline ganha uma coluna `fp_insumo_linha` gravada no
-congelamento, que a guarda recomputa e compara.
+Sob `todas`, o fecho da linha (fixture F de C/S, time T) é **a própria linha** — e o baseline ganha
+uma coluna `fp_insumo_linha` gravada no congelamento, que a guarda recomputa e compara.
+
+⚠️ **Correção de 28/08, na implementação (#123): o fecho tem CINCO insumos, não dois.** A primeira
+redação desta emenda enumerava só **(a)** os fixtures de T anteriores a F, em toda competição, e
+**(b)** as standings de (C,S). A leitura do SQL do `int_futebol_team_form_pit`, feita para escrever
+a digital, mostrou que faltavam três — e faltava justamente o que tornaria a digital *mentirosa*
+pelo mesmo mecanismo que esta emenda existe para corrigir, um grão abaixo:
+
+| # | insumo | por que a linha depende dele |
+|---|---|---|
+| 1 | a **âncora** F: `fixture_id`, competição, temporada, kickoff e os dois `team_id` | é o que define a linha. ⚠️ **Sem** status e **sem** placar de F: a linha de F não lê o resultado de F (`kickoff < kickoff(F)`, estrito), e digitalizá-lo faria toda linha quebrar quando o próprio jogo acontecesse — o recorte por linha voltaria a erodir |
+| 2 | os **10** jogos encerrados anteriores de T, em qualquer competição | o `pares` trunca em `tamanho_do_recorte`; correção num 11º jogo não muda saída nenhuma, e digitalizar o histórico inteiro derrubaria linha por insumo que ela não lê |
+| 3 | **quantos** jogos anteriores existem, sem o teto | é o `played_total_disponivel`, coluna de saída — e é ele que o piso de amostra do `task01_base()` lê |
+| 4 | os jogos anteriores de **(C,S) inteiro**, de todos os times | ⚠ **faltava.** O CTE `tabela` (competição-scoped, ADR 0008) dá `points`/`goal_diff`/`ppg`, e o `rank` ranqueia T contra os adversários de grupo. **Um adversário ter o placar corrigido muda o `rank` de T sem tocar em nenhum jogo de T** |
+| 5 | o **elenco** de (C,S) e a tabela de grupos | ⚠ **faltava.** `n_teams` é coluna de saída e sai do conjunto DISTINTO de `team_id` de (C,S) — e é também o conjunto sobre o qual o `rank` ranqueia |
+
+⚠️ O item 5 é **o único insumo do fecho que lê o futuro**, e por isso entra como **conjunto de
+times** e jamais como conjunto de fixtures: time novo em (C,S) muda `n_teams` de verdade e tem de
+quebrar a linha; jogo novo de um time que já estava lá, não. Digitalizá-lo como fixtures
+reproduziria exatamente a armadilha do recorte "por time" que a seção seguinte proíbe.
+
+A digital implementada é, portanto, **mais fina** que a enumeração original — e essa é a direção
+segura: digital mais fina que o fecho só declara não-comparável uma linha que era comparável
+(perde cobertura); digital mais grossa que o fecho declara comparável uma linha cujo insumo mudou,
+que é mentir. O detalhe insumo a insumo está no cabeçalho de
+`macros/taskf_fingerprint_insumo_pit.sql`.
 
 As três alternativas foram medidas sobre o baseline de 21.078 linhas, e não estimadas:
 
@@ -182,6 +205,12 @@ As três alternativas foram medidas sobre o baseline de 21.078 linhas, e não es
 | por `(competition_id, season)` — o de hoje | 88,1% | **mentirosa**: inclui as linhas que não deveriam ser comparáveis |
 | por **time** (digital do histórico global de T) | 57,1% | **erode até zero** |
 | por **linha** (o fecho exato) | **68,2%** — 14.366 linhas, 25 de 37 partições | **não erode; cresce** |
+
+⚠️ Os 68,2% são a **projeção de erosão** medida na grelha de 26/08 sobre a enumeração de dois
+insumos, não um número que a guarda produza. No instante do congelamento a cobertura é **1,0** por
+construção — foi o que a execução da #123 mediu, 21.374 de 21.374 linhas —, e é dela que a série
+parte. Sob a digital de cinco insumos a projeção é, se algo, um pouco menor que 68,2%, porque a
+digital é mais fina; medir a trajetória de verdade exige a série, que ainda não existe.
 
 ⚠️ **Por que "por time" é a armadilha, e não a resposta óbvia.** Ela *parece* o fecho, mas
 digitaliza o histórico inteiro do time — **incluindo jogos posteriores à linha**, que a linha não

--- a/dbt_futebol/macros/taskf_fingerprint_insumo_pit.sql
+++ b/dbt_futebol/macros/taskf_fingerprint_insumo_pit.sql
@@ -1,60 +1,222 @@
 {#
-    Impressão digital do INSUMO do int_futebol_team_form_pit, por (competition_id, season).
+    Impressão digital do INSUMO do int_futebol_team_form_pit, POR LINHA (fixture_id, team_id).
 
     Existe para que a Costura A (task [F], issue #49, ADR 0007) possa ser exata sem ser frágil.
     O insumo do modelo é vivo — fixture novo, resultado que entra, jogo remarcado —, e nada disso
-    é regressão, mas tudo isso muda a saída. A guarda então compara só as partições cujo insumo é
-    idêntico ao do congelamento, e nelas exige igualdade linha a linha, sem folga.
+    é regressão, mas tudo isso muda a saída. A guarda então compara só as LINHAS cujo insumo é
+    idêntico ao do congelamento, e nelas exige igualdade sem folga.
 
-    O recorte por (competition_id, season) é sólido porque no caminho DEFAULT a linha de uma
-    âncora em (C,S) é função só dos fixtures de (C,S) e das standings de (C,S): os dois joins do
-    modelo são escopados pelos dois campos. Sob pit_escopo=todas isso deixa de valer — e é aí que
-    a guarda deve mesmo falhar, porque a var saiu do default.
+    ⚠️ O RECORTE MUDOU NA #123, E O BASELINE FOI RECONGELADO NO MESMO COMMIT.
+
+    Até 26/08/2026 o recorte era por (competition_id, season), e a justificativa escrita aqui era:
+    "no caminho DEFAULT a linha de uma âncora em (C,S) é função só dos fixtures de (C,S) e das
+    standings de (C,S)". A #91 tornou `pit_escopo: todas` o DEFAULT e essa premissa morreu — sob
+    `todas` a linha lê o histórico do time em TODA competição. A partição ficou mais grossa que o
+    fecho da conta, e partição mais grossa que o fecho não fica frouxa: fica MENTIROSA. Ela declara
+    comparáveis linhas cujo insumo mudou fora do recorte. Medido em 26/08: o Brasileirão 2026 casou
+    byte a byte na digital antiga (380 fixtures, `fp_fixtures` idêntico) e ainda assim divergiu em
+    60 linhas, porque os 20 times dele também jogam Libertadores e Copa do Brasil.
+
+    Emenda à ADR 0007, e o verbete "Fecho de uma linha" no glossário do CONTEXT.md.
+
+    ─────────────────────────────────────────────────────────────────────────────────────────────
+    O FECHO DA CONTA, lido do SQL do modelo e não da intuição. A linha (âncora F em C/S, time T) é
+    função de CINCO coisas — e não das duas que o corpo da spec da #123 enumerou. A enumeração da
+    spec ("(a) os fixtures de T em toda competição e (b) as standings de (C,S)") é aproximação da
+    grelha; o que vale é o critério de aceite dela, "o fecho da conta". As três que faltavam estão
+    marcadas ⚠ FALTAVA NA SPEC.
+
+      1. a própria âncora F — `fixture_id, competition, competition_id, season, kickoff_utc` e os
+         dois `team_id`. ⚠️ SEM status/placar de F: a linha de F não lê o resultado de F (o
+         `team_log` do modelo exige `kickoff < kickoff(F)`, estrito). Digitalizar o placar de F
+         faria toda linha quebrar quando o próprio jogo acontecesse — e aí o recorte por linha
+         erodiria como o antigo, que é o defeito que ele existe para não ter.
+
+      2. os 10 jogos encerrados ANTERIORES de T, em QUALQUER competição — o `pares` do modelo
+         trunca em `tamanho_do_recorte` (QUALIFY ROW_NUMBER <= 10), então só a identidade desses 10
+         entra nos agregados de forma. Correção num 11º jogo anterior não muda saída nenhuma, e
+         digitalizar o histórico inteiro derrubaria linha por insumo que ela não lê.
+
+      3. QUANTOS jogos anteriores existem, SEM o teto — é o `played_total_disponivel`, que sai de
+         `COUNT(...) OVER (PARTITION BY fixture_id, team_id)` avaliado ANTES do QUALIFY. É coluna
+         de saída, e o piso de amostra do task01_base() lê ELA, não o played_total (que satura).
+
+      4. ⚠ FALTAVA NA SPEC — os jogos encerrados anteriores de (C,S) INTEIRO, de TODOS os times e
+         não só de T. É o CTE `tabela` do modelo (competição-scoped por decisão, ADR 0008) que
+         alimenta `points`, `goal_diff` e `ppg`, e é sobre ele que o `rank` faz `ROW_NUMBER() OVER
+         (PARTITION BY fixture_id, group_name ORDER BY tb.points DESC, tb.wins_total DESC, ...)`.
+         **Um adversário de grupo ter o placar corrigido muda o `rank` de T sem tocar em nenhum
+         jogo de T.** Uma digital que só olhasse o histórico de T seria mentirosa exatamente aqui —
+         o mesmo defeito da partição antiga, um grão abaixo.
+
+      5. ⚠ FALTAVA NA SPEC (o elenco) — o ELENCO de (C,S) e a tabela de grupos:
+         - `league_teams`/`league_size` saem de `targets`, ou seja, do conjunto DISTINTO de
+           `team_id` de (C,S) — inclusive dos jogos FUTUROS. É de onde vem `n_teams`, coluna de
+           saída, e é também o conjunto de adversários sobre o qual o `rank` ranqueia.
+           ⚠️ É o único insumo do fecho que lê o futuro, e por isso ele entra como CONJUNTO DE
+           TIMES e jamais como conjunto de fixtures: time novo em (C,S) muda `n_teams` de verdade e
+           TEM de quebrar a linha; jogo novo de um time que já estava lá, não. Digitalizar fixtures
+           aqui reproduziria a armadilha do recorte "por time" que a spec proíbe — aquela em que o
+           Palmeiras jogar amanhã invalida a linha dele de 2024.
+         - `team_group`, do `fact_standings_snapshot` com o MESMO QUALIFY do modelo: o insumo que
+           ele de fato lê, e não a tabela crua (o snapshot ganha uma linha por dia por time, e
+           digitalizar o cru mudaria todo dia — a guarda passaria em branco).
+
+    ─────────────────────────────────────────────────────────────────────────────────────────────
+    POR QUE ELE NÃO ERODE, que é a propriedade que o recorte por (C,S) não tinha: para âncora de
+    kickoff JÁ PASSADO os cinco insumos são fatos do passado e param de se mexer. Jogo novo na
+    competição entra no fecho das âncoras FUTURAS, não no das passadas. A cobertura cresce com o
+    tempo em vez de erodir — e o piso deixa de ser guarda de erosão para ser guarda de VACUIDADE
+    (ver o cabeçalho do teste). Os dois eroderes legítimos que sobram são raros e reais: correção de
+    placar de jogo antigo, e time novo entrando em (C,S) — este esperado nas copas de mata-mata,
+    onde a cobertura é função da FASE (ver `docs/TASKF_RESULTADOS.md`, Copa do Brasil).
+
+    ⚠️ ELA É DEFAULT-ONLY, como a guarda que a lê. O fecho acima é o do caminho `todas` +
+    `ultimos_10`, que desde a #91 É o default e É produção. Sob outra célula (`da_competicao` /
+    `temporada`) o modelo lê outro conjunto e esta digital não o descreve — o que está certo: a
+    guarda é vermelha por desenho fora do default, e é essa a primeira falsificação registrada no
+    cabeçalho do teste.
 
     ⚠️ ESTA DEFINIÇÃO É CONTRATO CONGELADO. Ela é usada nos dois lados da comparação: uma vez em
-    analyses/taskf_congela_baseline.sql, que gravou futebol_taskF.baseline_pit_fingerprint, e a
-    cada execução em tests/assert_taskf_pit_default_igual_baseline.sql. Mudar o que entra no
-    FARM_FINGERPRINT muda os valores e faz NENHUMA partição casar contra o baseline já gravado —
-    a guarda não fica vermelha, fica VAZIA, que é pior. Por isso as duas pontas leem daqui e não
-    de cópias: cópia que precisa ficar idêntica para sempre não fica. Se um dia for mesmo preciso
-    mudar, o baseline tem de ser recongelado no mesmo commit — decisão de quem revisa, não passo
-    de rotina.
+    analyses/taskf_congela_baseline.sql, que grava futebol_taskF.baseline_pit_fingerprint_linha, e
+    a cada execução em tests/assert_taskf_pit_default_igual_baseline.sql. Mudar o que entra no
+    FARM_FINGERPRINT muda os valores e faz NENHUMA linha casar contra o baseline já gravado — e a
+    guarda não fica vermelha, fica VAZIA. É o piso de cobertura que transforma essa vacuidade em
+    vermelho barulhento, e é essa a segunda falsificação registrada no cabeçalho do teste. Por isso
+    as duas pontas leem daqui e não de cópias: cópia que precisa ficar idêntica para sempre não
+    fica. Se um dia for mesmo preciso mudar, o baseline tem de ser recongelado NO MESMO COMMIT —
+    decisão de quem revisa, não passo de rotina.
 
-    Emite UMA CTE no escopo do chamador, `fp_insumo_pit`, com uma linha por (competition_id,
-    season) e as colunas n_fixtures / fp_fixtures / n_grupos / fp_standings. Uma CTE do chamador
-    com esse nome a sombreia em silêncio.
+    Emite UMA CTE no escopo do chamador, `fp_insumo_por_linha`, com uma linha por (fixture_id,
+    team_id). Uma CTE do chamador com esse nome a sombreia em silêncio.
+
+    ⚠️ A CTE se chama `fp_insumo_por_linha` e a coluna, `fp_insumo_linha` — de propósito, e não
+    por descuido. No BigQuery um nome de tabela usado como expressão é o STRUCT da linha inteira,
+    então CTE e coluna homônimas fazem `SELECT fp_insumo_linha FROM fp_insumo_linha` devolver o
+    struct em vez do inteiro, e o erro só aparece quando alguém tenta agregar
+    ("Aggregate functions with DISTINCT cannot be used with arguments of type STRUCT").
 
     Uso:
 
         WITH {{ taskf_fingerprint_insumo_pit() }},
-        casadas AS (SELECT ... FROM fp_insumo_pit JOIN baseline_pit_fingerprint USING (...))
+        linhas_casadas AS (
+            SELECT a.fixture_id, a.team_id
+            FROM fp_insumo_por_linha a
+            JOIN {{ source('futebol_taskF', 'baseline_pit_fingerprint_linha') }} b
+                USING (fixture_id, team_id)
+            WHERE a.fp_insumo_linha = b.fp_insumo_linha
+        )
 #}
 
 {% macro taskf_fingerprint_insumo_pit() %}
 
-fp_fixtures_pit AS (
+fp_fixtures_base AS (
+    SELECT
+        fixture_id, competition, competition_id, season,
+        home_team_id, away_team_id, kickoff_utc,
+        status_short, score_fulltime_home, score_fulltime_away
+    FROM {{ ref('fact_fixtures') }}
+),
+
+-- O grão de saída do modelo: os dois lados de cada jogo, inclusive jogo futuro.
+fp_targets AS (
+    SELECT fixture_id, competition, competition_id, season, kickoff_utc,
+           home_team_id AS team_id, away_team_id AS adversario_id
+    FROM fp_fixtures_base
+    UNION ALL
+    SELECT fixture_id, competition, competition_id, season, kickoff_utc,
+           away_team_id, home_team_id
+    FROM fp_fixtures_base
+),
+
+-- Mesma definição de "partida encerrada" do modelo (#71: AET/PEN entram), e mesmo par
+-- (time, jogo). `fixture_id` entra na digital porque BIT_XOR de dois structs idênticos se
+-- CANCELA: dois jogos com o mesmo placar, mesmo mando e mesmo kickoff sumiriam da impressão.
+fp_team_log AS (
+    SELECT fixture_id, competition_id, season, kickoff_utc,
+           home_team_id AS team_id, TRUE AS is_home,
+           score_fulltime_home AS gf, score_fulltime_away AS ga
+    FROM fp_fixtures_base
+    WHERE {{ futebol_jogo_encerrado() }}
+    UNION ALL
+    SELECT fixture_id, competition_id, season, kickoff_utc,
+           away_team_id, FALSE,
+           score_fulltime_away, score_fulltime_home
+    FROM fp_fixtures_base
+    WHERE {{ futebol_jogo_encerrado() }}
+),
+
+-- (2) e (3) do fecho: os 10 anteriores do TIME em qualquer competição, e a contagem SEM teto.
+-- O COUNT é window (avaliado antes do QUALIFY), igual ao `played_disponivel` do modelo.
+fp_hist_time_pares AS (
+    SELECT
+        t.fixture_id,
+        t.team_id,
+        l.fixture_id     AS log_fixture_id,
+        l.competition_id AS log_competition_id,
+        l.season         AS log_season,
+        l.kickoff_utc    AS log_kickoff_utc,
+        l.is_home,
+        l.gf,
+        l.ga,
+        COUNT(l.fixture_id) OVER (PARTITION BY t.fixture_id, t.team_id) AS n_hist_time_disponivel
+    FROM fp_targets t
+    LEFT JOIN fp_team_log l
+        ON  l.team_id     = t.team_id
+        AND l.kickoff_utc < t.kickoff_utc
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY t.fixture_id, t.team_id
+        ORDER BY l.kickoff_utc DESC
+    ) <= {{ taskf_eixos().tamanho_do_recorte }}
+),
+
+fp_hist_time AS (
+    SELECT
+        fixture_id,
+        team_id,
+        MAX(n_hist_time_disponivel) AS n_hist_time_disponivel,
+        COUNT(log_fixture_id)       AS n_hist_time_usado,
+        BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(
+            log_fixture_id, log_competition_id, log_season,
+            log_kickoff_utc, is_home, gf, ga
+        ))))                        AS fp_hist_time
+    FROM fp_hist_time_pares
+    GROUP BY fixture_id, team_id
+),
+
+-- (4) do fecho: os jogos anteriores da COMPETIÇÃO/temporada da âncora, de TODOS os times. É o
+-- insumo do CTE `tabela` (ADR 0008) e portanto de points/goal_diff/ppg — e do `rank` de T, que
+-- ranqueia contra os adversários de grupo. Por ÂNCORA: as duas linhas do jogo dividem o valor.
+fp_hist_comp_por_ancora AS (
+    SELECT
+        a.fixture_id,
+        COUNT(l.fixture_id) AS n_hist_comp,
+        BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(
+            l.fixture_id, l.team_id, l.is_home, l.gf, l.ga, l.kickoff_utc
+        ))))                AS fp_hist_comp
+    FROM fp_fixtures_base a
+    LEFT JOIN fp_team_log l
+        ON  l.competition_id = a.competition_id
+        AND l.season         = a.season
+        AND l.kickoff_utc    < a.kickoff_utc
+    GROUP BY a.fixture_id
+),
+
+-- (5a) do fecho: o ELENCO de (C,S) — conjunto DISTINTO de team_id, nunca de fixtures. Ver o
+-- cabeçalho: é o único insumo que lê o futuro, e digitalizá-lo como fixtures reproduziria a
+-- armadilha do recorte "por time".
+fp_roster AS (
     SELECT
         competition_id,
         season,
-        COUNT(*) AS n_fixtures,
-        -- ⚠️ #71: `score_fulltime_*` entrou porque o PIT passou a LER essas colunas em vez de
-        -- `goals_*`. Sem elas, um jogo cujo placar de tempo normal fosse corrigido sem que
-        -- `goals_*` mudasse passaria pela guarda como se o insumo estivesse intacto — deriva
-        -- real, muda. `goals_*` fica: a `fact_fixtures` continua expondo as duas, e digitalizar
-        -- as quatro custa nada e cobre os dois idiomas.
-        BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(
-            fixture_id, competition, home_team_id, away_team_id,
-            kickoff_utc, status_short, goals_home, goals_away,
-            score_fulltime_home, score_fulltime_away
-        )))) AS fp_fixtures
-    FROM {{ ref('fact_fixtures') }}
+        COUNT(*)                                                   AS n_roster,
+        BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(team_id)))) AS fp_roster
+    FROM (SELECT DISTINCT competition_id, season, team_id FROM fp_targets)
     GROUP BY competition_id, season
 ),
 
--- Mesmo QUALIFY do modelo: o insumo que ele de fato lê, e não a tabela crua. O snapshot ganha
--- uma linha por dia por time, então digitalizar o cru mudaria todo dia e jogaria todas as
--- competições fora da comparação — a guarda passaria em branco.
-fp_team_group_pit AS (
+-- (5b) do fecho: o grupo de cada time, com o MESMO QUALIFY do modelo.
+fp_team_group AS (
     SELECT league_id AS competition_id, season, team_id, group_name
     FROM {{ ref('fact_standings_snapshot') }}
     QUALIFY ROW_NUMBER() OVER (
@@ -64,26 +226,68 @@ fp_team_group_pit AS (
     ) = 1
 ),
 
-fp_standings_pit AS (
+fp_standings AS (
     SELECT
         competition_id,
         season,
         COUNT(*) AS n_grupos,
         BIT_XOR(FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(team_id, group_name)))) AS fp_standings
-    FROM fp_team_group_pit
+    FROM fp_team_group
     GROUP BY competition_id, season
 ),
 
-fp_insumo_pit AS (
+fp_insumo_por_linha AS (
     SELECT
-        f.competition_id,
-        f.season,
-        f.n_fixtures,
-        f.fp_fixtures,
-        COALESCE(s.n_grupos, 0) AS n_grupos,
-        s.fp_standings
-    FROM fp_fixtures_pit f
-    LEFT JOIN fp_standings_pit s USING (competition_id, season)
+        t.fixture_id,
+        t.team_id,
+        t.competition_id,
+        t.season,
+
+        -- (1) a âncora, SEM status/placar dela — ver o cabeçalho.
+        FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(
+            t.fixture_id, t.competition, t.competition_id, t.season,
+            t.kickoff_utc, t.team_id, t.adversario_id
+        )))                                   AS fp_ancora,
+
+        COALESCE(h.n_hist_time_disponivel, 0) AS n_hist_time_disponivel,
+        COALESCE(h.n_hist_time_usado, 0)      AS n_hist_time_usado,
+        h.fp_hist_time,
+
+        COALESCE(c.n_hist_comp, 0)            AS n_hist_comp,
+        c.fp_hist_comp,
+
+        COALESCE(r.n_roster, 0)               AS n_roster,
+        r.fp_roster,
+
+        COALESCE(s.n_grupos, 0)               AS n_grupos,
+        s.fp_standings,
+
+        -- A digital combinada. TO_JSON_STRING de STRUCT é determinístico e distingue NULL de
+        -- ausente, então o join da guarda é UMA igualdade — e a diagnose fica nas colunas acima,
+        -- que dizem QUAL dos cinco insumos se mexeu.
+        FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(
+            t.fixture_id, t.competition, t.competition_id, t.season,
+            t.kickoff_utc, t.team_id, t.adversario_id,
+            COALESCE(h.n_hist_time_disponivel, 0),
+            COALESCE(h.n_hist_time_usado, 0),
+            h.fp_hist_time,
+            COALESCE(c.n_hist_comp, 0),
+            c.fp_hist_comp,
+            COALESCE(r.n_roster, 0),
+            r.fp_roster,
+            COALESCE(s.n_grupos, 0),
+            s.fp_standings
+        )))                                   AS fp_insumo_linha
+
+    FROM fp_targets t
+    LEFT JOIN fp_hist_time h
+        ON  h.fixture_id = t.fixture_id AND h.team_id = t.team_id
+    LEFT JOIN fp_hist_comp_por_ancora c
+        ON  c.fixture_id = t.fixture_id
+    LEFT JOIN fp_roster r
+        ON  r.competition_id = t.competition_id AND r.season = t.season
+    LEFT JOIN fp_standings s
+        ON  s.competition_id = t.competition_id AND s.season = t.season
 )
 
 {% endmacro %}

--- a/dbt_futebol/models/staging/sources.yml
+++ b/dbt_futebol/models/staging/sources.yml
@@ -526,38 +526,88 @@ sources:
           sem dbt_loaded_at (que muda a cada build por construção e não é comportamento).
           Lado esquerdo da igualdade de assert_taskf_pit_default_igual_baseline.
 
-      - name: baseline_pit_fingerprint
+      # ⚠️ `baseline_pit_fingerprint` (a digital ANTIGA, por (competition_id, season)) saiu daqui
+      # na #123. A tabela continua no dataset como registro histórico, pelo mesmo precedente das
+      # cópias `baseline_*_pre91`, mas a declaração sai porque source que ninguém lê é convite a
+      # alguém voltar a lê-la — e essa partição é mais grossa que o fecho da conta desde que a #91
+      # virou o default para `pit_escopo: todas`. Ver a emenda à ADR 0007.
+      - name: baseline_pit_fingerprint_linha
         description: >
-          Impressão digital do INSUMO do modelo por (competition_id, season) no instante do
-          congelamento — contagem e BIT_XOR(FARM_FINGERPRINT) dos fixtures e do team_group já
-          resolvido. É o que deixa a Costura A ser exata sem ser frágil: fixture novo, resultado
-          que entra e jogo remarcado mudam legitimamente a saída de uma competição, e a guarda
-          compara só as partições cujo insumo é idêntico ao congelado. Produzida pela macro
-          taskf_fingerprint_insumo_pit(), a MESMA que o teste usa — se as duas divergirem, nenhuma
-          partição casa.
+          Impressão digital do INSUMO do modelo por LINHA (fixture_id, team_id) no instante do
+          congelamento. É o que deixa a Costura A ser exata sem ser frágil: fixture novo, resultado
+          que entra e jogo remarcado mudam legitimamente a saída, e a guarda compara só as linhas
+          cujo insumo é idêntico ao congelado.
+
+          O grão é por linha porque a linha É o fecho da conta desde a #91 — sob `pit_escopo:
+          todas` a linha lê o histórico do time em toda competição, e a partição por
+          (competition_id, season) passou a declarar comparáveis linhas cujo insumo mudou fora do
+          recorte. Ela não ficava frouxa: ficava mentirosa. Emenda à ADR 0007, verbete "Fecho de
+          uma linha" no CONTEXT.md, issue #123.
+
+          Produzida pela macro taskf_fingerprint_insumo_pit(), a MESMA que o teste usa — se as duas
+          divergirem, NENHUMA linha casa e a guarda fica vazia, não vermelha. É o piso de cobertura
+          que transforma essa vacuidade em vermelho.
         columns:
+          - name: fixture_id
+            description: "A âncora de tempo — o jogo cuja linha está sendo digitalizada"
+          - name: team_id
+            description: "O time da linha (um dos dois lados do jogo)"
           - name: competition_id
-            description: "ID da competição (a mesma chave de escopo do join do modelo)"
+            description: "Competição da âncora. Diagnose e legibilidade; não entra no join da guarda."
           - name: season
-            description: "Rótulo de temporada"
-          - name: n_fixtures
-            description: "Quantos fixtures a partição tinha no congelamento"
-          - name: fp_fixtures
+            description: "Temporada da âncora. Diagnose; não entra no join da guarda."
+          - name: fp_ancora
             description: >
-              BIT_XOR(FARM_FINGERPRINT(...)) sobre os campos de fixture que o modelo lê
-              (fixture_id, competition, times, kickoff, status, gols). Independente de ordem.
+              FARM_FINGERPRINT dos campos da PRÓPRIA âncora que a linha lê (fixture_id,
+              competition, competition_id, season, kickoff, os dois team_id). ⚠️ SEM status e SEM
+              placar: a linha de F não lê o resultado de F, e digitalizá-lo faria toda linha
+              quebrar quando o próprio jogo acontecesse.
+          - name: n_hist_time_disponivel
+            description: >
+              Quantos jogos encerrados anteriores o time tinha, em qualquer competição, SEM o teto
+              do recorte. É o insumo do `played_total_disponivel`, que é coluna de saída e é o que
+              o piso de amostra do task01_base() lê.
+          - name: n_hist_time_usado
+            description: "Quantos desses jogos sobreviveram ao teto de 10 e alimentaram as médias."
+          - name: fp_hist_time
+            description: >
+              BIT_XOR(FARM_FINGERPRINT(...)) sobre os 10 jogos anteriores do time, em qualquer
+              competição. `fixture_id` entra no struct porque BIT_XOR de dois structs idênticos se
+              CANCELA. Independente de ordem.
+          - name: n_hist_comp
+            description: "Quantos jogos encerrados de (C,S) inteiro precediam a âncora."
+          - name: fp_hist_comp
+            description: >
+              BIT_XOR(FARM_FINGERPRINT(...)) sobre os jogos anteriores de (C,S) inteiro, de TODOS
+              os times. É o insumo do CTE `tabela` (ADR 0008) e portanto de points/goal_diff/ppg —
+              e do `rank`, que ranqueia o time contra os adversários de grupo. Sem ele a digital
+              seria mentirosa: adversário com placar corrigido muda o rank do time sem tocar em
+              nenhum jogo dele.
+          - name: n_roster
+            description: "Quantos times distintos (C,S) tinha — é o `n_teams`, coluna de saída."
+          - name: fp_roster
+            description: >
+              BIT_XOR(FARM_FINGERPRINT(team_id)) sobre o conjunto DISTINTO de times de (C,S),
+              inclusive os de jogos futuros. ⚠️ Conjunto de TIMES e nunca de fixtures: time novo
+              muda `n_teams` de verdade e tem de quebrar a linha; jogo novo de um time que já
+              estava lá, não. Digitalizar fixtures aqui reproduziria a armadilha do recorte "por
+              time", em que um jogo de amanhã invalida uma linha de 2024.
           - name: n_grupos
-            description: "Quantos times tinham grupo resolvido na partição"
+            description: "Quantos times tinham grupo resolvido em (C,S)"
           - name: fp_standings
             description: >
               BIT_XOR(FARM_FINGERPRINT(...)) sobre (team_id, group_name) do team_group JÁ
-              RESOLVIDO — não do snapshot cru, que ganha uma linha por dia e jogaria todas as
-              competições fora da comparação.
+              RESOLVIDO — não do snapshot cru, que ganha uma linha por dia e jogaria tudo fora da
+              comparação.
+          - name: fp_insumo_linha
+            description: >
+              A digital combinada dos cinco insumos acima. É a ÚNICA coluna que entra no join da
+              guarda; as outras existem para dizer QUAL insumo se mexeu quando a cobertura cai.
 
       - name: baseline_pit_meta
         description: >
-          Quando o baseline foi congelado, de qual commit, e com quantas linhas/partições.
-          Uma linha só.
+          Quando o baseline foi congelado, de qual commit, e com quantas linhas. Uma linha só.
+          ⚠️ A coluna `n_particoes` virou `n_linhas_digital` na #123, junto com o grão da digital.
 
       - name: taskf_teste2_54
         description: >

--- a/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
+++ b/dbt_futebol/tests/assert_taskf_pit_default_igual_baseline.sql
@@ -1,51 +1,61 @@
 {{ config(tags=['taskf']) }}
 -- COSTURA A da task [F] (issue #49, ADR 0007) — o default do PIT não se move sozinho.
 --
--- ⚠️ ESTA GUARDA MUDOU DE SENTIDO NA #91, E O BASELINE FOI RECONGELADO COM ELA.
+-- O QUE ELA AFIRMA: a saída de produção do int_futebol_team_form_pit não mudou desde o
+-- congelamento, nas linhas cujo INSUMO não mudou. Falha = deriva: a saída se mexeu sem que o
+-- insumo tivesse se mexido.
 --
--- O que ela afirmava até 24/08/2026: a ADR 0007 deixou no código de produção duas vars que
--- produção nunca passava, e prometeu que o DEFAULT delas preservava o comportamento anterior.
--- A guarda transformava a promessa em fato verificado, e falha significava "o andaime da
--- medição vazou para o caminho que o board serve".
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+-- ⚠️ O RECORTE DA COMPARAÇÃO MUDOU NA #123: DE PARTIÇÃO PARA LINHA.
 --
--- Essa premissa morreu por decisão, não por acidente: a #91 (ADR 0010, Recomendação 1 da [F])
--- virou os defaults para `todas` + `ultimos_10` — a célula `ambos` —, e produção passou a USAR
--- o default. "O default reproduz o comportamento de antes das vars" deixou de ser verdade no
--- mesmo commit em que deixou de ser desejável.
+-- Até 26/08/2026 a guarda comparava as PARTIÇÕES (competition_id, season) cuja impressão digital
+-- do insumo estivesse intacta. Esse recorte era sólido enquanto o default fosse
+-- `da_competicao`/`temporada`: a linha de uma âncora em (C,S) era função só de (C,S). A #91
+-- tornou `todas` o DEFAULT, a linha passou a ler o histórico do time em TODA competição, e a
+-- partição virou mais grossa que o fecho da conta.
 --
--- O que ela afirma AGORA: o default não se move sozinho. O baseline É REGRAVADO (pelo
--- analyses/taskf_congela_baseline.sql) a partir da célula `ambos` com AET/PEN no histórico (#71),
--- e a guarda segue comparando linha a linha contra ele.
+-- Partição mais grossa que o fecho não fica frouxa: fica MENTIROSA — declara comparáveis linhas
+-- cujo insumo mudou fora do recorte. Foi o que a guarda passou a acusar como se fosse regressão:
+-- em 26/08 ela estava vermelha com 60 linhas, todas do Brasileirão 2026, cuja digital de insumo
+-- casava BYTE A BYTE (380 fixtures, mesmo `fp_fixtures`). Os 20 times dele também jogam
+-- Libertadores e Copa do Brasil, e foram essas duas que se mexeram. Recongelar não resolveria:
+-- ficaria verde até a próxima partida em qualquer competição do portfólio, e voltaria. É a
+-- "guarda permanentemente vermelha morre ignorada" na versão lenta.
 --
--- ✅ O RECONGELAMENTO ACONTECEU: 2026-08-25 17:59 UTC, de PRODUÇÃO, carimbado com `887a1f9` —
--- o `PROCEDENCIA_SHA` da imagem que produziu a tabela, que é o merge da #91/#71. 21.078 linhas
--- e 37 partições, contra 21.054 do congelamento de 12/08 (commit `a3b954e`, célula `base`), que
--- ficou preservado nas cópias `baseline_*_pre91`. Rodada a guarda logo depois, `--target prod`:
--- verde.
+-- Hoje o recorte é o FECHO da conta — por (fixture_id, team_id). O que compõe esse fecho, e por
+-- que ele são CINCO insumos e não os dois que o corpo da spec da #123 enumerava, está no
+-- cabeçalho de macros/taskf_fingerprint_insumo_pit.sql. Emenda à ADR 0007; verbete "Fecho de uma
+-- linha" no glossário do CONTEXT.md.
 --
--- ⚠️ Ele tinha de sair de PRODUÇÃO, não do `futebol_taskF`: congelar do dataset de medição
--- carimbaria o baseline de produção com os fatos parados de 12/08, que é pior que não
--- recongelar. A receita do `taskf_congela_baseline.sql` dizia `--target taskF` e foi corrigida
--- no mesmo commit — ela é anterior a esta virada de sentido e mandava fazer exatamente o que
--- este parágrafo proíbe.
+-- ✅ O RECONGELAMENTO ACONTECEU NO MESMO COMMIT: sem ele nenhuma linha casaria — a guarda não
+-- ficaria vermelha, ficaria VAZIA. 2026-08-28 14:25:03 UTC, de PRODUÇÃO, carimbo `687950f` (o
+-- `PROCEDENCIA_SHA` do job `dbt-futebol`), 21.374 linhas. Receita e histórico dos três
+-- congelamentos em analyses/taskf_congela_baseline.sql.
 --
--- Entre a #91 e esse recongelamento a guarda ficou VERMELHA em qualquer build do PIT no default,
--- e é por isso que a receita da âncora da #82 a exclui por escrito. Deixou de ser guarda de
--- vazamento-de-andaime e virou guarda de DERIVA: falha = a saída de produção mudou sem que o
--- insumo tenha mudado, que é o mesmo modo de falha que ela sempre pegou, só que agora sobre o
--- caminho que o board de fato serve.
+-- Rodada logo depois, `--target prod`: VERDE, com cobertura **1,0** — 21.374 de 21.374 linhas
+-- comparadas. Cobertura cheia é o esperado no instante do congelamento, e é dela que a série de
+-- erosão (ou de crescimento) vai partir.
 --
--- É o cabeçalho da própria guarda que autorizava esta saída: "as duas saídas honestas são
--- recongelar o baseline de propósito (no mesmo commit da mudança que o justifica) ou baixar o
--- piso de propósito — as duas explícitas, nenhuma silenciosa".
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+-- HISTÓRICO DE SENTIDO (a guarda já quis dizer três coisas, e as três estão registradas):
 --
--- QUEM RODA. Não é o agendado: a tag é `taskf` e não `guarda`, de propósito — o pipeline horário
--- executa `dbt test --select tag:guarda` e o ticket que criou este teste (#50) promete que nada
--- do agendado mudou. Quem roda é a própria medição, que materializa a camada de premissas com
--- `dbt build` a cada célula (#51 a #54); a #52 chega a exigir por escrito que "a Costura A segue
--- verde". O teste é executado, portanto, exatamente quando a var pode ter vazado — que é quando
--- a pergunta dele importa. Fora disso: `dbt build --target taskF --select
--- int_futebol_team_form_pit`.
+--   até 24/08 — "o default preserva o comportamento de antes das vars da ADR 0007". Essa premissa
+--   morreu por DECISÃO na #91 (ADR 0010), que virou os defaults para `todas` + `ultimos_10` e pôs
+--   produção a USAR o default.
+--
+--   25/08 — recongelada de PRODUÇÃO contra a célula `ambos` (21.078 linhas, 37 partições, carimbo
+--   `887a1f9`), virando guarda de DERIVA sobre o caminho que o board de fato serve. O baseline
+--   anterior (12/08, commit `a3b954e`, célula `base`) ficou nas cópias `baseline_*_pre91`.
+--
+--   28/08 (#123) — mesmo sentido, recorte novo: a comparação passa a ser por linha, porque a
+--   partição parou de ser o fecho quando o default mudou.
+--
+-- QUEM RODA. Não é o agendado: a tag é `taskf` e não `guarda`, de propósito, pelo precedente da
+-- #33 — guarda com baseline permanente não entra na tag, e o ticket que criou este teste (#50)
+-- promete que nada do agendado mudou. Quem roda é a própria medição, que materializa a camada de
+-- premissas com `dbt build` a cada célula (#51 a #54); a #52 exige por escrito que "a Costura A
+-- segue verde". O teste é executado, portanto, exatamente quando a var pode ter vazado. Fora
+-- disso: `dbt test --target prod --select assert_taskf_pit_default_igual_baseline`.
 --
 -- Igualdade EXATA, sem tolerância: o modelo lê só fact_fixtures e fact_standings_snapshot — é
 -- determinístico, não encosta em odds, e por isso não há deriva legítima para acomodar. A
@@ -56,35 +66,74 @@
 -- ⚠️ O que é restringido é QUAIS LINHAS são comparáveis, nunca QUANTO elas podem diferir. O
 -- porquê, e o contrato congelado da impressão digital, estão na macro
 -- taskf_fingerprint_insumo_pit — a MESMA que gravou o baseline. Se as duas pontas divergirem,
--- nenhuma partição casa.
+-- nenhuma linha casa.
 --
--- PISO DE COBERTURA. Restringir linhas comparáveis tem um modo de falha próprio: a cobertura
--- encolhe sozinha conforme o insumo anda, e uma guarda que compara 3 linhas continua verde
--- dizendo o mesmo que uma que compara 21 mil. Por isso a cobertura é medida e tem piso declarado
--- (`taskf_cobertura_minima`, hoje 0,5 das linhas do baseline): abaixo dele o teste FALHA, com os
--- números na saída. O piso não é alto de propósito — durante a [F] as competições da temporada
--- corrente saem da comparação legitimamente, uma a uma, conforme os jogos acontecem. Ele pega a
--- erosão estrutural, não a natural. Quando ele disparar, as duas saídas honestas são recongelar
--- o baseline de propósito (no mesmo commit da mudança que o justifica) ou baixar o piso de
--- propósito — as duas explícitas, nenhuma silenciosa.
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+-- PISO DE COBERTURA (`taskf_cobertura_minima`, 0,5) — O NÚMERO É O MESMO, O SENTIDO MUDOU.
 --
--- ⚠️ A FALSIFICAÇÃO INVERTEU DE LADO NA #91. Ela foi falsificada uma vez com
--- `--vars '{pit_escopo: todas}'`, que a deixava vermelha (12.868 divergências) — porque `todas`
--- era a célula juntada e o baseline era o da célula `base`. Hoje `todas` + `ultimos_10` É o
--- default e o baseline, então quem a deixa vermelha agora é o caminho ANTIGO:
+-- Sob o recorte por partição ele era guarda de EROSÃO: a cobertura encolhia sozinha conforme o
+-- insumo andava, e uma guarda que compara 3 linhas continua verde dizendo o mesmo que uma que
+-- compara 21 mil.
 --
---   dbt build --target taskF --select int_futebol_team_form_pit \
---     --vars '{pit_escopo: da_competicao, pit_recorte: temporada}' \
---     --exclude assert_taskf_pit_default_igual_baseline
+-- Sob o recorte por LINHA ele é guarda de VACUIDADE. O fecho de uma âncora de kickoff já passado
+-- é feito só de fatos do passado: ele para de se mexer, e a cobertura CRESCE com o tempo em vez de
+-- erodir. O que o piso pega agora é o passado sendo reescrito em massa — e, sobretudo, o caso
+-- `cobertura = 0`, que é o que acontece quando a digital muda sem recongelamento. Sem o piso isso
+-- passaria em branco; com ele, vira vermelho barulhento.
 --
--- A regra por trás não mudou: esta guarda é default-only por definição, então QUALQUER célula
--- que não seja o default a deixa vermelha por desenho e tem de excluí-la. O que mudou é qual
--- célula é o default. Ela segue sendo a única exclusão que a medição precisa.
+-- ⚠️ O 0,5 NÃO FOI RECALIBRADO, de propósito (#123 diz isso por escrito). Recalibrá-lo exigiria
+-- medir uma trajetória de cobertura sob o recorte novo que ninguém mediu — a projeção da grelha de
+-- 26/08 era 68,2% no instante da medição, e a afirmação de que ela cresce é dedução do fecho, não
+-- série observada. Quando houver série, recalibrar é decisão explícita, no mesmo commit.
 --
--- ⚠️ Esta receita já mandou excluir também o `assert_pit_first_game_has_no_history`. NÃO EXCLUA
--- MAIS (#52): a partição dele passou a seguir os eixos da célula, ele é verde nas quatro, e
--- excluí-lo faz a célula rodar sem guarda de look-ahead — o defeito (Task 0) que contaminou a
--- medição que a [F] existe para refazer.
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+-- AS DUAS FALSIFICAÇÕES, com comando e resultado.
+--
+-- 1) CÉLULA FORA DO DEFAULT DEIXA A GUARDA VERMELHA POR DESENHO. Esta guarda é default-only por
+--    definição, então qualquer célula que não seja o default tem de excluí-la.
+--
+--      dbt build --target taskF --select int_futebol_team_form_pit \
+--        --vars '{pit_escopo: da_competicao, pit_recorte: temporada}' \
+--        --exclude assert_taskf_pit_default_igual_baseline
+--      dbt test  --target taskF --select assert_taskf_pit_default_igual_baseline \
+--        --vars '{pit_escopo: da_competicao, pit_recorte: temporada}'
+--
+--    EXECUTADA EM 2026-08-28 14:28 UTC, contra o dataset de medição: VERMELHA, **27.278**
+--    divergências — 13.639 `so_no_baseline` + 13.639 `so_no_atual`, simétricas porque a célula
+--    `base` reescreve o valor de toda linha comparável em vez de perder linhas. NENHUMA linha de
+--    `cobertura_abaixo_do_piso`: casaram 13.639 das 21.374 do baseline (63,8%, acima do piso), e é
+--    isso que torna a falsificação boa — ela é vermelha por CONTEÚDO, não por vacuidade, que é o
+--    modo de falha distinto que a falsificação 2 cobre.
+--
+--    ⚠️ A cobertura não é 100% aqui porque a comparação corre com `--target taskF` e a digital sai
+--    da CÓPIA de `fact_fixtures` daquele dataset, que é mais velha que a de produção. Isso é
+--    esperado e não enfraquece a falsificação.
+--
+--    ⚠️ Este comando SOBRESCREVE `futebol_taskF.int_futebol_team_form_pit` com a célula `base` —
+--    é o fluxo documentado no cabeçalho do modelo, uma tabela de trabalho por célula. Depois desta
+--    execução ela foi reconstruída no default. Segue sendo a única exclusão que a medição precisa.
+--    ⚠️ NÃO exclua também o `assert_pit_first_game_has_no_history` (#52): ele é verde nas quatro
+--    células, e excluí-lo faz a célula rodar sem guarda de look-ahead — o defeito (Task 0) que a
+--    [F] existe para refazer.
+--
+-- 2) RECORTE NOVO SEM RECONGELAR O BASELINE TEM DE DAR **VAZIA** — a falsificação que a #123
+--    acrescentou, porque é a falha que o macro descreve e que produzir por acidente é fácil.
+--    Perturbar a digital sem regravar o baseline (um campo a mais no STRUCT que produz o
+--    `fp_insumo_linha`, em macros/taskf_fingerprint_insumo_pit.sql) e rodar:
+--
+--      dbt test --target prod --select assert_taskf_pit_default_igual_baseline
+--
+--    EXECUTADA EM 2026-08-28 14:26 UTC: VERMELHA com **uma** linha só, motivo
+--    `cobertura_abaixo_do_piso`, com
+--
+--      {"linhas_comparadas":0, "linhas_no_baseline":21374, "cobertura":0, "piso":0.5,
+--       "linhas_casadas_n":0, "linhas_na_digital_do_baseline":21374}
+--
+--    ZERO divergências de conteúdo — porque não há conteúdo comparado. É exatamente o modo "vazia"
+--    ficando barulhento por causa do piso: sem ele a saída seria zero linhas e a guarda passaria
+--    dizendo NADA sobre 21.374 linhas. Perturbação revertida em seguida e a guarda voltou a VERDE
+--    (14:27 UTC), o que é a segunda metade da falsificação — uma falsificação que não volta ao
+--    verde não provou o que dizia provar.
 
 {% set colunas = [
     'fixture_id', 'team_id', 'competition', 'competition_id', 'season', 'kickoff_utc',
@@ -99,24 +148,22 @@
 
 WITH {{ taskf_fingerprint_insumo_pit() }},
 
--- As partições em que o insumo não se mexeu desde o congelamento. IS NOT DISTINCT FROM porque
--- fp_standings é NULL em competição sem tabela (Copa do Brasil) — NULL = NULL tem de casar.
-particoes_casadas AS (
-    SELECT b.competition_id, b.season
-    FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }} b
-    JOIN fp_insumo_pit a
-        ON  a.competition_id = b.competition_id
-        AND a.season         = b.season
-    WHERE a.n_fixtures    = b.n_fixtures
-      AND a.fp_fixtures   = b.fp_fixtures
-      AND a.n_grupos      = b.n_grupos
-      AND a.fp_standings IS NOT DISTINCT FROM b.fp_standings
+-- As LINHAS em que o insumo não se mexeu desde o congelamento. Uma igualdade só, sobre a digital
+-- combinada: as colunas de componente existem no baseline para dizer QUAL insumo se mexeu quando
+-- a cobertura cai, não para entrar no join.
+linhas_casadas AS (
+    SELECT b.fixture_id, b.team_id
+    FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint_linha') }} b
+    JOIN fp_insumo_por_linha a
+        ON  a.fixture_id = b.fixture_id
+        AND a.team_id    = b.team_id
+    WHERE a.fp_insumo_linha = b.fp_insumo_linha
 ),
 
 atual AS (
     SELECT {{ colunas | join(', ') }}
     FROM {{ ref('int_futebol_team_form_pit') }}
-    JOIN particoes_casadas USING (competition_id, season)
+    JOIN linhas_casadas USING (fixture_id, team_id)
 ),
 
 baseline_completo AS (
@@ -127,7 +174,7 @@ baseline_completo AS (
 baseline AS (
     SELECT {{ colunas | join(', ') }}
     FROM baseline_completo
-    JOIN particoes_casadas USING (competition_id, season)
+    JOIN linhas_casadas USING (fixture_id, team_id)
 ),
 
 divergencias AS (
@@ -150,23 +197,24 @@ SELECT
     'cobertura_abaixo_do_piso' AS motivo,
     TO_JSON_STRING(STRUCT(
         linhas_comparadas, linhas_no_baseline, cobertura, piso,
-        particoes_casadas_n, particoes_no_baseline
+        linhas_casadas_n, linhas_na_digital_do_baseline
     )) AS linha
 FROM (
     SELECT
         linhas_comparadas,
         linhas_no_baseline,
-        particoes_casadas_n,
-        particoes_no_baseline,
+        linhas_casadas_n,
+        linhas_na_digital_do_baseline,
         {{ var('taskf_cobertura_minima', 0.5) }} AS piso,
         SAFE_DIVIDE(linhas_comparadas, linhas_no_baseline) AS cobertura
     FROM (
         SELECT
-            (SELECT COUNT(*) FROM atual)               AS linhas_comparadas,
-            (SELECT COUNT(*) FROM baseline_completo)   AS linhas_no_baseline,
-            (SELECT COUNT(*) FROM particoes_casadas)   AS particoes_casadas_n,
-            (SELECT COUNT(*) FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint') }})
-                                                       AS particoes_no_baseline
+            (SELECT COUNT(*) FROM atual)              AS linhas_comparadas,
+            (SELECT COUNT(*) FROM baseline_completo)  AS linhas_no_baseline,
+            (SELECT COUNT(*) FROM linhas_casadas)     AS linhas_casadas_n,
+            (SELECT COUNT(*)
+             FROM {{ source('futebol_taskF', 'baseline_pit_fingerprint_linha') }})
+                                                      AS linhas_na_digital_do_baseline
     )
 )
 WHERE cobertura IS NULL OR cobertura < piso


### PR DESCRIPTION
Fecha a #123. A Costura A (`assert_taskf_pit_default_igual_baseline`) volta ao verde, e volta
verde **pelo motivo certo**: o recorte da comparação passou a ser o fecho da conta.

## O diagnóstico, confirmado

A #91 tornou `pit_escopo: todas` o default. Sob `todas` a linha de um jogo do Brasileirão lê o
histórico do time em **toda** competição, e a partição por `(competition_id, season)` ficou mais
grossa que o fecho — declarando comparáveis linhas cujo insumo mudou fora do recorte.

## ⚠️ Um desvio da spec, e por quê

O corpo da #123 enumera o fecho como **dois** insumos: *"(a) os fixtures de T com `kickoff <
kickoff(F)`, em toda competição, e (b) as standings correntes de (C,S)"*. **Ler o SQL do
`int_futebol_team_form_pit` para escrever a digital mostrou que faltavam três**, e uma delas
reproduziria, um grão abaixo, exatamente o defeito que o ticket existe para matar:

| # | insumo | evidência no SQL |
|---|---|---|
| 4 | os jogos anteriores de **(C,S) inteiro**, de todos os times | `rank` é `ROW_NUMBER() OVER (PARTITION BY p.fixture_id, tg.group_name ORDER BY tb.points DESC, tb.wins_total DESC, …)` sobre o CTE `tabela`, que é competição-scoped (ADR 0008). **Adversário de grupo com placar corrigido muda o `rank` de T sem tocar em nenhum jogo de T** |
| 5 | o **elenco** de (C,S) | `league_size` conta `league_teams`, que sai do `DISTINCT team_id` de `targets`. É o `n_teams`, coluna de saída |
| 1 | a exclusão do **placar da própria âncora** | o `team_log` exige `kickoff < kickoff(F)`, estrito — a linha de F não lê o resultado de F. Digitalizá-lo faria toda linha quebrar quando o próprio jogo acontecesse, e o recorte por linha voltaria a erodir |

Segui o **critério de aceite** ("por linha — *o fecho da conta*") em vez da enumeração do corpo. A
digital ficou **mais fina** que o pedido, e essa é a direção segura: mais fina só custa cobertura;
mais grossa é mentir. A emenda à ADR 0007 e o verbete do `CONTEXT.md` foram corrigidos no mesmo
commit — deixá-los afirmando "(a) e (b) = o fecho exato" seria fossilizar o erro no documento que
seis subtasks vão citar.

⚠️ O item 5 é **o único insumo do fecho que lê o futuro**, e por isso entra como **conjunto de
times** e nunca de fixtures — senão vira a armadilha do "por time" que a spec proíbe.

## Aceite

| AC | estado |
|---|---|
| digital por **linha**, num macro só, lido pelas duas pontas | ✅ `taskf_fingerprint_insumo_pit` emite `fp_insumo_por_linha`; congelamento e guarda leem de lá |
| baseline **recongelado de produção no mesmo commit**, guarda **verde** | ✅ 2026-08-28 14:25:03 UTC, carimbo `687950f`, 21.374 linhas; guarda PASS com cobertura **1,0** |
| `taskf_cobertura_minima` **continua 0,5**, com o sentido novo escrito | ✅ vacuidade, não erosão — e dito que recalibrar exigiria uma série que ninguém mediu |
| continua em **`tag:taskf`**, fora do agendado | ✅ intacto (precedente da #33) |
| **duas falsificações**, com comando e resultado no cabeçalho | ✅ abaixo |
| cabeçalhos param de descrever o mundo pré-#91 | ✅ guarda, macro, receita de congelamento, sources.yml |
| validação sem tocar produção fora do recongelamento | ✅ `dbt compile` + `bq query`; o único `dbt run` foi no `futebol_taskF` |

## As duas falsificações, executadas

**1 — célula fora do default é vermelha por desenho** (14:28 UTC, `--target taskF`):
`27.278` divergências, **13.639 `so_no_baseline` + 13.639 `so_no_atual`** — simétricas, porque a
célula `base` reescreve o valor de toda linha comparável em vez de perder linhas. **Nenhuma** linha
de `cobertura_abaixo_do_piso`: casaram 13.639 de 21.374 (63,8%, acima do piso). Vermelha por
**conteúdo**.

**2 — recorte novo sem recongelar dá VAZIA** (14:26 UTC, `--target prod`), a falsificação nova:

```json
{"linhas_comparadas":0,"linhas_no_baseline":21374,"cobertura":0,"piso":0.5,
 "linhas_casadas_n":0,"linhas_na_digital_do_baseline":21374}
```

Uma linha só, motivo `cobertura_abaixo_do_piso`, **zero** divergências de conteúdo — porque não há
conteúdo comparado. É o modo "vazia" ficando barulhento por causa do piso: sem ele a saída seria
zero linhas e a guarda passaria dizendo **nada** sobre 21.374 linhas. Perturbação revertida e
guarda de volta ao verde às 14:27.

As duas são vermelhas por mecanismos **diferentes** — conteúdo e vacuidade —, que é o que as torna
complementares em vez de redundantes.

## ⚠️ Correção a um item do "o que este ticket NÃO faz"

O ticket afirma *"não há `./build-and-push.sh` nem redeploy de workflow"*. A primeira metade está
**errada**: `scripts/procedencia.sh` hasheia `dbt_futebol/macros` e `dbt_futebol/tests`, e este PR
toca as duas. Sem o rebuild o `deriva-imagem.yml` fica vermelho de hora em hora sobre uma mudança
que não muda comportamento nenhum — alarme falso que treina todo mundo a ignorar o detector.

**Depois do merge: `./build-and-push.sh dbt_futebol`.** Nenhum modelo muda, então nenhum workflow
precisa de redeploy e o `--select` de ninguém muda.

## Fora de escopo, como o ticket pede

Não promove a guarda para `tag:guarda`, não recalibra o piso, e **não toca a âncora da #82** — o
`fp_insumo_linha` não é lido por nenhum modelo de premissa, nem pelo `task01_base`, nem pelo
de-vig.

## Efeito colateral declarado

`futebol_taskF.int_futebol_team_form_pit` foi sobrescrita duas vezes durante a falsificação 1
(célula `base`, depois de volta ao default) — é a tabela de trabalho por célula, e o fluxo está
documentado no cabeçalho do modelo. `baseline_pit_fingerprint` (a digital antiga, por partição)
fica no dataset como registro histórico, mas sai do `sources.yml`: source que ninguém lê é convite
a alguém voltar a lê-la.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTnLDMmnTqwZZwycqB3DT9
