### PR TITLE
feat(futebol): as três barreiras de preço viram coluna medida no funil (#104)

### DIFF
--- a/dbt_futebol/models/marts/_fact_value_funnel.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel.yml
@@ -132,13 +132,24 @@ models:
         tests: [not_null]
       - name: porta_valor_estimavel
         description: >
-          TRUE = há `prob_justa_fechamento`. ⚠️ ANINHADA com `porta_conjunto_completo`:
-          pela ADR 0002, conjunto incompleto implica prob justa ausente. As duas ficam
-          porque a leitura marginal é o produto da tabela — mas quem as somar como
-          independentes conta a mesma linha duas vezes.
+          TRUE = há `prob_justa_fechamento` — a regra da ADR 0002
+          (`n_outcomes_valor = conjunto_esperado`).
+
+          ⚠️ CORREÇÃO (#118, medida em 28/08): esta descrição afirmava que a porta é
+          ANINHADA com `porta_conjunto_completo` e avisava contra somá-las. É o oposto do
+          medido — elas são quase DISJUNTAS, e quem seguir o aviso antigo SUBESTIMA a
+          leitura marginal: 9.102 linhas de Handicap e 10.644 de Gols, todas de consenso,
+          têm `porta_valor_estimavel = TRUE` e `porta_conjunto_completo = FALSE`. As duas
+          fazem perguntas diferentes apesar do nome; ver a #118 (`ready-for-human`).
         tests: [not_null]
       - name: porta_liquidez
-        description: "TRUE = `n_casas >= 3`. (A A3 vai mexer neste número; é para medir o antes/depois que esta tabela existe.)"
+        description: >
+          TRUE = `n_casas >= 3`. É a porta EM VIGOR, e continua sendo — a A3 não a
+          redefiniu. O mínimo de 4 que a A3 decidiu vive na coluna irmã
+          `porta_liquidez_estrita`, fora da conjunção, e a virada (#109) troca qual das
+          duas está no gate. Redefinir esta aqui faria um nome de coluna valer >= 3 nas
+          linhas já congeladas e >= 4 nas novas, para sempre, dentro de uma tabela
+          append-only.
         tests: [not_null]
       - name: porta_edge
         description: "TRUE = `edge > 0`, ou `> consensus_min_edge` (3%) quando o valor vem do consenso — o edge de consenso é enviesado p/ cima (best_odd é o MÁXIMO das casas contra a prob da MEDIANA). (A A2 tira o edge do gate.)"
@@ -150,15 +161,60 @@ models:
         description: "TRUE = a linha é meia (.5, sem push/meio-push). Só se aplica a Handicap asiático e Gols O/U; nos outros três passa trivialmente, porque a porta não se aplica — não porque a linha foi isentada."
         tests: [not_null]
       - name: porta_odd_dc
-        description: "TRUE = `best_odd >= 1,25`. Gate de odd PRÓPRIO da Dupla Chance (que por isso não aplica a penalidade de juice). Trivialmente TRUE nos outros quatro mercados."
+        description: >
+          TRUE = `best_odd >= 1,25`. Gate de odd PRÓPRIO da Dupla Chance (que por isso não
+          aplica a penalidade de juice). Trivialmente TRUE nos outros quatro mercados.
+          ⚠️ O 1,25 deixou de ser literal na #104 e passou a sair da var `faixa_odd_dc_min`,
+          a MESMA que a `porta_faixa_odd` usa como piso da DC — o número existe num lugar
+          só, e mexer nele não pode mover uma porta e esquecer a outra.
         tests: [not_null]
       - name: passou_no_gate
         description: >
-          A CONJUNÇÃO das oito portas, DERIVADA e nunca escrita à mão (ADR 0006). Não
-          inclui `janela_e_corrente` (redução, não veredito) nem o expurgo do board
+          A CONJUNÇÃO das oito portas EM VIGOR, DERIVADA e nunca escrita à mão (ADR 0006).
+          Não inclui `janela_e_corrente` (redução, não veredito), nem o expurgo do board
           (o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a
-          faixa descartada).
+          faixa descartada), nem as três barreiras MEDIDAS da #104, que ainda não estão em
+          vigor. A expressão é byte a byte a de antes da #104: é assim que "o board não muda
+          de volume nem de composição" é verdade por CONSTRUÇÃO, e não por medição.
         tests: [not_null]
+
+      # ------------------------------------- as três barreiras MEDIDAS (#104, A3+A5)
+      # Fora de `passou_no_gate`. Dizem quem PASSARIA; quem as põe em vigor é a virada (#109).
+      # ⚠️ Chegam por append_new_columns e ficam NULL para sempre na linha de jogo já apitado
+      # antes do deploy — append-only funcionando, igual a nota_contexto (A1) e
+      # score_normalizado (A6). Por isso não levam `not_null`.
+      - name: porta_liquidez_estrita
+        description: >
+          TRUE = `n_casas >= 4` (var `liquidez_min_casas`). A barreira de liquidez que a A3
+          decidiu, MEDIDA e fora da conjunção. Convive com `porta_liquidez` (>= 3, em vigor)
+          em vez de substituí-la: o funil é append-only, e redefinir o predicado sob o mesmo
+          nome faria a coluna valer duas coisas em duas eras da mesma tabela. A virada troca
+          qual das duas está no gate, sem renomear nada.
+      - name: porta_outlier
+        description: >
+          TRUE = a odd NÃO está fora da curva — `NOT pen_odd_outlier`, isto é,
+          `best_odd < 1,10 × média das demais casas`. O `pen_odd_outlier` deixa de dar
+          penalidade e vira barreira na virada. ⚠️ A barreira elimina A LINHA, não a casa:
+          descartar a casa fora da curva e publicar a segunda melhor odd mudaria o
+          `best_odd` de todo o board, o edge exibido e o CLV histórico — é feature nova, fora
+          de escopo. ⚠️ COALESCE por FORA do NOT: penalidade ausente (NULL) REPROVA a
+          barreira, em vez de aprovar por acidente de negação.
+      - name: porta_faixa_odd
+        description: >
+          TRUE = `best_odd` está na faixa do mercado, com fronteiras INCLUSIVAS nas duas
+          pontas (odd exatamente igual ao piso ou ao teto PASSA — escrito porque este repo já
+          teve knife-edge de float, na #92):
+
+          | mercado | piso | teto | vars |
+          |---|---|---|---|
+          | Resultado, Handicap, Gols, Ambos marcam | 1,50 | 4,00 | `faixa_odd_min` / `faixa_odd_max` |
+          | Dupla chance | 1,25 | 2,00 | `faixa_odd_dc_min` / `faixa_odd_dc_max` |
+
+          O piso existe porque abaixo dele a margem embutida no mercado come o lucro
+          possível (92% no Handicap e 106% no Gols em odd até 1,30). ⚠️ O teto de 4,00 é
+          DECISÃO DE PRODUTO e o único número da [A] sem medição atrás — registrado como tal
+          para não ser defendido depois como se tivesse. A Dupla Chance tem faixa própria
+          porque é mercado de proteção e as odds vivem em outra faixa.
       - name: motivo_primario
         description: >
           CONVENIÊNCIA DE LEITURA, NÃO FONTE (ADR 0006). A primeira porta reprovada na

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -5,7 +5,7 @@
     on_schema_change='append_new_columns',
     full_refresh=false,
     cluster_by=['competition', 'fixture_id'],
-    description='O FUNIL DE AVALIAÇÃO (#95/#96, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011): materialização INCREMENTAL por merge no grão (fixture_id, market, outcome, line_key, janela). A linha é escrita e atualizada enquanto o kickoff do fixture está no FUTURO e nenhuma escrita acontece depois dele — o funil deixa de ser uma foto do que o código de hoje diria e passa a ser registro do que o Motor disse. `full_refresh=false` no config porque a fase de RECOVERY do workflow_futebol_odds roda o mesmo --select com --full-refresh: sem isso, a primeira recuperação de deriva apagaria o histórico inteiro. Toda linha carrega `gravado_em` e `origem`: `backfill` no build que cria a tabela (recalculado com o código de hoje, e é a única parte que NÃO é registro de época) e `corrente` em toda escrita incremental. Jogo adiado (PST/SUSP) cujo kickoff volta para o futuro VOLTA a ser gravável — o filtro lê o kickoff corrente, não o da escrita anterior. Fixture ausente em fact_fixtures (kickoff NULL) é FAIL-OPEN: continua gravável para sempre, porque perdê-lo quebraria a reconciliação (ADR 0003). NÃO HÁ EXPURGO DO FUNIL (~45 mil linhas/mês; a política se revisita se a tabela passar de 10 milhões de linhas). NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil). A NOTA DE CONTEXTO (#103, ADR 0012): a coluna `nota_contexto` é a nota depois que o preço sai dela — pts_premissas menos as penalidades de CONTEXTO (pick_empate −10, desfalque_proprio −15, linha_extrema −10, handicap_alto −12), com GREATEST(..., 0) —, e nada mais: sem pts_valor, sem corroboração e sem as quatro penalidades de odd. Ela nasce AO LADO do `score`, que continua sendo o do board: nesta entrega o produto não muda de gate nem de número, e existe UMA virada só, no fim da [A]. A composição mora em macros/futebol_nota_contexto.sql (num lugar só, consumida pelo funil e pela guarda de reconstrução, nunca copiada); duas guardas a protegem — assert_nota_contexto_sem_preco (sentinela da decisão: falha se qualquer componente de preço aparecer no texto da composição) e assert_funil_nota_contexto_reconstroi (a coluna gravada bate com a recomposta). NULL onde não houve premissa a avaliar (a "12" da DC), pelo mesmo motivo que o score (ADR 0003). ⚠️ A coluna chega por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar: as linhas de jogo já apitado antes do deploy da A1 ficam com nota_contexto NULL para sempre, e isso é o append-only funcionando (ADR 0011), não defeito — a guarda de reconstrução é escopada a elas de propósito. A NOTA NORMALIZADA (#105, ADR 0005): as colunas `lado` e `score_normalizado`. `lado` é o eixo do denominador — os ONZE pares de (mercado, lado) que `futebol_lado()` enumera, e no Handicap ele NÃO é o outcome (é o sinal do handicap na ótica do lado apostado: Favorito/Azarao/Pick), enquanto na Dupla Chance 1X e X2 colapsam em `unico` porque as quatro premissas se aplicam às duas saídas. `score_normalizado` é a nota de contexto dividida pelo p95 OBSERVADO daquele lado, congelado no seed versionado `futebol_p95_nota_contexto` (medido uma vez, sobre janela declarada — recalcular em runtime faria a régua significar coisa diferente a cada dia). A nota é ABSOLUTA — quanta evidência acendeu —, nunca percentil dentro do lado: o preço declarado é que os mercados publicam em taxas diferentes, e isso é consequência, não defeito. Clamp em 100 EXPLÍCITO, porque com o p95 no denominador ~5% das linhas de cada lado ficam acima de 100 por construção. Denominador zero (o empate do 1X2 e o Pick do Handicap, que não têm lado apostado) resolve para ZERO explícito e nunca por SAFE_DIVIDE: o NULL faria a comparação com a régua virar NULL e a linha sairia sem passar e sem ser marcada. Denominador AUSENTE (lado fora do seed) cai no mesmo ramo — o join é LEFT para que a linha nunca suma — e quem acende é assert_p95_nota_contexto_nao_derivou, que cobra tanto a COBERTURA dos onze lados quanto a DERIVA do p95 vivo contra o congelado. A aritmética mora em macros/futebol_score_normalizado.sql, sem argumento, pela mesma razão do macro da nota de contexto. O BOARD NÃO MUDA: ele segue no `score` e no gate de 40, e a virada é uma só, no fim da [A]. ⚠️ As duas colunas chegam por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar — linha de jogo já apitado antes do deploy fica com elas NULL para sempre, e isso é o append-only funcionando.'
+    description='O FUNIL DE AVALIAÇÃO (#95/#96, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011): materialização INCREMENTAL por merge no grão (fixture_id, market, outcome, line_key, janela). A linha é escrita e atualizada enquanto o kickoff do fixture está no FUTURO e nenhuma escrita acontece depois dele — o funil deixa de ser uma foto do que o código de hoje diria e passa a ser registro do que o Motor disse. `full_refresh=false` no config porque a fase de RECOVERY do workflow_futebol_odds roda o mesmo --select com --full-refresh: sem isso, a primeira recuperação de deriva apagaria o histórico inteiro. Toda linha carrega `gravado_em` e `origem`: `backfill` no build que cria a tabela (recalculado com o código de hoje, e é a única parte que NÃO é registro de época) e `corrente` em toda escrita incremental. Jogo adiado (PST/SUSP) cujo kickoff volta para o futuro VOLTA a ser gravável — o filtro lê o kickoff corrente, não o da escrita anterior. Fixture ausente em fact_fixtures (kickoff NULL) é FAIL-OPEN: continua gravável para sempre, porque perdê-lo quebraria a reconciliação (ADR 0003). NÃO HÁ EXPURGO DO FUNIL (~45 mil linhas/mês; a política se revisita se a tabela passar de 10 milhões de linhas). NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil). A NOTA DE CONTEXTO (#103, ADR 0012): a coluna `nota_contexto` é a nota depois que o preço sai dela — pts_premissas menos as penalidades de CONTEXTO (pick_empate −10, desfalque_proprio −15, linha_extrema −10, handicap_alto −12), com GREATEST(..., 0) —, e nada mais: sem pts_valor, sem corroboração e sem as quatro penalidades de odd. Ela nasce AO LADO do `score`, que continua sendo o do board: nesta entrega o produto não muda de gate nem de número, e existe UMA virada só, no fim da [A]. A composição mora em macros/futebol_nota_contexto.sql (num lugar só, consumida pelo funil e pela guarda de reconstrução, nunca copiada); duas guardas a protegem — assert_nota_contexto_sem_preco (sentinela da decisão: falha se qualquer componente de preço aparecer no texto da composição) e assert_funil_nota_contexto_reconstroi (a coluna gravada bate com a recomposta). NULL onde não houve premissa a avaliar (a "12" da DC), pelo mesmo motivo que o score (ADR 0003). ⚠️ A coluna chega por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar: as linhas de jogo já apitado antes do deploy da A1 ficam com nota_contexto NULL para sempre, e isso é o append-only funcionando (ADR 0011), não defeito — a guarda de reconstrução é escopada a elas de propósito. A NOTA NORMALIZADA (#105, ADR 0005): as colunas `lado` e `score_normalizado`. `lado` é o eixo do denominador — os ONZE pares de (mercado, lado) que `futebol_lado()` enumera, e no Handicap ele NÃO é o outcome (é o sinal do handicap na ótica do lado apostado: Favorito/Azarao/Pick), enquanto na Dupla Chance 1X e X2 colapsam em `unico` porque as quatro premissas se aplicam às duas saídas. `score_normalizado` é a nota de contexto dividida pelo p95 OBSERVADO daquele lado, congelado no seed versionado `futebol_p95_nota_contexto` (medido uma vez, sobre janela declarada — recalcular em runtime faria a régua significar coisa diferente a cada dia). A nota é ABSOLUTA — quanta evidência acendeu —, nunca percentil dentro do lado: o preço declarado é que os mercados publicam em taxas diferentes, e isso é consequência, não defeito. Clamp em 100 EXPLÍCITO, porque com o p95 no denominador ~5% das linhas de cada lado ficam acima de 100 por construção. Denominador zero (o empate do 1X2 e o Pick do Handicap, que não têm lado apostado) resolve para ZERO explícito e nunca por SAFE_DIVIDE: o NULL faria a comparação com a régua virar NULL e a linha sairia sem passar e sem ser marcada. Denominador AUSENTE (lado fora do seed) cai no mesmo ramo — o join é LEFT para que a linha nunca suma — e quem acende é assert_p95_nota_contexto_nao_derivou, que cobra tanto a COBERTURA dos onze lados quanto a DERIVA do p95 vivo contra o congelado. A aritmética mora em macros/futebol_score_normalizado.sql, sem argumento, pela mesma razão do macro da nota de contexto. O BOARD NÃO MUDA: ele segue no `score` e no gate de 40, e a virada é uma só, no fim da [A]. ⚠️ As duas colunas chegam por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar — linha de jogo já apitado antes do deploy fica com elas NULL para sempre, e isso é o append-only funcionando. AS TRÊS BARREIRAS DE PREÇO (#104, A3+A5): as colunas `porta_liquidez_estrita` (n_casas >= 4), `porta_outlier` (NOT pen_odd_outlier) e `porta_faixa_odd` (best_odd dentro de [1,50; 4,00], e [1,25; 2,00] na Dupla Chance, fronteiras INCLUSIVAS nas duas pontas). Elas são MEDIDAS e ficam FORA de `passou_no_gate` — dizem quem passaria sem remover ninguém; quem as põe em vigor é a virada (#109), que no mesmo ato tira a `porta_liquidez` (>= 3) e põe a `porta_liquidez_estrita` no lugar. ⚠️ A de liquidez tem NOME PRÓPRIO em vez de a `porta_liquidez` ser redefinida para 4, e isso é decisão: o funil é append-only, então redefinir o predicado no lugar faria um nome de coluna valer >= 3 nas linhas congeladas e >= 4 nas novas, para sempre, dentro do registro de época — e as outras duas saídas (mínimo 4 dentro da conjunção, ou a porta de liquidez fora dela) mudariam o board, contra o aceite. As duas convivem e a virada troca qual está na conjunção, sem renomear nada. `porta_outlier` inverte a polaridade da penalidade (penalidade TRUE = suspeita; porta TRUE = passa) com o COALESCE POR FORA do NOT, para que penalidade ausente reprove em vez de aprovar por acidente de negação. Os quatro limites são `var` com default no modelo (liquidez_min_casas=4, faixa_odd_min=1.50, faixa_odd_max=4.00, faixa_odd_dc_min=1.25, faixa_odd_dc_max=2.00), e o piso da DC é lido TAMBÉM pela `porta_odd_dc` já em vigor — o 1,25 existe num lugar só. ⚠️ As três chegam por append_new_columns, como as anteriores, e ficam NULL para sempre na linha de jogo já apitado antes deste deploy. `motivo_primario` NÃO as conhece: linha que só reprovaria nelas continua passando hoje, e dar-lhe um motivo seria descrever uma rejeição que não aconteceu.'
 ) }}
 
 -- ============================================================================
@@ -495,10 +495,22 @@ com_nota_normalizada AS (
 -- reprova a porta em vez de propagar NULL para dentro da conjunção. É a degradação
 -- graciosa do Motor, e é o que impede o descarte silencioso que a ADR 0006 proíbe.
 --
--- ⚠️ `porta_conjunto_completo` e `porta_valor_estimavel` são ANINHADAS: pela ADR 0002,
--- conjunto incompleto implica prob justa ausente. As duas ficam mesmo assim, porque a
--- leitura marginal é o produto da tabela — mas quem somar as duas como se fossem
--- independentes conta a mesma linha duas vezes.
+-- ⚠️ CORREÇÃO (#118, medida em 28/08): este parágrafo dizia que `porta_conjunto_completo`
+-- e `porta_valor_estimavel` são ANINHADAS ("pela ADR 0002, conjunto incompleto implica
+-- prob justa ausente") e avisava contra somá-las. Os dados dizem o contrário: elas são
+-- quase DISJUNTAS, e quem seguir o aviso antigo SUBESTIMA a leitura marginal.
+--
+--   | mercado          | valor_fonte | completo | estimavel | linhas |
+--   |------------------|-------------|----------|-----------|--------|
+--   | asian_handicap   | consenso    | false    | TRUE      |  9.102 |
+--   | goals_over_under | consenso    | false    | TRUE      | 10.644 |
+--
+-- O motivo é que as duas fazem perguntas diferentes, apesar do nome: a
+-- `porta_valor_estimavel` é a regra da ADR 0002 (`n_outcomes_valor = conjunto_esperado`),
+-- enquanto a `porta_conjunto_completo` é `pin_n_outcomes >= N` em 1X2/Gols/Handicap — ou
+-- seja, "a PINNACLE cobriu?" — e `n_outcomes_valor >= N` em BTTS/DC. Um nome, dois
+-- predicados. A decisão sobre o que fazer com isso é a #118 (`ready-for-human`); aqui só
+-- o parágrafo que afirmava o oposto do medido sai do caminho.
 -- ============================================================================
 com_portas AS (
     SELECT
@@ -523,9 +535,61 @@ com_portas AS (
                            '{{ futebol_mercados_pontuados()[5] }}') OR is_half_line,
             FALSE)                                          AS porta_linha_meia,
         -- Gate de odd próprio da Dupla Chance. Trivialmente TRUE nos outros quatro.
+        -- ⚠️ O 1,25 saiu do literal e passou a ser lido da MESMA var que a faixa da A5 usa
+        -- como piso da DC (#104): o número existe num lugar só, e mexer nele não pode mover
+        -- uma porta e deixar a outra para trás.
         COALESCE(
-            market <> '{{ futebol_mercados_pontuados()[12] }}' OR best_odd >= 1.25,
-            FALSE)                                          AS porta_odd_dc
+            market <> '{{ futebol_mercados_pontuados()[12] }}'
+            OR best_odd >= {{ var('faixa_odd_dc_min', 1.25) }},
+            FALSE)                                          AS porta_odd_dc,
+
+        -- ====================================================================
+        -- AS TRÊS BARREIRAS DE PREÇO DA [A3+A5] (#104) — MEDIDAS, FORA DA CONJUNÇÃO.
+        --
+        -- Elas dizem quem PASSARIA, sem ainda remover ninguém do board. Quem as põe em
+        -- vigor é a virada (#109), acrescentando-as à conjunção logo abaixo; nesta entrega
+        -- o board não muda de volume nem de composição.
+        --
+        -- ⚠️ POR QUE `porta_liquidez_estrita` E NÃO `porta_liquidez` COM O MÍNIMO EM 4,
+        -- que é o que a spec da #104 pede literalmente. Redefinir a `porta_liquidez` no
+        -- lugar tem três saídas e as três quebram um aceite:
+        --   (a) mínimo 4 E dentro da conjunção -> o board perde as linhas de exatamente 3
+        --       casas, contra o aceite "não muda de volume nem de composição";
+        --   (b) mínimo 4 E fora da conjunção -> o gate fica SEM termo de liquidez nenhum,
+        --       linha de 1-2 casas passa, e a `assert_funil_paridade_com_board` fica
+        --       vermelha contra um board que não mudou;
+        --   (c) redefinir de qualquer jeito -> o funil é APPEND-ONLY. Um nome de coluna
+        --       passaria a valer >= 3 nas linhas já congeladas e >= 4 nas novas, para
+        --       sempre, dentro do registro de época. É o rótulo mentiroso da #118
+        --       reproduzido de propósito, e no lugar onde não dá para desfazer.
+        -- As duas convivem, portanto, e a virada troca qual delas está na conjunção — sem
+        -- renomear nada, que é o único jeito de não mentir sobre o passado.
+        --
+        -- ⚠️ POLARIDADE: `pen_odd_outlier` é TRUE quando a linha é SUSPEITA; porta é TRUE
+        -- quando a linha PASSA. Daí o NOT, e o COALESCE por FORA dele — penalidade ausente
+        -- (NULL) tem de REPROVAR a barreira, não aprová-la por acidente de negação.
+        --
+        -- ⚠️ FRONTEIRAS INCLUSIVAS NAS DUAS PONTAS (`>=` e `<=`): odd exatamente 1,50, 4,00,
+        -- 1,25 ou 2,00 PASSA. Está escrito porque neste repo já houve knife-edge de float
+        -- (a #92) e porque "faixa 1,50–4,00" não diz sozinho o que acontece na fronteira.
+        --
+        -- ⚠️ As três chegam por `append_new_columns` e SÓ nas linhas que o congelamento
+        -- ainda deixa gravar: linha de jogo já apitado antes deste deploy fica com elas
+        -- NULL para sempre. É o append-only funcionando (ADR 0011), não defeito — igual ao
+        -- que aconteceu com `nota_contexto` na A1 e com `score_normalizado` na A6.
+        -- ====================================================================
+        COALESCE(n_casas >= {{ var('liquidez_min_casas', 4) }}, FALSE)
+                                                            AS porta_liquidez_estrita,
+        COALESCE(NOT pen_odd_outlier, FALSE)                AS porta_outlier,
+        COALESCE(
+            best_odd >= CASE WHEN market = '{{ futebol_mercados_pontuados()[12] }}'
+                             THEN {{ var('faixa_odd_dc_min', 1.25) }}
+                             ELSE {{ var('faixa_odd_min', 1.50) }} END
+            AND
+            best_odd <= CASE WHEN market = '{{ futebol_mercados_pontuados()[12] }}'
+                             THEN {{ var('faixa_odd_dc_max', 2.00) }}
+                             ELSE {{ var('faixa_odd_max', 4.00) }} END,
+            FALSE)                                          AS porta_faixa_odd
     FROM com_nota_normalizada
 ),
 
@@ -541,6 +605,13 @@ com_portas AS (
 --
 -- O EXPURGO também não está (ADR 0011): o funil guarda jogo encerrado de propósito.
 -- Quem filtra por status é o board.
+--
+-- ⚠️ AS TRÊS BARREIRAS DA #104 TAMBÉM NÃO ESTÃO, e é a entrega inteira daquele ticket:
+-- `porta_liquidez_estrita`, `porta_outlier` e `porta_faixa_odd` são MEDIDAS e não estão em
+-- vigor. A conjunção abaixo é, byte a byte, a de antes da #104 — é assim que o aceite
+-- "o board não muda de volume nem de composição" fica verdadeiro POR CONSTRUÇÃO, e não por
+-- medição. Quem as acrescenta aqui é a virada (#109), que no mesmo ato TIRA a
+-- `porta_liquidez` (>= 3) e põe a `porta_liquidez_estrita` (>= 4) no lugar dela.
 -- ============================================================================
 com_gate AS (
     SELECT
@@ -586,7 +657,7 @@ SELECT
     -- congelar a linha no apito.
     _fx_kickoff_utc             AS kickoff_utc,
 
-    -- ---------------------------------------------------------------- as oito portas
+    -- ------------------------------------------------- as oito portas EM VIGOR
     porta_saida_catalogada,
     porta_conjunto_completo,
     porta_valor_estimavel,
@@ -596,6 +667,15 @@ SELECT
     porta_linha_meia,
     porta_odd_dc,
     passou_no_gate,
+
+    -- ------------------------------------- as três barreiras MEDIDAS (#104, A3+A5)
+    -- Fora de `passou_no_gate` até a virada (#109). Ver o bloco de comentário na CTE
+    -- `com_portas` para por que a de liquidez tem nome próprio em vez de redefinir a
+    -- `porta_liquidez` — resumo: o funil é append-only e um nome não pode valer duas
+    -- coisas em duas eras da mesma tabela.
+    porta_liquidez_estrita,
+    porta_outlier,
+    porta_faixa_odd,
 
     -- CONVENIÊNCIA DE LEITURA, NÃO FONTE (ADR 0006). Uma linha reprova em várias portas
     -- ao mesmo tempo, e um campo único de motivo é vitória do primeiro da fila: ele


### PR DESCRIPTION
Fecha a #104. As três barreiras de preço da A3+A5 passam a existir como **colunas medidas** do
funil, **fora da conjunção** — dizem quem passaria, sem remover ninguém do board. Quem as põe em
vigor é a virada (#109).

| coluna | predicado | vars |
|---|---|---|
| `porta_liquidez_estrita` | `n_casas >= 4` | `liquidez_min_casas` |
| `porta_outlier` | `NOT pen_odd_outlier` | — |
| `porta_faixa_odd` | `best_odd` em **[1,50; 4,00]**, e **[1,25; 2,00]** na Dupla Chance | `faixa_odd_min/max`, `faixa_odd_dc_min/max` |

Fronteiras **inclusivas nas duas pontas** — odd exatamente 1,50/4,00/1,25/2,00 **passa**. Está
escrito no cabeçalho porque este repo já teve knife-edge de float (#92).

## ⚠️ Um desvio de nome, deliberado — e por quê

A spec pede *"o funil carrega **`porta_liquidez`** com o mínimo em 4"*. Fazer isso literalmente tem
três saídas e **as três quebram um aceite**:

| saída | o que quebra |
|---|---|
| mínimo 4 **dentro** da conjunção | o board perde as linhas de exatamente 3 casas — contra o aceite *"não muda de volume nem de composição"* |
| mínimo 4 **fora** da conjunção | o gate fica **sem termo de liquidez nenhum**: linha de 1–2 casas passa, e a `assert_funil_paridade_com_board` fica vermelha contra um board que não mudou |
| redefinir de qualquer jeito | ⚠️ o funil é **append-only**. O nome passaria a valer `>= 3` nas linhas já congeladas e `>= 4` nas novas, **para sempre**, dentro do registro de época — o rótulo mentiroso da #118 reproduzido de propósito, no lugar onde não dá para desfazer |

Então **`porta_liquidez` (≥ 3) fica intacta e em vigor**, e a barreira nova nasce como
**`porta_liquidez_estrita` (≥ 4)**, fora da conjunção. As duas convivem, e a virada troca qual está
no gate — **sem renomear nada**, que é o único jeito de não mentir sobre o passado. Mesmo playbook
da #123.

## O aceite "o board não muda" é verdade por CONSTRUÇÃO

`passou_no_gate` continua sendo **byte a byte** a conjunção de antes — o diff não toca uma linha
dela. Não foi verificado por medição; não pode mudar. `motivo_primario` também não conhece as três:
linha que só reprovaria nelas continua passando hoje, e dar-lhe um motivo descreveria uma rejeição
que não aconteceu.

## Dimensionamento (aceite explícito), medido em 28/08 sobre o board

Board = funil na janela corrente que passa no gate em vigor: **107 linhas**.

| mercado | no board | **exatamente 3 casas** | outlier remove | fora da faixa | fora: abaixo do piso | fora: acima do teto |
|---|---|---|---|---|---|---|
| asian_handicap | 32 | **0** | 0 | 11 | 9 | 2 |
| goals_over_under | 50 | **0** | 2 | 9 | 4 | 5 |
| match_winner | 22 | **0** | 0 | 5 | 5 | 0 |
| double_chance | 2 | **0** | 0 | 1 | — | — |
| btts | 1 | **0** | 0 | 0 | 0 | 0 |
| **total** | **107** | **0** | **2** | **26** | **18** | **7** |

**Marginal**, na ordem liquidez → outlier → faixa:

| barreira | remove marginalmente |
|---|---|
| liquidez (≥ 4) | **0** |
| outlier | 2 |
| faixa de odd | 25 |
| **sobreviveriam às três** | **80 de 107 (74,8%)** |

### O número que o Victor pediu: **zero**

O aceite pede explicitamente *"quantas linhas do board de hoje têm exatamente 3 casas e sairiam"*.
São **zero**, nos cinco mercados. **A mudança de 3 para 4 casas não custa uma linha do board atual**
— todo o efeito das três barreiras vem da **faixa de odd** (25 das 27 linhas removidas). Se a A3
era percebida como a mudança cara, ela não é; a cara é a A5.

### O número de referência, conferido

O aceite manda conferir que a faixa 1,50–4,00 corta mais forte justo onde a porta de nota é
permissiva. Confirmado, entre linhas com preço da **Pinnacle** na janela corrente:

| faixa de premissa | linhas | passam na faixa |
|---|---|---|
| zero premissa | 5.499 | **67,0%** |
| entre 1 e 29 | 12.112 | 67,5% |
| **≥ 30 pontos** | 2.556 | **45,0%** |

A spec projetava 62% / 47%; hoje são **67,0% / 45,0%**. Os pontos percentuais mudaram porque o
universo cresceu desde a medição, mas **a inversão — o que é o achado — é maior, não menor**: a
faixa de odd derruba 55% das linhas mais bem pontuadas e só 33% das que não pontuaram nada.

## Reparo de documentação que a triagem da #118 prometeu

O cabeçalho do funil e o `_fact_value_funnel.yml` afirmavam que `porta_conjunto_completo` e
`porta_valor_estimavel` são **aninhadas**, e avisavam contra somá-las. Medido, é o oposto: são
quase **disjuntas** — 9.102 linhas de Handicap e 10.644 de Gols, todas de consenso, têm
`porta_valor_estimavel = TRUE` e `porta_conjunto_completo = FALSE`. Quem seguisse o aviso antigo
**subestimaria** a leitura marginal.

Aqui só sai o parágrafo que afirmava o oposto do medido. **A decisão sobre o que a porta deve fazer
é a #118**, que triei hoje como `ready-for-human`.

## Verificação

- **38 testes do funil verdes** (7 unit + 31 data), `--target prod`.
- `dbt parse` limpo; validação por `compile` + `bq query`, **nenhum `dbt run` em produção**.
- Sem guarda nova exigindo o board obedecer às barreiras — elas não estão em vigor; as guardas de
  publicação entram na virada, como o aceite pede.

## Depois do merge

`./build-and-push.sh dbt_futebol` — o modelo mudou. **Sem redeploy de workflow** (`fact_value_funnel`
já está no `--select` do `workflow_futebol_odds`), **sem migração no Postgres** e sem tocar RPC: o
funil não sincroniza.

⚠️ As três colunas chegam por `append_new_columns` e ficam **NULL para sempre** na linha de jogo já
apitado antes do deploy. É o append-only funcionando (ADR 0011), igual ao que aconteceu com
`nota_contexto` (A1) e `score_normalizado` (A6) — por isso não levam `not_null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTnLDMmnTqwZZwycqB3DT9
