### PR TITLE
analise(futebol): o Valencia x Betis foi publicado 56 min antes do apito (#121)

### DIFF
--- a/dbt_futebol/analyses/board_reconstrucao_de_publicacao.sql
+++ b/dbt_futebol/analyses/board_reconstrucao_de_publicacao.sql
@@ -1,0 +1,158 @@
+/*
+    RECONSTRUÇÃO DO HORÁRIO DE PUBLICAÇÃO de um candidato no board (issues #120 / #121).
+
+    Responde três perguntas sobre uma seleção de um jogo, com carimbo de tempo em BRT:
+
+      1. QUANDO ela apareceu no painel pela primeira vez — e se isso foi antes ou depois do apito;
+      2. se ela ficou CONTINUAMENTE disponível ou sumiu e voltou (cada reativação reinicia o
+         "Disponível desde");
+      3. o que o Motor disse em CADA janela de coleta, e por qual porta ela reprovava antes.
+
+    ─────────────────────────────────────────────────────────────────────────────────────────────
+    ⚠️ QUAL FONTE RESPONDE O QUÊ — e a lacuna de telemetria que a #121 mediu.
+
+    O funil (`fact_value_funnel`) é append-only e congela no apito, e por isso parece a fonte
+    óbvia para "quando isto passou pela primeira vez". **Ele não responde essa pergunta.** Medido
+    em 2026-08-28 sobre a semana de 20 a 26/08: dos **7.660** candidatos com mais de uma janela,
+    **7.660** — todos, sem exceção — têm um `gravado_em` ÚNICO compartilhado por todas as suas
+    janelas. O `gravado_em` data a EXECUÇÃO que escreveu a linha, não a janela que ela descreve.
+
+    O funil diz, portanto, **o que o Motor disse em cada janela**; não diz **quando ele disse**, e
+    muito menos quando o assinante viu. Quem data a tela é o snapshot do board
+    (`fact_value_opportunities_hist`), cujo `dbt_valid_from` é o instante da execução em que a
+    versão nasceu.
+
+    ⚠️ `janela_usada` NÃO É HORÁRIO DE NASCIMENTO. Ela é a janela de odds da versão VIVA naquele
+    instante — a última pré-apito, quando lida do PIT. Uma oportunidade publicada em `t1h` e
+    atualizada em `t15m` aparece no PIT como `t15m`, e confundir as duas coisas foi exatamente o
+    que originou a #120. Quem diz a janela de DETECÇÃO é a coluna `janela_deteccao` (#40).
+
+    ⚠️ O `hist` estreou em **27/07/2026**. Para chave anterior a essa data o `MIN(dbt_valid_from)`
+    data a estreia do snapshot, não o nascimento da oportunidade — o mesmo artefato que produziu o
+    pico falso registrado no `CONTEXT.md`. Este SQL emite `anterior_a_estreia_do_hist` para que a
+    leitura não passe disso em silêncio.
+
+    ─────────────────────────────────────────────────────────────────────────────────────────────
+    COMO RODAR (do dbt_futebol/):
+
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target prod \
+        --select board_reconstrucao_de_publicacao \
+        --vars '{pub_fixture_id: 1570342, pub_market: goals_over_under, pub_outcome: Over, pub_line: 3.5}'
+      bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+        < target/compiled/dbt_futebol/analyses/board_reconstrucao_de_publicacao.sql
+
+    (`bq query` com o SQL como argumento trava nesta máquina — sempre por redirecionamento.)
+
+    Os defaults são o caso da #121 (Valencia × Betis, Mais de 3,5 gols). `pub_line` aceita NULL
+    para mercados sem linha (1X2, BTTS, Dupla Chance) — a comparação é NULL-safe.
+
+    → RESULTADOS: `docs/TASKA_RESULTADOS.md`, seção "Quando o Valencia × Betis foi publicado".
+*/
+
+{%- set fx    = var('pub_fixture_id', 1570342) -%}
+{%- set mkt   = var('pub_market',     'goals_over_under') -%}
+{%- set out   = var('pub_outcome',    'Over') -%}
+{%- set linha = var('pub_line',       3.5) -%}
+
+WITH kickoff AS (
+    SELECT fixture_id, kickoff_utc, status_short
+    FROM {{ ref('fact_fixtures') }}
+    WHERE fixture_id = {{ fx }}
+),
+
+-- (A) O QUE O MOTOR DISSE, janela a janela. Sem horário — ver o aviso do cabeçalho.
+por_janela AS (
+    SELECT
+        'A. veredito por janela'                       AS bloco,
+        v.janela                                       AS chave,
+        CAST(NULL AS STRING)                           AS de_brt,
+        CAST(NULL AS STRING)                           AS ate_brt,
+        CAST(NULL AS INT64)                            AS min_antes_do_apito,
+        v.passou_no_gate,
+        v.motivo_primario,
+        v.best_odd, v.n_casas, ROUND(v.edge, 4) AS edge, v.score,
+        v.valor_fonte,
+        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S', v.gravado_em, 'America/Sao_Paulo') AS gravado_em_brt
+    FROM {{ ref('fact_value_funnel') }} v
+    WHERE v.fixture_id  = {{ fx }}
+      AND v.market      = '{{ mkt }}'
+      AND v.outcome     = '{{ out }}'
+      AND v.line_value IS NOT DISTINCT FROM {{ linha if linha is not none else 'NULL' }}
+),
+
+-- (B) O QUE O PAINEL MOSTROU, versão a versão. `dbt_valid_from` é o instante da execução.
+versoes AS (
+    SELECT
+        h.dbt_valid_from,
+        h.dbt_valid_to,
+        h.janela_usada,
+        h.janela_deteccao,
+        h.best_odd, h.n_casas, h.edge, h.score, h.faixa,
+        k.kickoff_utc,
+        -- Uma REATIVAÇÃO é um buraco entre a morte de uma versão e o nascimento da seguinte.
+        -- Versões contíguas (valid_to == valid_from da próxima) são ATUALIZAÇÃO, não republicação.
+        LAG(h.dbt_valid_to) OVER (ORDER BY h.dbt_valid_from) AS fim_da_anterior
+    FROM `smartbetting-dados.futebol.fact_value_opportunities_hist` h
+    CROSS JOIN kickoff k
+    WHERE h.fixture_id  = {{ fx }}
+      AND h.market      = '{{ mkt }}'
+      AND h.outcome     = '{{ out }}'
+      AND h.line_value IS NOT DISTINCT FROM {{ linha if linha is not none else 'NULL' }}
+),
+
+no_painel AS (
+    SELECT
+        'B. versao no painel'                          AS bloco,
+        CONCAT(janela_usada, ' (deteccao: ', COALESCE(janela_deteccao, '—'), ')') AS chave,
+        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S', dbt_valid_from, 'America/Sao_Paulo') AS de_brt,
+        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S', dbt_valid_to,   'America/Sao_Paulo') AS ate_brt,
+        TIMESTAMP_DIFF(kickoff_utc, dbt_valid_from, MINUTE) AS min_antes_do_apito,
+        TRUE                                           AS passou_no_gate,
+        CASE
+            WHEN fim_da_anterior IS NULL                     THEN 'primeira publicacao'
+            WHEN fim_da_anterior = dbt_valid_from            THEN 'atualizacao (contigua)'
+            ELSE CONCAT('REATIVACAO apos ',
+                        CAST(TIMESTAMP_DIFF(dbt_valid_from, fim_da_anterior, MINUTE) AS STRING),
+                        ' min fora do painel')
+        END                                            AS motivo_primario,
+        best_odd, n_casas, ROUND(edge, 4) AS edge, score,
+        faixa                                          AS valor_fonte,
+        CAST(NULL AS STRING)                           AS gravado_em_brt
+    FROM versoes
+),
+
+-- (C) O VEREDITO. Publicação a partir do apito é inválida; antes dele é válida, mesmo em t15m.
+veredito AS (
+    SELECT
+        'C. veredito'                                  AS bloco,
+        CASE
+            WHEN (SELECT COUNT(*) FROM versoes) = 0 THEN 'NUNCA PUBLICADA'
+            WHEN (SELECT MIN(dbt_valid_from) FROM versoes)
+                 >= (SELECT kickoff_utc FROM kickoff) THEN 'INVALIDA: primeira publicacao no apito ou depois'
+            ELSE 'VALIDA: publicada antes do apito'
+        END                                            AS chave,
+        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S',
+            (SELECT MIN(dbt_valid_from) FROM versoes), 'America/Sao_Paulo') AS de_brt,
+        FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S',
+            (SELECT kickoff_utc FROM kickoff), 'America/Sao_Paulo')         AS ate_brt,
+        TIMESTAMP_DIFF((SELECT kickoff_utc FROM kickoff),
+                       (SELECT MIN(dbt_valid_from) FROM versoes), MINUTE)   AS min_antes_do_apito,
+        (SELECT COUNTIF(fim_da_anterior IS NOT NULL AND fim_da_anterior <> dbt_valid_from)
+         FROM versoes) = 0                             AS passou_no_gate,
+        CASE
+            WHEN (SELECT MIN(dbt_valid_from) FROM versoes)
+                 < TIMESTAMP('2026-07-27') THEN 'anterior_a_estreia_do_hist: o horario data o snapshot, nao a oportunidade'
+            WHEN (SELECT COUNTIF(fim_da_anterior IS NOT NULL AND fim_da_anterior <> dbt_valid_from)
+                  FROM versoes) = 0 THEN 'disponibilidade continua, sem reativacao'
+            ELSE 'houve reativacao — "Disponivel desde" reinicia na ultima'
+        END                                            AS motivo_primario,
+        CAST(NULL AS FLOAT64) AS best_odd, CAST(NULL AS INT64) AS n_casas,
+        CAST(NULL AS FLOAT64) AS edge,     CAST(NULL AS INT64) AS score,
+        (SELECT status_short FROM kickoff)             AS valor_fonte,
+        CAST(NULL AS STRING)                           AS gravado_em_brt
+)
+
+SELECT * FROM por_janela
+UNION ALL SELECT * FROM no_painel
+UNION ALL SELECT * FROM veredito
+ORDER BY bloco, de_brt NULLS FIRST, chave

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -539,3 +539,115 @@ bq query --use_legacy_sql=false --format=csv \
 
 Para remedir mais tarde, mover `corte_fim` no cabeçalho da análise. Para replayar um congelamento,
 mover os dois cortes. Nada em produção muda: é `compile` + `bq query`, nunca `dbt run`.
+
+---
+
+# Issues #120 / #121 — Quando o Valencia × Betis foi publicado
+
+**Análise:** `dbt_futebol/analyses/board_reconstrucao_de_publicacao.sql`
+**Fontes:** `fact_value_funnel` (veredito por janela) e `fact_value_opportunities_hist` (o painel)
+**Rodada publicada:** **2026-08-28 14:41 UTC**
+**Caso:** fixture `1570342`, Valencia × Real Betis, `goals_over_under` / `Over` / linha `3.5`,
+apito em **25/08/2026 16:00 BRT**
+
+## A resposta
+
+**Publicada às 15:03:09 BRT de 25/08 — 56 minutos ANTES do apito.** Comportamento **válido**, e
+disponibilidade **contínua**: não houve sumiço nem reativação.
+
+| versão no painel | de (BRT) | até (BRT) | antes do apito | transição |
+|---|---|---|---|---|
+| `t1h` (detecção `t1h`) | **15:03:09** | 15:48:00 | **+56 min** | **primeira publicação** |
+| `t15m` (detecção `t1h`) | 15:48:00 | 20:48:39 | +11 min | atualização (contígua) |
+| `t15m` | 20:48:39 | 21:04:35 | −288 min | atualização (contígua) |
+| `t15m` | 21:04:35 | 21:32:54 | −304 min | atualização (contígua) |
+| `t15m` | 21:32:54 | 26/08 09:14:45 | −332 min | atualização (contígua) |
+
+Odd, edge e nota **não se moveram** em nenhuma das cinco versões: 4,00 / +6,94% / 44 / faixa
+`Média`, com 11 casas e `valor_fonte = pinnacle`.
+
+## Por que parecia t15m — e por que isso é uma armadilha de leitura, não um defeito
+
+O PIT devolve a versão **viva no apito**, que é a de 15:48:00, cujo `janela_usada` é `t15m`. Mas
+`janela_usada` é a **janela de odds da versão**, não o horário de nascimento: às 15:48 houve uma
+*atualização contígua* (o `dbt_valid_to` de uma versão é o `dbt_valid_from` da seguinte, sem
+buraco), não uma republicação.
+
+Quem responde a pergunta certa já existe: **`janela_deteccao` = `t1h`** nas cinco versões — a
+coluna que a **#40** criou. A leitura de "apareceu em t15m" vinha de olhar `janela_usada`.
+
+## O Motor de fato não passou antes — e o que mudou foi o preço
+
+Não é caso de publicação atrasada. Nas janelas anteriores a candidata **reprovava de verdade**:
+
+| janela | odd | edge | nota | passou? | porta que barrou |
+|---|---|---|---|---|---|
+| `daily` | 3,60 | +1,34% | 21 | não | `nota_abaixo_da_regua` |
+| `t24h` | 3,52 | **−4,00%** | 14 | não | `sem_edge` |
+| **`t1h`** | **4,00** | **+6,94%** | **44** | **sim** | — |
+| `t15m` | 4,00 | +6,94% | 44 | sim | — |
+
+A Pinnacle abriu a odd de 3,52 para 4,00 entre `t24h` e `t1h`. O edge virou de −4,0% para +6,9% e
+a nota saltou de 14 para 44. **O sinal nasceu tarde porque o preço nasceu tarde**, e o pipeline o
+publicou 56 minutos depois — não é atraso de serving.
+
+## ⚠️ A lacuna de telemetria, medida: o funil não data janela
+
+A spec #120 propõe reconstruir as transições "usando o funil append-only". **O funil não sustenta
+essa reconstrução**, e isto foi medido, não suposto:
+
+> Dos **7.660** candidatos com mais de uma janela na semana de 20–26/08, **7.660** — todos, sem
+> uma exceção — têm um `gravado_em` **único**, compartilhado por todas as suas janelas.
+
+No caso do Valencia × Betis, as **oito** linhas do funil (4 janelas × 2 lados) carimbam
+`2026-08-25 15:46:34`, treze minutos antes do apito. O `gravado_em` data a **execução que
+escreveu**, não a janela que a linha descreve.
+
+O funil, portanto, responde **o que o Motor disse em cada janela** — e é insubstituível nisso,
+como a tabela acima mostra. **Não** responde *quando* ele disse, nem quando o assinante viu. Quem
+data a tela é o `dbt_valid_from` do `hist`, e só ele.
+
+Que a ausência antes das 15:03 é ausência de verdade, e não falta de execução, o próprio `hist`
+prova: o snapshot rodou às 13:32:54 e abriu uma versão de outra chave, **sem** nenhuma deste
+fixture.
+
+## "Disponível desde": o campo que falta, e o que ele não pode ser
+
+O contrato de dados pedido pela #120 é: **`disponivel_desde` = o início do período contínuo
+ATUAL**, com reativação reiniciando o relógio. Ele se calcula do `hist` — o `dbt_valid_from` da
+versão que abre a corrida contígua corrente, exatamente como o bloco B da análise faz.
+
+Três avisos que precisam ir junto do campo, senão ele mente:
+
+1. **Não é `MIN(dbt_valid_from)` da chave.** Isso data o *primeiro* nascimento e ignora
+   reativação, que é justamente a distinção que a spec pede.
+2. **Não é `janela_usada`.** É o erro que originou esta investigação.
+3. ⚠️ **O `hist` estreou em 27/07/2026.** Para chave anterior, `MIN(dbt_valid_from)` data a
+   estreia do snapshot, não a oportunidade — é o pico falso já registrado no `CONTEXT.md`. A
+   análise emite `anterior_a_estreia_do_hist` para que isso não passe em silêncio, e o campo no
+   app precisa do mesmo cuidado: **melhor vazio do que um horário inventado**.
+
+## Um achado colateral: três versões nasceram DEPOIS do apito
+
+As versões de 20:48:39, 21:04:35 e 21:32:54 nasceram **4h48, 5h04 e 5h32 após o apito** — o jogo já
+tinha acabado. É o resíduo que a **#86** mediu e nomeou: a faixa **0–10 h**, que não é do mart e sim
+da latência de coleta de placar, e que virou **`data-engineering#60`**. Este fixture é um caso dela,
+com número. O expurgo fechou a chave às 09:14:45 de 26/08, quando o `FT` finalmente entrou.
+
+Nada a fazer aqui: já está rastreado, e no repositório certo.
+
+## Como rerodar
+
+```bash
+cd dbt_futebol
+DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --target prod \
+  --select board_reconstrucao_de_publicacao \
+  --vars '{pub_fixture_id: 1570342, pub_market: goals_over_under, pub_outcome: Over, pub_line: 3.5}'
+bq query --use_legacy_sql=false --project_id=smartbetting-dados \
+  < target/compiled/dbt_futebol/analyses/board_reconstrucao_de_publicacao.sql
+```
+
+A análise é **parametrizada** — serve para qualquer candidato, não só para este. `pub_line` aceita
+`NULL` nos mercados sem linha (1X2, BTTS, Dupla Chance): a comparação é NULL-safe. Nada em produção
+muda: é `compile` + `bq query`, nunca `dbt run`. E como o `hist` fecha versões em vez de apagá-las,
+rerodar para este jogo passado devolve as mesmas transições — hoje e daqui a um ano.


### PR DESCRIPTION
Fecha a #121, e responde a pergunta da spec **#120**.

## A resposta

**Publicada em 25/08 às 15:03:09 BRT — 56 minutos ANTES do apito** (16:00 BRT). Comportamento
**válido**, disponibilidade **contínua**: nenhum sumiço, nenhuma reativação.

| versão no painel | de (BRT) | até (BRT) | antes do apito | transição |
|---|---|---|---|---|
| `t1h` (detecção `t1h`) | **15:03:09** | 15:48:00 | **+56 min** | **primeira publicação** |
| `t15m` (detecção `t1h`) | 15:48:00 | 20:48:39 | +11 min | atualização (contígua) |
| `t15m` | 20:48:39 | 21:04:35 | −288 min | atualização (contígua) |
| `t15m` | 21:04:35 | 21:32:54 | −304 min | atualização (contígua) |
| `t15m` | 21:32:54 | 26/08 09:14:45 | −332 min | atualização (contígua) |

Odd, edge e nota não se moveram em nenhuma: 4,00 / +6,94% / 44 / `Média`, 11 casas, Pinnacle.

## Por que parecia `t15m`

O PIT devolve a versão viva no apito, a de 15:48:00, cujo `janela_usada` é `t15m`. Mas
`janela_usada` é a **janela de odds da versão**, não o horário de nascimento — e às 15:48 houve uma
*atualização contígua* (`dbt_valid_to` de uma = `dbt_valid_from` da seguinte, sem buraco), não uma
republicação.

Quem responde a pergunta certa **já existe**: `janela_deteccao` = `t1h` nas cinco versões, coluna
criada pela **#40**.

## Não foi atraso de serving: o preço nasceu tarde

| janela | odd | edge | nota | passou? | porta |
|---|---|---|---|---|---|
| `daily` | 3,60 | +1,34% | 21 | não | `nota_abaixo_da_regua` |
| `t24h` | 3,52 | **−4,00%** | 14 | não | `sem_edge` |
| **`t1h`** | **4,00** | **+6,94%** | **44** | **sim** | — |
| `t15m` | 4,00 | +6,94% | 44 | sim | — |

A Pinnacle abriu 3,52 → 4,00 entre `t24h` e `t1h`. Nas janelas anteriores a candidata **reprovava
de verdade** — não havia o que publicar.

## ⚠️ A spec #120 assume uma telemetria que o funil não tem

A #120 pede para reconstruir as transições "usando o funil append-only". **O funil não sustenta
essa reconstrução**, e isso foi medido:

> Dos **7.660** candidatos com mais de uma janela na semana de 20–26/08, **7.660** — todos, sem uma
> exceção — têm um `gravado_em` **único**, compartilhado por todas as suas janelas.

No caso, as **oito** linhas do funil (4 janelas × 2 lados) carimbam `2026-08-25 15:46:34` — treze
minutos antes do apito. O `gravado_em` data a **execução que escreveu**, não a janela descrita.

O funil responde **o que** o Motor disse em cada janela, e é insubstituível nisso (é dele que sai a
tabela de preços acima). Não responde **quando**. Quem data a tela é o `dbt_valid_from` do `hist`.

Que a ausência antes das 15:03 é ausência de verdade e não falta de execução, o próprio `hist`
prova: o snapshot rodou às 13:32:54 e abriu versão de outra chave, nenhuma deste fixture.

## O contrato do "Disponível desde"

`disponivel_desde` = início do período contínuo **atual** (reativação reinicia), calculado do
`hist` como o bloco B da análise faz. Três avisos vão junto, senão o campo mente:

1. **não** é `MIN(dbt_valid_from)` da chave — isso ignora reativação, que é a distinção pedida;
2. **não** é `janela_usada` — o erro que originou esta investigação;
3. ⚠️ o `hist` **estreou em 27/07/2026**: para chave anterior, `MIN(dbt_valid_from)` data a estreia
   do snapshot e não a oportunidade — o pico falso já registrado no `CONTEXT.md`. **Melhor vazio
   que um horário inventado.**

## O que entra

- **`analyses/board_reconstrucao_de_publicacao.sql`** — parametrizado por fixture / mercado /
  seleção / linha (NULL-safe para 1X2, BTTS e DC), não amarrado a este caso. Emite o veredito por
  janela, as versões do painel com a transição classificada (*primeira publicação* / *atualização
  contígua* / *REATIVAÇÃO após N min fora do painel*) e o veredito final, incluindo o aviso
  `anterior_a_estreia_do_hist`.
- A seção em **`docs/TASKA_RESULTADOS.md`**.

## Achado colateral, já rastreado

Três versões nasceram **4h48, 5h04 e 5h32 depois do apito** — a faixa **0–10 h** que a #86 mediu e
mandou para **`data-engineering#60`** (latência de coleta de placar, não do mart). Este fixture é um
caso dela, com número. O expurgo fechou a chave às 09:14:45 de 26/08, quando o `FT` entrou.

## Fora de escopo, como a #120 pede

Não muda cadência de coleta, não muda porta da [A], não mexe em Telegram, e não implementa a UI do
"Disponível desde" antes do contrato de dados existir.

Nada em produção muda: `compile` + `bq query`, nenhum `dbt run` — e portanto nenhum
`build-and-push` (só `analyses/` e `docs/`, que o `procedencia.sh` não hasheia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTnLDMmnTqwZZwycqB3DT9
