### PR TITLE
futebol: as duas fronteiras de faixa sao 25 e 55, e o ROI nao discrimina (#107)

### DIFF
--- a/dbt_futebol/analyses/taskA_a4_fronteiras.sql
+++ b/dbt_futebol/analyses/taskA_a4_fronteiras.sql
@@ -282,7 +282,14 @@ grade AS (
         CASE WHEN score_normalizado >= {{ par[1] }} THEN 'Alta'
              WHEN score_normalizado >= {{ par[0] }} THEN 'Media'
              ELSE                                        'Baixa' END AS faixa
-    FROM com_lucro WHERE NOT sem_lado_apostado
+    -- ⚠️ `score_normalizado IS NOT NULL` é EXPLÍCITO, e não confiança no `ELSE`. O CASE das
+    -- faixas termina em `ELSE 'Baixa'`, então uma nota NULL — linha sem premissa avaliável —
+    -- cairia na `Baixa` sem carimbo nenhum, e "não pôde ser avaliada" viraria "foi avaliada
+    -- e tirou pouco", que é a confusão que a ADR 0003 existe para impedir. Medido nesta
+    -- rodada: ZERO linhas nulas na população publicável, nos cinco mercados. O filtro não
+    -- muda número nenhum hoje; ele existe para o dia em que mudar, e o bloco 0 conta quantas
+    -- ele tirou para que o zero seja LIDO em vez de suposto.
+    FROM com_lucro WHERE NOT sem_lado_apostado AND score_normalizado IS NOT NULL
     {%- if not loop.last %}
     UNION ALL
     {%- endif %}
@@ -437,7 +444,12 @@ bloco0 AS (
         CAST(NULL AS FLOAT64) AS roi,
         CAST(NULL AS FLOAT64) AS ep_cluster,
         CAST(NULL AS FLOAT64) AS gap_roi,
-        'n_apostas = pares que passam C1-C3; n_jogos = quantos discriminam' AS veredito
+        'pares que passam C1-C3 = ' || CAST(r.n_pares_validos AS STRING)
+          || ' | discriminam = ' || CAST(r.n_discriminam AS STRING)
+          || ' | linhas com nota NULA excluidas = '
+          || CAST((SELECT COUNT(*) FROM com_lucro
+                   WHERE NOT sem_lado_apostado AND score_normalizado IS NULL) AS STRING)
+          AS veredito
     FROM ramo r
 ),
 

--- a/dbt_futebol/analyses/taskA_a4_fronteiras.sql
+++ b/dbt_futebol/analyses/taskA_a4_fronteiras.sql
@@ -1,0 +1,423 @@
+{#
+    A4 — AS DUAS FRONTEIRAS DE FAIXA, NA ESCALA PÓS-A6 (issue #107)
+
+    A subtask foi ENCURTADA pela decisão do PM de 20/08: o corte de publicação por nota sai
+    do back, o board passa a mapear TODAS as faixas e a seleção vira filtro no front. Sobram
+    as duas fronteiras de `Alta` / `Média` / `Baixa`.
+
+    **Nada em produção muda nesta entrega.** Quem põe os números em vigor é a virada (#109).
+
+    Rodar com:
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_a4_fronteiras
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/taskA_a4_fronteiras.sql
+
+    ⚠️ RODAR A `taskA_a4_reconciliacao.sql` ANTES, e só seguir se ela vier verde. Ela prova
+    que o caminho universo→recomputação→nota desta análise é o mesmo que produziu o seed do
+    denominador. Sem isso, a curva abaixo tem a forma de sempre e a escala errada.
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    O UNIVERSO
+
+    Do `fact_value_funnel` (ADR 0011), que é append-only: é ele que torna o recorte
+    REPRODUZÍVEL, e a reprodutibilidade é o ponto — a mesma query de backtest, três dias
+    depois e sem mudar um byte, moveu a faixa 20–40 de −3,6% para +9,7%. O recorte congelado
+    são os dois tetos declarados abaixo, no padrão da `taskA_linha_de_base_funil.sql` (#106).
+
+      · `janela_e_corrente`         uma janela por candidato. O funil guarda até quatro
+                                    (daily, t24h, t1h, t15m) e a nota de contexto é a MESMA
+                                    nas quatro desde a #103 — contar as quatro faria o jogo
+                                    precificado cedo pesar 4×.
+      · `gravado_em < {{ var('a4_teto_gravado_em', '2026-08-28 21:00:00') }}`
+                                    o teto desta rodada.
+      · jogo LIQUIDADO              `fact_fixtures` com placar e status encerrado
+                                    (`futebol_jogo_encerrado`), kickoff < o mesmo teto.
+      · `lado IS NOT NULL`          a "12" da Dupla Chance sai (não é saída catalogada).
+
+    A NOTA vem RECOMPUTADA dos cinco modelos de premissa, não lida do registro congelado —
+    é a rota da A6 (#105) e da `taskA_a40_transporte.sql`, e a razão é a mesma: qualquer
+    janela do funil anterior ao deploy da A1 mistura DUAS ESCALAS DO GOLS (tetos 56/52 antes,
+    50/46 depois), e numa linha congelada não dá para saber se as duas premissas de movimento
+    acenderam. O DENOMINADOR, ao contrário, vem do SEED e nunca é recalculado (ADR 0005).
+
+    O PREÇO (`best_odd`) vem do FUNIL, congelado: é o preço que o Motor viu, não o que o
+    de-vig diria hoje.
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    A POPULAÇÃO SOBRE A QUAL AS FRONTEIRAS SÃO DECIDIDAS: o board PÓS-VIRADA
+
+    A faixa é o que o front filtra, então a restrição de forma tem de incidir sobre o que o
+    board vai de fato publicar depois da #109 — não sobre o funil inteiro nem sobre o board
+    de hoje. O gate pós-virada é recomposto aqui a partir dos insumos CONGELADOS do funil,
+    e não lido das colunas de porta, por um motivo: `porta_liquidez_estrita`, `porta_outlier`
+    e `porta_faixa_odd` chegaram na #104 por `append_new_columns` e são NULL para sempre nas
+    linhas de jogo já apitado — que são exatamente as linhas liquidadas de que esta medição
+    precisa. Recompor dos insumos é a única leitura que cobre a série inteira.
+
+      ENTRA (#109):  saída catalogada · conjunto completo · valor estimável · linha meia
+                     (AH/Gols) · odd mínima da DC · n_casas >= 4 · sem outlier de odd ·
+                     best_odd na faixa do mercado
+      SAI   (#109):  `edge > 0`, o piso de edge de consenso e a régua de nota (>= 40)
+
+    ⚠️ Os DOIS LADOS SEM LADO APOSTADO — o `Draw` do 1X2 e o `Pick` do Handicap — ficam FORA
+    das restrições de forma e são reportados à parte. Eles têm p95 = 0 e nota 0 POR
+    CONSTRUÇÃO (nenhuma premissa se aplica); contá-los dentro faria um terço do 1X2 aparecer
+    como `Baixa` e a restrição leria severidade de régua onde há ausência de lado — a
+    confusão que a coluna `sem_lado_apostado` existe para impedir (ADR 0005/0006).
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    REGRA DE DECISÃO, FIXADA ANTES DE OLHAR
+    ──────────────────────────────────────────────────────────────────────────────────────
+
+    A grade de pares candidatos (B = fronteira Baixa/Média, A = fronteira Média/Alta), em
+    INTEIROS sobre a escala normalizada 0–100:
+
+        (20,50) (25,55) (25,60) (30,60) (33,67) (35,65) (40,70) (50,75)
+
+    INCLUSIVIDADE, declarada porque este repositório já teve bug de knife-edge de float:
+        Baixa  =  score_normalizado <  B
+        Média  =  B <= score_normalizado <  A
+        Alta   =  score_normalizado >= A
+    O valor da fronteira pertence à faixa DE CIMA, nas duas.
+
+    RESTRIÇÕES (duras, sobre a população pós-virada, excluídos Draw e Pick):
+        C1  cada uma das três faixas fica com >= 10% das linhas
+        C2  nenhuma faixa fica com > 65% das linhas
+        C3  em cada um dos NOVE pares (mercado, lado) com p95 > 0, nenhuma faixa fica vazia
+
+    OBJETIVO, entre os pares que satisfazem C1–C3:
+        maximizar  ROI(Alta) − ROI(Baixa)
+
+    DESEMPATE, determinístico:
+        1º  o par mais redondo — menor (B mod 5) + (A mod 5)
+        2º  menor B
+
+    OS TRÊS RAMOS DE SAÍDA:
+      · nenhum par da grade satisfaz C1–C3
+            -> NENHUMA fronteira é proposta. A questão vai ao PM, como o aceite manda.
+      · o objetivo não discrimina — ROI(Alta) − ROI(Baixa) fica dentro de 1 EP agrupado por
+        fixture em TODOS os pares que passam
+            -> cai para o par de melhor EQUILÍBRIO (o que minimiza a maior faixa), e o
+               achado "a nota não separa ROI nesta janela" é reportado como resultado, não
+               escondido como ruído.
+      · ROI não monotônico entre as três faixas
+            -> é REPORTADO, e não corrigido. Desde a decisão do PM de 20/08 a nota INFORMA e
+               não barra: faixa é rótulo, não porta, e não precisa de ROI monotônico para
+               existir. Ajustar a grade para "consertar" a monotonia seria escolher depois de
+               olhar, que é o que esta seção existe para impedir.
+
+    ⚠️ NENHUM CORTE DE PUBLICAÇÃO É PROPOSTO por esta análise, em ramo nenhum. Se a medição
+    sugerir um, ele vai ao PM como pergunta (aceite da #107).
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    O QUE A SAÍDA TRAZ
+
+      bloco = '1. GRADE'      um par por linha: as três faixas, share, ROI, EP e o veredito
+                              das restrições. É onde a regra acima é aplicada.
+      bloco = '2. CURVA'      a curva de ROI por faixa do par ESCOLHIDO, com EP agrupado por
+                              fixture — o que o aceite pede como medição.
+      bloco = '3. LADOS'      a distribuição de nota por (mercado, lado): o aceite manda que
+                              ela entre na decisão, porque a nota é ABSOLUTA e os mercados
+                              publicam em taxas diferentes por desenho (ADR 0005).
+      bloco = '4. SEM LADO'   Draw e Pick, à parte, pelo motivo do ⚠️ acima.
+#}
+
+{%- set grade = [(20,50), (25,55), (25,60), (30,60), (33,67), (35,65), (40,70), (50,75)] -%}
+{%- set teto = var('a4_teto_gravado_em', '2026-08-28 21:00:00') -%}
+
+WITH universo AS (
+    SELECT
+        f.fixture_id,
+        f.market,
+        f.outcome,
+        f.line_key,
+        f.line_value,
+        f.kickoff_utc,
+        f.best_odd,
+        f.n_casas,
+        f.pen_odd_outlier,
+        f.prob_justa_fechamento,
+        f.porta_saida_catalogada,
+        f.porta_conjunto_completo,
+        {{ futebol_lado('f.market', 'f.outcome', 'f.line_value') }} AS lado
+    FROM {{ ref('fact_value_funnel') }} f
+    WHERE f.janela_e_corrente
+      AND f.gravado_em < TIMESTAMP '{{ teto }}'
+      AND f.kickoff_utc < TIMESTAMP '{{ teto }}'
+),
+
+{#- A liquidação. O funil não carrega placar nem status de propósito (ADR 0011, D10: status
+    muda depois do apito e uma coluna congelada mentiria), então o resultado vem de
+    `fact_fixtures`.
+
+    ⚠️ `status_short = 'FT'` E NÃO o `futebol_jogo_encerrado()`, que também aceita `AET` e
+    `PEN`. É o predicado do `task01_base`, e a diferença NÃO é estilo: o
+    `task01_liquidacao()` liquida mercado de 90 MINUTOS (1X2, Gols, Handicap, BTTS, DC), e
+    `goals_home`/`goals_away` de um jogo decidido na prorrogação carregam o placar DEPOIS
+    dela. Liquidar um Over 2.5 de mata-mata pelo placar com prorrogação dá vitória a uma
+    aposta que perdeu — erro de liquidação, não de escopo. O `futebol_jogo_encerrado()`
+    existe para outra pergunta ("o jogo acabou?", que é a do expurgo), e a #71 já separou as
+    duas noções no histórico de time. Fica FT, como no artefato que produziu a [0.1]. -#}
+jogos AS (
+    SELECT fixture_id, goals_home, goals_away
+    FROM {{ ref('fact_fixtures') }}
+    WHERE status_short = 'FT'
+      AND goals_home IS NOT NULL
+      AND goals_away IS NOT NULL
+),
+
+recomputado AS (
+    SELECT u.*, p.pts_premissas, p.penalidades_1x2_pts AS penalidades_especificas_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_1x2') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[1] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_ou_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_ou') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+     AND COALESCE(CAST(p.line_value AS STRING), 'NONE') = u.line_key
+    WHERE u.market = '{{ futebol_mercados_pontuados()[5] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_ah_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_ah') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+     AND COALESCE(CAST(p.line_value AS STRING), 'NONE') = u.line_key
+    WHERE u.market = '{{ futebol_mercados_pontuados()[4] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_btts_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_btts') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[8] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_dc_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_dc') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[12] }}'
+),
+
+{#- O `market_id` de volta, para a liquidação: o macro `task01_liquidacao` chaveia por id e o
+    funil carrega o slug. O mapa vem do `futebol_mercados_pontuados()`, nunca digitado à mão
+    (é a razão de aquele macro existir). -#}
+com_nota AS (
+    SELECT
+        r.*,
+        CASE r.market
+            {%- for mid, slug in futebol_mercados_pontuados().items() %}
+            WHEN '{{ slug }}' THEN {{ mid }}
+            {%- endfor %}
+        END AS market_id,
+        {{ futebol_nota_contexto() }} AS nota_contexto
+    FROM recomputado r
+    WHERE r.lado IS NOT NULL
+),
+
+normalizado AS (
+    SELECT
+        c.*,
+        s.p95,
+        {{ futebol_score_normalizado() }} AS score_normalizado
+    FROM com_nota c
+    -- LEFT: lado ausente do seed vira denominador NULL e o macro o resolve para zero
+    -- visível, nunca NULL silencioso. Quem cobra ausência é a guarda de cobertura.
+    LEFT JOIN {{ ref('futebol_p95_nota_contexto') }} s
+           ON s.market = c.market AND s.lado = c.lado
+),
+
+{#- O gate PÓS-VIRADA, recomposto dos insumos congelados — ver a seção do cabeçalho. -#}
+publicavel AS (
+    SELECT
+        n.*,
+        j.goals_home,
+        j.goals_away,
+        {{ task01_liquidacao('n.', 'j.') }} AS ganhou
+    FROM normalizado n
+    JOIN jogos j ON j.fixture_id = n.fixture_id
+    WHERE COALESCE(n.porta_saida_catalogada, FALSE)
+      AND COALESCE(n.porta_conjunto_completo, FALSE)
+      AND n.prob_justa_fechamento IS NOT NULL
+      AND COALESCE(n.n_casas >= {{ var('liquidez_min_casas', 4) }}, FALSE)
+      AND NOT COALESCE(n.pen_odd_outlier, TRUE)
+      AND n.best_odd IS NOT NULL
+      AND CASE
+              WHEN n.market = '{{ futebol_mercados_pontuados()[12] }}'
+                  THEN n.best_odd BETWEEN {{ var('faixa_odd_dc_min', 1.25) }}
+                                      AND {{ var('faixa_odd_dc_max', 2.00) }}
+              ELSE     n.best_odd BETWEEN {{ var('faixa_odd_min', 1.50) }}
+                                      AND {{ var('faixa_odd_max', 4.00) }}
+          END
+      -- linha meia só onde a linha existe (AH e Gols); 1X2/BTTS/DC não têm linha.
+      AND (n.line_value IS NULL OR {{ futebol_e_linha_meia('n.line_value') }})
+),
+
+com_lucro AS (
+    SELECT
+        *,
+        IF(ganhou, best_odd, 0) - 1 AS lucro,
+        -- os dois lados sem lado apostado saem das restrições e vão para o bloco 4.
+        (lado IN ('Draw', 'Pick')) AS sem_lado_apostado
+    FROM publicavel
+),
+
+{#- ======================================================================================
+    BLOCO 1 — A GRADE. Um par por linha × três faixas.
+    ====================================================================================== -#}
+grade AS (
+    {%- for par in grade %}
+    SELECT
+        '{{ par[0] }}/{{ par[1] }}' AS par,
+        {{ par[0] }} AS b, {{ par[1] }} AS a,
+        fixture_id, market, lado, lucro,
+        CASE WHEN score_normalizado >= {{ par[1] }} THEN 'Alta'
+             WHEN score_normalizado >= {{ par[0] }} THEN 'Media'
+             ELSE                                        'Baixa' END AS faixa
+    FROM com_lucro WHERE NOT sem_lado_apostado
+    {%- if not loop.last %}
+    UNION ALL
+    {%- endif %}
+    {%- endfor %}
+),
+
+grade_media AS (
+    SELECT g.*, AVG(lucro) OVER (PARTITION BY par, faixa) AS media_faixa
+    FROM grade g
+),
+grade_por_fixture AS (
+    SELECT par, faixa, fixture_id, SUM(lucro - media_faixa) AS resid_jogo
+    FROM grade_media GROUP BY 1, 2, 3
+),
+grade_erro AS (
+    SELECT par, faixa, SUM(POW(resid_jogo, 2)) AS soma_quad, COUNT(*) AS n_jogos
+    FROM grade_por_fixture GROUP BY 1, 2
+),
+grade_faixa AS (
+    SELECT
+        g.par, ANY_VALUE(g.b) AS b, ANY_VALUE(g.a) AS a, g.faixa,
+        COUNT(*)                                                   AS n_apostas,
+        ANY_VALUE(e.n_jogos)                                       AS n_jogos,
+        ROUND(AVG(g.lucro) * 100, 1)                               AS roi,
+        ROUND(SAFE_DIVIDE(SQRT(ANY_VALUE(e.soma_quad)), COUNT(*)) * 100, 1) AS ep_cluster,
+        ROUND(COUNT(*) * 100.0
+              / SUM(COUNT(*)) OVER (PARTITION BY g.par), 1)        AS share_pct
+    FROM grade_media g
+    JOIN grade_erro e USING (par, faixa)
+    GROUP BY g.par, g.faixa
+),
+
+{#- C3: nenhuma faixa vazia em nenhum dos nove pares (mercado, lado) com p95 > 0. -#}
+grade_c3 AS (
+    SELECT par,
+           MIN(n_faixas_no_lado) = 3 AS c3_ok
+    FROM (
+        SELECT par, market, lado, COUNT(DISTINCT faixa) AS n_faixas_no_lado
+        FROM grade GROUP BY 1, 2, 3
+    )
+    GROUP BY par
+),
+
+grade_veredito AS (
+    SELECT
+        f.par,
+        ANY_VALUE(f.b) AS b, ANY_VALUE(f.a) AS a,
+        MIN(f.share_pct)                          AS menor_share,
+        MAX(f.share_pct)                          AS maior_share,
+        MIN(f.share_pct) >= 10                    AS c1_ok,
+        MAX(f.share_pct) <= 65                    AS c2_ok,
+        ANY_VALUE(c3.c3_ok)                       AS c3_ok,
+        MAX(IF(f.faixa = 'Alta',  f.roi, NULL))
+          - MAX(IF(f.faixa = 'Baixa', f.roi, NULL)) AS gap_roi,
+        MAX(IF(f.faixa = 'Alta',  f.ep_cluster, NULL)) AS ep_alta,
+        MAX(IF(f.faixa = 'Baixa', f.ep_cluster, NULL)) AS ep_baixa
+    FROM grade_faixa f
+    JOIN grade_c3 c3 USING (par)
+    GROUP BY f.par
+),
+
+bloco1 AS (
+    SELECT
+        '1. GRADE' AS bloco,
+        v.par AS chave, f.faixa AS sub,
+        f.n_apostas, f.n_jogos, f.share_pct, f.roi, f.ep_cluster,
+        v.gap_roi,
+        CASE WHEN NOT v.c1_ok THEN 'reprova C1 (faixa < 10%)'
+             WHEN NOT v.c2_ok THEN 'reprova C2 (faixa > 65%)'
+             WHEN NOT v.c3_ok THEN 'reprova C3 (lado com faixa vazia)'
+             ELSE                  'passa C1-C3' END AS veredito
+    FROM grade_veredito v
+    JOIN grade_faixa f USING (par)
+),
+
+{#- A ESCOLHA, aplicando a regra do cabeçalho: entre os pares que passam, maior gap; empate
+    pelo par mais redondo, depois pelo menor B. -#}
+escolhido AS (
+    SELECT par, b, a
+    FROM grade_veredito
+    WHERE c1_ok AND c2_ok AND c3_ok
+    ORDER BY gap_roi DESC,
+             (MOD(b, 5) + MOD(a, 5)) ASC,
+             b ASC
+    LIMIT 1
+),
+
+bloco2 AS (
+    SELECT
+        '2. CURVA (par escolhido)' AS bloco,
+        f.par AS chave, f.faixa AS sub,
+        f.n_apostas, f.n_jogos, f.share_pct, f.roi, f.ep_cluster,
+        CAST(NULL AS FLOAT64) AS gap_roi,
+        CAST(NULL AS STRING)  AS veredito
+    FROM grade_faixa f
+    JOIN escolhido e USING (par)
+),
+
+{#- BLOCO 3 — a distribuição por (mercado, lado), que o aceite manda entrar na decisão. -#}
+bloco3 AS (
+    SELECT
+        '3. LADOS' AS bloco,
+        c.market || '/' || c.lado AS chave,
+        CAST(NULL AS STRING) AS sub,
+        COUNT(*)                                    AS n_apostas,
+        COUNT(DISTINCT c.fixture_id)                AS n_jogos,
+        CAST(NULL AS FLOAT64)                       AS share_pct,
+        ROUND(AVG(c.lucro) * 100, 1)                AS roi,
+        CAST(NULL AS FLOAT64)                       AS ep_cluster,
+        CAST(NULL AS FLOAT64)                       AS gap_roi,
+        'nota media ' || CAST(ROUND(AVG(c.score_normalizado), 1) AS STRING)
+          || ' | p10 ' || CAST(APPROX_QUANTILES(c.score_normalizado, 10)[OFFSET(1)] AS STRING)
+          || ' | mediana ' || CAST(APPROX_QUANTILES(c.score_normalizado, 10)[OFFSET(5)] AS STRING)
+          || ' | p90 ' || CAST(APPROX_QUANTILES(c.score_normalizado, 10)[OFFSET(9)] AS STRING)
+          AS veredito
+    FROM com_lucro c
+    WHERE NOT c.sem_lado_apostado
+    GROUP BY 1, 2, 3
+),
+
+bloco4 AS (
+    SELECT
+        '4. SEM LADO APOSTADO (fora das restricoes)' AS bloco,
+        c.market || '/' || c.lado AS chave,
+        CAST(NULL AS STRING) AS sub,
+        COUNT(*)                     AS n_apostas,
+        COUNT(DISTINCT c.fixture_id) AS n_jogos,
+        CAST(NULL AS FLOAT64)        AS share_pct,
+        ROUND(AVG(c.lucro) * 100, 1) AS roi,
+        CAST(NULL AS FLOAT64)        AS ep_cluster,
+        CAST(NULL AS FLOAT64)        AS gap_roi,
+        'nota sempre 0 por construcao' AS veredito
+    FROM com_lucro c
+    WHERE c.sem_lado_apostado
+    GROUP BY 1, 2, 3
+)
+
+SELECT * FROM bloco1
+UNION ALL SELECT * FROM bloco2
+UNION ALL SELECT * FROM bloco3
+UNION ALL SELECT * FROM bloco4
+ORDER BY bloco, chave, sub

--- a/dbt_futebol/analyses/taskA_a4_fronteiras.sql
+++ b/dbt_futebol/analyses/taskA_a4_fronteiras.sql
@@ -214,6 +214,10 @@ com_nota AS (
             WHEN '{{ slug }}' THEN {{ mid }}
             {%- endfor %}
         END AS market_id,
+        -- o `task01_liquidacao()` chaveia por `outcome_side`; o funil chama a mesma coisa
+        -- de `outcome`. Renomear aqui, e não reescrever o macro, mantém a liquidação
+        -- byte a byte a mesma que produziu os números publicados da [0.1].
+        r.outcome AS outcome_side,
         {{ futebol_nota_contexto() }} AS nota_contexto
     FROM recomputado r
     WHERE r.lado IS NOT NULL
@@ -354,16 +358,69 @@ bloco1 AS (
     JOIN grade_faixa f USING (par)
 ),
 
-{#- A ESCOLHA, aplicando a regra do cabeçalho: entre os pares que passam, maior gap; empate
-    pelo par mais redondo, depois pelo menor B. -#}
-escolhido AS (
-    SELECT par, b, a
+{#- ======================================================================================
+    A ESCOLHA — a regra do cabeçalho aplicada em SQL, e não a olho.
+
+    O ramo E1 ("o objetivo não discrimina") é avaliado ANTES do objetivo, porque é ele que
+    decide QUAL objetivo vale. `discrimina` é o gap maior que 1 erro-padrão da DIFERENÇA,
+    com o EP da diferença tomado como a raiz da soma dos quadrados dos dois EP de faixa.
+
+    ⚠️ Essa soma IGNORA a covariância: um mesmo fixture pode ter linha na Alta e na Baixa,
+    então os dois clusters não são independentes e o EP da diferença é aproximado. A
+    aproximação é conservadora para o lado que interessa aqui — ela não INVENTA
+    discriminação — e a leitura alternativa (comparar o gap contra o maior dos dois EP de
+    faixa, sem somar) devolve o MESMO veredito em todos os oito pares. Está medido, não
+    suposto: nenhuma das duas leituras muda o ramo.
+    ====================================================================================== -#}
+grade_discrimina AS (
+    SELECT
+        *,
+        SQRT(POW(ep_alta, 2) + POW(ep_baixa, 2)) AS ep_gap,
+        ABS(gap_roi) > SQRT(POW(ep_alta, 2) + POW(ep_baixa, 2)) AS discrimina
     FROM grade_veredito
     WHERE c1_ok AND c2_ok AND c3_ok
-    ORDER BY gap_roi DESC,
-             (MOD(b, 5) + MOD(a, 5)) ASC,
-             b ASC
+),
+
+ramo AS (
+    SELECT
+        COUNT(*)                         AS n_pares_validos,
+        COUNTIF(discrimina)              AS n_discriminam,
+        -- E2: nenhum par passa nas restrições -> nada é proposto.
+        -- E1: nenhum par discrimina        -> cai para o melhor equilíbrio.
+        CASE WHEN COUNT(*) = 0        THEN 'E2 - nenhum par satisfaz C1-C3: NADA e proposto, a questao vai ao PM'
+             WHEN COUNTIF(discrimina) = 0 THEN 'E1 - o objetivo nao discrimina: escolha por EQUILIBRIO'
+             ELSE                          'PRINCIPAL - maior gap de ROI entre Alta e Baixa'
+        END AS ramo_aplicado
+    FROM grade_discrimina
+),
+
+escolhido AS (
+    SELECT d.par, d.b, d.a
+    FROM grade_discrimina d
+    CROSS JOIN ramo r
+    ORDER BY
+        -- no ramo principal manda o gap; no E1 ele é ignorado e manda o equilíbrio
+        -- (menor faixa máxima). O desempate é o mesmo nos dois: par mais redondo, menor B.
+        CASE WHEN r.n_discriminam > 0 THEN d.gap_roi      ELSE NULL END DESC,
+        CASE WHEN r.n_discriminam = 0 THEN d.maior_share  ELSE NULL END ASC,
+        (MOD(d.b, 5) + MOD(d.a, 5)) ASC,
+        d.b ASC
     LIMIT 1
+),
+
+bloco0 AS (
+    SELECT
+        '0. RAMO DA REGRA' AS bloco,
+        r.ramo_aplicado AS chave,
+        (SELECT par FROM escolhido) AS sub,
+        r.n_pares_validos AS n_apostas,
+        r.n_discriminam   AS n_jogos,
+        CAST(NULL AS FLOAT64) AS share_pct,
+        CAST(NULL AS FLOAT64) AS roi,
+        CAST(NULL AS FLOAT64) AS ep_cluster,
+        CAST(NULL AS FLOAT64) AS gap_roi,
+        'n_apostas = pares que passam C1-C3; n_jogos = quantos discriminam' AS veredito
+    FROM ramo r
 ),
 
 bloco2 AS (
@@ -416,7 +473,8 @@ bloco4 AS (
     GROUP BY 1, 2, 3
 )
 
-SELECT * FROM bloco1
+SELECT * FROM bloco0
+UNION ALL SELECT * FROM bloco1
 UNION ALL SELECT * FROM bloco2
 UNION ALL SELECT * FROM bloco3
 UNION ALL SELECT * FROM bloco4

--- a/dbt_futebol/analyses/taskA_a4_fronteiras.sql
+++ b/dbt_futebol/analyses/taskA_a4_fronteiras.sql
@@ -315,15 +315,33 @@ grade_faixa AS (
     GROUP BY g.par, g.faixa
 ),
 
-{#- C3: nenhuma faixa vazia em nenhum dos nove pares (mercado, lado) com p95 > 0. -#}
+{#- C3: nenhuma faixa vazia em nenhum dos nove pares (mercado, lado) com p95 > 0.
+
+    ⚠️ A lista dos nove vem do SEED, e não dos lados que por acaso aparecem na população.
+    A diferença importa: um lado que sumisse inteiro do board pós-virada teria ZERO faixas,
+    e um `MIN` sobre os grupos observados simplesmente não o veria — C3 passaria contando
+    oito lados em vez de nove, e o descarte seria silencioso, que é o que a ADR 0006 proíbe.
+    Não é hipótese: nesta mesma rodada o `Pick` do Handicap sumiu exatamente assim (zero
+    linhas publicáveis, apagadas pela porta de linha meia). Ele está fora de C3 por ser
+    `sem_lado_apostado`, mas o modo de falha é o mesmo e o próximo lado a sumir pode não ter
+    essa isenção. Com o CROSS JOIN abaixo, sumir vira C3 vermelho em vez de C3 mudo. -#}
+lados_do_seed AS (
+    SELECT market, lado
+    FROM {{ ref('futebol_p95_nota_contexto') }}
+    WHERE p95 > 0
+),
 grade_c3 AS (
-    SELECT par,
-           MIN(n_faixas_no_lado) = 3 AS c3_ok
-    FROM (
+    SELECT
+        p.par,
+        MIN(COALESCE(o.n_faixas_no_lado, 0)) = 3 AS c3_ok
+    FROM (SELECT DISTINCT par FROM grade) p
+    CROSS JOIN lados_do_seed s
+    LEFT JOIN (
         SELECT par, market, lado, COUNT(DISTINCT faixa) AS n_faixas_no_lado
         FROM grade GROUP BY 1, 2, 3
-    )
-    GROUP BY par
+    ) o
+      ON o.par = p.par AND o.market = s.market AND o.lado = s.lado
+    GROUP BY p.par
 ),
 
 grade_veredito AS (

--- a/dbt_futebol/analyses/taskA_a4_reconciliacao.sql
+++ b/dbt_futebol/analyses/taskA_a4_reconciliacao.sql
@@ -1,0 +1,131 @@
+{#
+    A4 — RECONCILIAÇÃO POR RESPOSTA CONHECIDA: a máquina desta medição é a da A6?
+
+    Esta análise NÃO produz número da entrega. Ela existe para provar, antes de qualquer
+    leitura de ROI, que o caminho universo→recomputação→nota de contexto usado na
+    `taskA_a4_fronteiras.sql` é o MESMO que produziu o seed `futebol_p95_nota_contexto`
+    (#105, PR #125). Se ele não for, as fronteiras saem medidas numa escala que não é a
+    que está em produção, e o defeito seria invisível: a curva de ROI teria a forma de
+    sempre e os números estariam errados por um fator que ninguém veria.
+
+    É o mesmo padrão da `taskf_reconciliacao_01.sql` e da `task01_reconciliacao.sql` —
+    reconciliação por resposta conhecida. A resposta conhecida aqui são os onze p95 do seed.
+
+    Rodar com:
+      DBT_PROFILES_DIR=.. ../.venv/bin/dbt compile --select taskA_a4_reconciliacao
+      bq query --use_legacy_sql=false < target/compiled/dbt_futebol/analyses/taskA_a4_reconciliacao.sql
+
+    ──────────────────────────────────────────────────────────────────────────────────────
+    O CRITÉRIO DE ACEITE, fixado antes de rodar
+
+      · os DOIS lados estruturalmente zerados (1X2/Draw e Handicap/Pick) reproduzem
+        EXATAMENTE 0                                                     -> obrigatório
+      · os NOVE lados restantes reproduzem o seed dentro de ±2 pontos     -> obrigatório
+      · qualquer desvio maior  ->  a máquina NÃO é a da A6. PARAR e diagnosticar antes de
+        medir ROI. Não "ajustar a tolerância depois de olhar".
+
+    POR QUE ±2 E NÃO ZERO. A A6 mediu em 2026-08-26 sobre o funil inteiro daquele instante,
+    sem teto de `gravado_em`. O funil cresceu desde então: candidato de jogo por vir é
+    reescrito a cada ciclo de odds e candidato novo entrou. Reproduzir o recorte de kickoff
+    (16/06–31/08, que é o que o seed carimba) reconstrói quase toda a população, mas não
+    exatamente a mesma — e a diferença que sobra é crescimento de janela, não divergência de
+    máquina. Um p95 é um quantil discreto sobre pontuação inteira: dois dias de rodada o
+    movem em ponto, não em dezena. Desvio grande seria outra coisa — outra composição, outro
+    eixo de lado, outro universo — e é isso que o critério separa.
+
+    ⚠️ A irreprodutibilidade da #78 é herdada da A6 e não é novidade desta medição: premissa
+    recomputada acende em número ligeiramente diferente a cada build com o insumo congelado.
+    Ela está DENTRO do ±2, não fora dele.
+#}
+
+WITH universo AS (
+    SELECT
+        f.fixture_id,
+        f.market,
+        f.outcome,
+        f.line_key,
+        f.line_value,
+        f.kickoff_utc,
+        {{ futebol_lado('f.market', 'f.outcome', 'f.line_value') }} AS lado
+    FROM {{ ref('fact_value_funnel') }} f
+    -- uma janela por candidato, exatamente como a `taskA_a6_p95.sql`.
+    WHERE f.janela_e_corrente
+      -- o recorte de kickoff que o seed carimba em `janela_inicio` / `janela_fim`.
+      AND DATE(f.kickoff_utc) BETWEEN DATE '2026-06-16' AND DATE '2026-08-31'
+),
+
+{#- A recomputação. As chaves de junção são as mesmas da `taskA_a6_p95.sql`, que por sua vez
+    as copiou do `fact_value_funnel` — reescrevê-las diferente aqui mediria outra coisa. -#}
+recomputado AS (
+    SELECT u.*, p.pts_premissas, p.penalidades_1x2_pts AS penalidades_especificas_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_1x2') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[1] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_ou_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_ou') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+     AND COALESCE(CAST(p.line_value AS STRING), 'NONE') = u.line_key
+    WHERE u.market = '{{ futebol_mercados_pontuados()[5] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_ah_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_ah') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+     AND COALESCE(CAST(p.line_value AS STRING), 'NONE') = u.line_key
+    WHERE u.market = '{{ futebol_mercados_pontuados()[4] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_btts_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_btts') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[8] }}'
+
+    UNION ALL
+    SELECT u.*, p.pts_premissas, p.penalidades_dc_pts
+    FROM universo u
+    JOIN {{ ref('int_futebol_premissas_dc') }} p
+      ON p.fixture_id = u.fixture_id AND p.outcome = u.outcome
+    WHERE u.market = '{{ futebol_mercados_pontuados()[12] }}'
+),
+
+com_nota AS (
+    SELECT r.*, {{ futebol_nota_contexto() }} AS nota_contexto
+    FROM recomputado r
+    WHERE r.lado IS NOT NULL
+),
+
+medido AS (
+    SELECT DISTINCT
+        market,
+        lado,
+        {{ futebol_p95('nota_contexto') }} OVER (PARTITION BY market, lado) AS p95_recomputado,
+        COUNT(*) OVER (PARTITION BY market, lado)                           AS n_recomputado
+    FROM com_nota
+)
+
+SELECT
+    m.market,
+    m.lado,
+    s.p95                          AS p95_seed,
+    m.p95_recomputado,
+    m.p95_recomputado - s.p95      AS desvio,
+    s.n_candidatos                 AS n_seed,
+    m.n_recomputado,
+    CASE
+        WHEN s.p95 = 0 AND m.p95_recomputado = 0             THEN 'OK (zero estrutural)'
+        WHEN s.p95 = 0 OR  m.p95_recomputado = 0             THEN 'FALHA (zero de um lado só)'
+        WHEN ABS(m.p95_recomputado - s.p95) <= 2             THEN 'OK'
+        ELSE                                                      'FALHA (fora de +-2)'
+    END AS veredito
+FROM medido m
+-- FULL OUTER de propósito: lado no seed e ausente da recomputação (ou o inverso) tem de
+-- aparecer como linha, nunca sumir no join. Cobertura é metade do que esta análise prova.
+FULL OUTER JOIN {{ ref('futebol_p95_nota_contexto') }} s
+  ON s.market = m.market AND s.lado = m.lado
+ORDER BY m.market, m.lado

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -810,6 +810,14 @@ inteira.
 **5. `best_odd` é o máximo entre casas** e enviesa o ROI para cima, uniformemente nas três faixas.
 Não afeta a comparação entre faixas, que é o que a decisão usa.
 
+**5b. O universo fecha por fora, e nenhuma linha entra sem nota.** As 3.930 linhas da grade
+reconciliam por `outcome` contra uma contagem independente do funil: Handicap 546 + 542, Gols
+625 + 656, BTTS 372 + 369, Dupla Chance 197 + 198, Resultado 268 + 157 — os mesmos 3.930, à
+linha. E as linhas com nota NULA excluídas são **zero** nos cinco mercados, número que a própria
+análise imprime no bloco 0 em vez de deixar suposto: o `CASE` das faixas termina em
+`ELSE 'Baixa'`, e sem o filtro explícito uma linha sem premissa avaliável seria contada como
+"avaliada e tirou pouco" — a confusão que a ADR 0003 existe para impedir.
+
 **6. O que invalida estas fronteiras.** Elas são medidas sobre a escala do seed
 `futebol_p95_nota_contexto`. Mudança no seed, no catálogo de premissas, no
 `macros/futebol_nota_contexto.sql` ou no conjunto de barreiras da #109 **remede as duas

--- a/docs/TASKA_RESULTADOS.md
+++ b/docs/TASKA_RESULTADOS.md
@@ -651,3 +651,173 @@ A análise é **parametrizada** — serve para qualquer candidato, não só para
 `NULL` nos mercados sem linha (1X2, BTTS, Dupla Chance): a comparação é NULL-safe. Nada em produção
 muda: é `compile` + `bq query`, nunca `dbt run`. E como o `hist` fecha versões em vez de apagá-las,
 rerodar para este jogo passado devolve as mesmas transições — hoje e daqui a um ano.
+
+---
+
+# Ticket #107 — As duas fronteiras de faixa, na escala pós-A6
+
+**Análises:** `dbt_futebol/analyses/taskA_a4_fronteiras.sql` (a medição) e
+`dbt_futebol/analyses/taskA_a4_reconciliacao.sql` (a resposta conhecida, que roda antes)
+**Fonte:** `fact_value_funnel` (ADR 0011), nota **recomputada**, denominador do **seed**
+**Rodada publicada:** **2026-08-28**, teto `gravado_em` e `kickoff_utc` em `2026-08-28 21:00:00 UTC`
+
+## As duas fronteiras
+
+**`Baixa` < 25 ≤ `Média` < 55 ≤ `Alta`**, na escala normalizada 0–100. Fronteira pertence à
+faixa **de cima**, nas duas — declarado porque este repositório já teve bug de knife-edge de float.
+
+**E o número que importa mais que as fronteiras: elas NÃO saíram do ROI, porque o ROI não
+discrimina.** Dos oito pares candidatos, os oito passam nas três restrições de forma e **nenhum**
+separa `Alta` de `Baixa` além de um erro-padrão. O ramo E1 da regra fixada de antemão foi o que
+disparou, e ele manda escolher por equilíbrio de distribuição — o par que deixa a maior faixa
+menor. É o 25/55, com a maior faixa em 36,4%.
+
+## A regra, que foi fixada antes de olhar
+
+Está no cabeçalho da `taskA_a4_fronteiras.sql` e no commit `1136f48`, **anterior a qualquer
+execução** — a ordem do histórico é a prova, como o cabeçalho da `taskA_a40_transporte.sql` foi a
+da A4.0. Em resumo: grade de oito pares inteiros; três restrições duras (cada faixa ≥ 10%, nenhuma
+> 65%, e nenhuma faixa vazia em nenhum dos nove lados com p95 > 0); objetivo de maior `ROI(Alta) −
+ROI(Baixa)`; desempate pelo par mais redondo; e três ramos de saída declarados, entre eles o que
+de fato ocorreu.
+
+O ramo **é derivado em SQL, não a olho** (bloco `0. RAMO DA REGRA` da saída): a análise conta
+quantos pares passam e quantos discriminam, e a ordenação da escolha troca de critério sozinha.
+
+## A curva de ROI do par escolhido
+
+Erro-padrão agrupado por fixture, como o aceite pede.
+
+| faixa | linhas | jogos | share | ROI | EP |
+|---|---:|---:|---:|---:|---:|
+| `Alta` (≥ 55) | 1.306 | 350 | 33,2% | **−4,6** | 2,7 |
+| `Média` (25–55) | 1.192 | 361 | 30,3% | **−8,4** | 2,6 |
+| `Baixa` (< 25) | 1.432 | 368 | 36,4% | **−2,6** | 3,3 |
+
+**Três leituras, e as três desagradáveis:**
+
+**1. A ordenação está invertida, e a `Média` é o fundo.** `Baixa` (−2,6) rende melhor que `Alta`
+(−4,6), e a `Média` é pior que as duas pontas. Isso é **reportado e não corrigido**, pelo ramo E3
+da regra: desde a decisão do PM de 20/08 a nota **informa e não barra**, então faixa é rótulo e não
+porta — ela não precisa de ROI monotônico para existir. Mexer na grade para "consertar" a monotonia
+seria escolher depois de olhar, que é o que a regra existe para impedir.
+
+**2. Nenhuma faixa é positiva, em par nenhum da grade.** Os 24 valores de ROI medidos (oito pares ×
+três faixas) vão de −1,6 a −8,8. Isto é o **board pós-virada** — a população que a #109 vai
+publicar, com as três barreiras de preço já em vigor.
+
+**3. Nenhum corte de publicação é proposto**, em ramo nenhum, como o aceite manda. O que a leitura 2
+sugere vai ao PM **como pergunta**, não ao modelo como porta.
+
+## A grade inteira
+
+| par | share Baixa / Média / Alta | ROI Baixa / Média / Alta | gap A−B | EP do gap | discrimina? |
+|---|---|---|---:|---:|---|
+| 20/50 | 30,4 / 31,1 / 38,5 | −1,6 / −8,7 / −4,8 | −3,2 | 4,5 | não |
+| **25/55** | **36,4 / 30,3 / 33,2** | **−2,6 / −8,4 / −4,6** | **−2,0** | **4,3** | **não** |
+| 25/60 | 36,4 / 36,6 / 26,9 | −2,6 / −8,4 / −3,6 | −1,0 | 4,5 | não |
+| 30/60 | 47,2 / 25,9 / 26,9 | −4,1 / −8,1 / −3,6 | +0,5 | 4,0 | não |
+| 33/67 | 48,8 / 28,1 / 23,1 | −3,7 / −8,8 / −3,2 | +0,5 | 4,2 | não |
+| 35/65 | 52,4 / 24,5 / 23,1 | −5,7 / −5,3 / −3,2 | +2,5 | 4,1 | não |
+| 40/70 | 56,3 / 25,7 / 18,0 | −5,5 / −3,1 / −6,3 | −0,8 | 4,7 | não |
+| 50/75 | 61,5 / 24,9 / 13,7 | −5,2 / −4,1 / −6,0 | −0,8 | 5,2 | não |
+
+O 35/65 é o par de **maior gap** (+2,5) e teria sido o escolhido pelo objetivo principal. Ele não
+foi escolhido porque 2,5 está dentro do EP de 4,1 — e porque ele deixa a `Baixa` com 52,4% do
+board, contra 36,4% do 25/55.
+
+⚠️ **O EP do gap ignora a covariância.** Um mesmo fixture pode ter linha na `Alta` e na `Baixa`, e
+a raiz da soma dos quadrados trata os dois clusters como independentes. A aproximação não
+**inventa** discriminação, e a leitura alternativa — comparar o gap contra o maior dos dois EP de
+faixa, sem somar — devolve o mesmo veredito nos oito pares. Medido, não suposto.
+
+## A distribuição por (mercado, lado), que o aceite manda entrar na decisão
+
+A nota é **absoluta** (ADR 0005), então fronteira única não significa volume igual — e isso precisa
+estar dito junto do número.
+
+| mercado / lado | linhas | ROI | nota média | p10 | mediana | p90 |
+|---|---:|---:|---:|---:|---:|---:|
+| asian_handicap / Azarao | 460 | −8,7 | 49,4 | 0 | 67 | 100 |
+| asian_handicap / Favorito | 628 | −1,0 | 37,8 | 0 | 33 | 92 |
+| btts / No | 372 | −1,9 | 45,5 | 0 | 57 | 100 |
+| btts / Yes | 369 | −6,7 | 34,1 | 0 | 29 | 79 |
+| double_chance / unico | 395 | −0,2 | 43,7 | 0 | 29 | 93 |
+| goals_over_under / Over | 625 | −8,9 | 35,2 | 0 | 32 | 73 |
+| goals_over_under / Under | 656 | −5,2 | 32,0 | 0 | 22 | 72 |
+| match_winner / Away | 157 | +1,2 | 39,3 | 0 | 36 | 91 |
+| match_winner / Home | 268 | −11,4 | 32,9 | 0 | 24 | 76 |
+
+**O p10 é ZERO nos NOVE lados.** Pelo menos um décimo de cada lado tem nota de contexto zerada —
+não é peculiaridade de um mercado, é o formato da distribuição inteira. É o que faz a `Baixa`
+existir com folga em qualquer par da grade, e é por isso que a restrição C3 nunca mordeu.
+
+O `Azarao` do Handicap é o lado de nota mais alta (média 49,4, mediana 67) **e** o segundo pior de
+ROI (−8,7). Os dois lados de melhor ROI — `match_winner/Away` (+1,2) e `double_chance/unico` (−0,2)
+— têm nota média no meio da tabela. É a leitura 1 acontecendo lado a lado, e não só no agregado.
+
+## Os dois lados sem lado apostado, à parte
+
+Ficam fora das restrições de propósito: têm p95 = 0 e nota 0 **por construção** — nenhuma premissa
+se aplica —, e contá-los dentro faria a restrição ler severidade de régua onde há ausência de lado
+(ADR 0005/0006).
+
+- **`match_winner/Draw` — 257 linhas, ROI +15,1.** É a **única célula positiva de toda esta
+  medição**, e ela é o empate, cuja nota é sempre zero. Não é recomendação de nada: é o aviso de
+  que a nota, nesta janela, não está capturando o que ordena resultado. Vai ao PM junto da
+  leitura 2.
+- **`asian_handicap/Pick` — ZERO linhas.** Não é amostra pequena, é ausência total, e a causa foi
+  isolada: nesta janela existem **762 linhas de `Pick` liquidadas**, e **nenhuma** passa na porta de
+  linha meia — a linha 0 não é meia (`MOD(ROUND(0×4), 4) = 0`). As outras portas não são o gargalo:
+  **642 das 762** passariam na liquidez de 4 casas e **390** na faixa de odd. É a porta de linha
+  meia sozinha que apaga o lado inteiro, antes de qualquer nota. É o defeito que a B3 chama de "a
+  linha de handicap zero fica invisível", medido aqui pelo outro lado — e é a razão de o `Pick` ter
+  entrado no seed da A6 (952 candidatos na janela dela) sem nunca aparecer no board.
+
+## Ressalvas de validade — o que esta medição herda e o que ela deixa armado
+
+**1. O recorte é congelado, e é reproduzível.** Para reler exatamente esta rodada:
+
+```sql
+FROM fact_value_funnel
+WHERE janela_e_corrente
+  AND gravado_em  < TIMESTAMP '2026-08-28 21:00:00'
+  AND kickoff_utc < TIMESTAMP '2026-08-28 21:00:00'
+```
+
+É o padrão da #106, e é a resposta ao vício que matou o 40 e o 60: a mesma query de backtest, três
+dias depois e sem mudar um byte, moveu a faixa 20–40 de −3,6% para +9,7%. O funil é append-only,
+então esta fatia fica preservada.
+
+**2. A nota vem recomputada, e herda a #78.** Universo do funil, pontos dos cinco modelos como
+estão hoje — a rota da A6. Premissa recomputada acende em número ligeiramente diferente a cada
+build com o insumo congelado. A reconciliação mede o tamanho disso: dez dos onze p95 reproduzem o
+seed **exatamente**, e o `match_winner/Home` fica em **−2** (31 contra 33), dentro do ±2 declarado
+antes de rodar. É o único lado que se moveu, e é o de menor amostra dos que pontuam.
+
+**3. A liquidação é `status_short = 'FT'`, e não o `futebol_jogo_encerrado()`.** O
+`task01_liquidacao()` liquida mercado de 90 minutos; `goals_home`/`goals_away` de jogo decidido na
+prorrogação já trazem o placar depois dela, e liquidar um Over 2.5 de mata-mata por ele daria
+vitória a uma aposta que perdeu. Consequência declarada: **jogo de mata-mata que foi para a
+prorrogação ou para os pênaltis está fora desta medição**, como está fora da [0.1].
+
+**4. O gate pós-virada é recomposto, não lido.** `porta_liquidez_estrita`, `porta_outlier` e
+`porta_faixa_odd` chegaram por `append_new_columns` na #104 e são NULL para sempre nas linhas de
+jogo já apitado — que são exatamente as liquidadas. Recompor dos insumos congelados
+(`n_casas`, `pen_odd_outlier`, `best_odd`, `line_value`) é a única leitura que cobre a série
+inteira.
+
+**5. `best_odd` é o máximo entre casas** e enviesa o ROI para cima, uniformemente nas três faixas.
+Não afeta a comparação entre faixas, que é o que a decisão usa.
+
+**6. O que invalida estas fronteiras.** Elas são medidas sobre a escala do seed
+`futebol_p95_nota_contexto`. Mudança no seed, no catálogo de premissas, no
+`macros/futebol_nota_contexto.sql` ou no conjunto de barreiras da #109 **remede as duas
+fronteiras**. Em particular: **a B3 (a linha zero do Handicap) muda o par `Pick`** de zero linhas
+publicáveis para até 642 nesta janela — se ela entrar entre esta medição e a virada, invalida o que
+está escrito aqui. A B3 vai **depois** da #109, ou estas fronteiras são remedidas.
+
+## O que ainda não é decisão
+
+O `accepted_values` de `faixa` e as duas RPCs recebem `Alta` / `Média` / `Baixa` com estas
+fronteiras **na virada (#109)**, não aqui. Nada em produção muda nesta entrega.


### PR DESCRIPTION
Fecha a **#107 — [A4] As duas fronteiras de faixa, na escala pós-A6**.

**Nada em produção muda.** São duas `analyses/` (compile-only, fora de todo `--select` de workflow) e a seção da #107 no `docs/TASKA_RESULTADOS.md`. Quem põe os números em vigor é a virada (#109).

---

## O resultado

**`Baixa` < 25 ≤ `Média` < 55 ≤ `Alta`**, na escala normalizada 0–100. Fronteira pertence à faixa **de cima**, nas duas — declarado porque este repositório já teve bug de knife-edge de float.

**E o achado importa mais que os números: as fronteiras NÃO saíram do ROI, porque o ROI não discrimina.** Dos oito pares candidatos, os oito passam nas três restrições de forma, e **nenhum** separa `Alta` de `Baixa` além de um erro-padrão agrupado por fixture. Disparou o ramo **E1** da regra fixada de antemão, que manda escolher por equilíbrio de distribuição — o par que deixa a maior faixa menor.

### A curva do par escolhido

| faixa | linhas | jogos | share | ROI | EP |
|---|---:|---:|---:|---:|---:|
| `Alta` (≥ 55) | 1.306 | 350 | 33,2% | **−4,6** | 2,7 |
| `Média` (25–55) | 1.192 | 361 | 30,3% | **−8,4** | 2,6 |
| `Baixa` (< 25) | 1.432 | 368 | 36,4% | **−2,6** | 3,3 |

**A ordenação está invertida e a `Média` é o fundo.** Reportado e **não corrigido**, pelo ramo E3: desde a decisão do PM de 20/08 a nota **informa e não barra**, então faixa é rótulo e não porta — ela não precisa de ROI monotônico para existir. Mexer na grade para "consertar" a monotonia seria escolher depois de olhar.

**Nenhuma faixa é positiva, em par nenhum.** Os 24 ROI medidos (8 pares × 3 faixas) vão de −1,6 a −8,8, e isto é o **board pós-virada**. **Nenhum corte de publicação é proposto** — o que essa leitura sugere vai ao PM como pergunta, como o aceite manda.

---

## A regra de decisão, e a prova de que ela foi fixada antes

O aceite exige que a regra seja fixada **antes de olhar o resultado** e escrita aqui. Ela está no cabeçalho da `taskA_a4_fronteiras.sql`, e a prova é a **ordem do histórico**:

| commit | o quê |
|---|---|
| `1136f48` | **a regra** — grade, restrições, objetivo, desempate e os três ramos de saída. Anterior a qualquer execução. |
| `fcea35f` | os números, e o doc |
| `b24fc14` | correção de implementação do C3, com invariância conferida |
| `4e3b363` | nota NULA sai explícita, com invariância conferida |

**A regra, em resumo:**

- **Grade** de oito pares inteiros: (20,50) (25,55) (25,60) (30,60) (33,67) (35,65) (40,70) (50,75)
- **Restrições duras**, sobre a população pós-virada, excluídos os lados sem lado apostado: **C1** cada faixa ≥ 10% · **C2** nenhuma > 65% · **C3** nenhuma faixa vazia em nenhum dos **nove** lados com p95 > 0
- **Objetivo**: maximizar `ROI(Alta) − ROI(Baixa)`
- **Desempate**: par mais redondo, depois menor B
- **Três ramos de saída**, todos declarados: E2 (nenhum par passa → nada é proposto, a questão vai ao PM) · **E1** (nenhum par discrimina → escolha por equilíbrio) · E3 (ROI não monotônico → reportado, não corrigido)

O ramo é **derivado em SQL** (bloco `0. RAMO DA REGRA`), não a olho: a análise conta quantos pares passam e quantos discriminam, e a ordenação da escolha troca de critério sozinha.

O 35/65 é o par de **maior gap** (+2,5) e teria vencido pelo objetivo principal. Não venceu porque 2,5 está dentro do EP de 4,1 — e porque deixa a `Baixa` com 52,4% do board, contra 36,4% do 25/55.

---

## O recorte congelado

O aceite pede que o PR diga sobre qual recorte a medição foi feita. É a resposta ao vício que matou o 40 e o 60 — a mesma query, três dias depois e sem mudar um byte, moveu a faixa 20–40 de −3,6% para +9,7%:

```sql
FROM fact_value_funnel
WHERE janela_e_corrente
  AND gravado_em  < TIMESTAMP '2026-08-28 21:00:00'
  AND kickoff_utc < TIMESTAMP '2026-08-28 21:00:00'
```

O funil é append-only, então esta fatia fica preservada. É o padrão da `taskA_linha_de_base_funil.sql` (#106).

---

## A reconciliação por resposta conhecida, que rodou ANTES

`taskA_a4_reconciliacao.sql` prova que o caminho universo→recomputação→nota é o mesmo que produziu o seed do denominador da A6. Sem ela a curva teria a forma de sempre e a escala errada, e nada acusaria.

**Critério fixado antes de rodar:** os dois lados estruturalmente zerados reproduzem exatamente 0; os nove restantes, dentro de ±2.

**Resultado:** dez dos onze reproduzem **exatamente**; `match_winner/Home` fica em **−2** (31 contra 33) — o único que se moveu, e o de menor amostra entre os que pontuam.

---

## Dois achados colaterais, medidos

**`match_winner/Draw` rende +15,1 em 257 linhas** — a única célula positiva da medição inteira, e é o empate, cuja nota é sempre zero por construção. Fica fora das restrições de propósito (`sem_lado_apostado`), e vai ao PM junto da leitura de que nenhuma faixa é positiva.

**`asian_handicap/Pick` tem ZERO linhas publicáveis, e a causa foi isolada.** Das **762** linhas de `Pick` liquidadas na janela, **nenhuma** passa na porta de linha meia (a linha 0 não é meia); **642** passariam na liquidez de 4 casas e **390** na faixa de odd. É a porta de linha meia sozinha que apaga o lado inteiro, antes de qualquer nota.

⚠️ **Consequência de sequenciamento:** é o defeito que a B3 chama de "a linha de handicap zero fica invisível". Consertá-la leva o `Pick` de zero para até 642 linhas publicáveis — **a B3 tem de entrar depois da #109, ou estas fronteiras são remedidas.**

---

## Três decisões de método que ficam registradas

**1. A liquidação é `status_short = 'FT'`, não o `futebol_jogo_encerrado()`.** É o predicado do `task01_base`, e a diferença não é estilo: o `task01_liquidacao()` liquida mercado de **90 minutos**, e `goals_home`/`goals_away` de jogo decidido na prorrogação já trazem o placar depois dela. Liquidar um Over 2.5 de mata-mata por ele daria vitória a uma aposta que perdeu. Consequência declarada: jogo que foi para prorrogação ou pênaltis está fora desta medição, como está fora da [0.1].

**2. A nota vem recomputada; o denominador, do seed.** Universo do funil, pontos dos cinco modelos como estão hoje — a rota da A6 (#105), pelo mesmo motivo: qualquer janela anterior ao deploy da A1 mistura duas escalas do Gols, e numa linha congelada não dá para saber se as duas premissas de movimento acenderam. O denominador **nunca** é recalculado (ADR 0005). Herda a irreprodutibilidade da #78, e a reconciliação mede o tamanho dela.

**3. O gate pós-virada é recomposto dos insumos congelados, não lido das colunas de porta.** `porta_liquidez_estrita`, `porta_outlier` e `porta_faixa_odd` chegaram por `append_new_columns` na #104 e são NULL para sempre nas linhas de jogo já apitado — que são exatamente as liquidadas. Recompor é a única leitura que cobre a série inteira.

---

## Revisão

O `/code-review` despachado para esta branch **morreu por limite de sessão** e não produziu achado nenhum — porque não chegou a rodar, não porque o código esteja limpo. A revisão foi feita à mão e encontrou duas fragilidades da classe **descarte silencioso**, as duas corrigidas com invariância verificada antes do commit:

- **C3 lia os lados que apareciam, não os nove do seed.** Um lado que sumisse inteiro teria zero grupos, o `MIN` não o veria, e C3 passaria contando oito. Não é hipótese — o `Pick` sumiu exatamente assim nesta rodada. Passou a vir do seed por `CROSS JOIN` com `COALESCE(..., 0)`: sumir vira C3 **vermelho** em vez de C3 **mudo**.
- **Nota NULL cairia na `Baixa` pelo `ELSE`**, e "não pôde ser avaliada" viraria "foi avaliada e tirou pouco" (ADR 0003). Filtro explícito, e o bloco 0 passa a **imprimir** a contagem de excluídas para o zero ser lido em vez de suposto.

Nenhuma das duas move um número: mesmo ramo E1, mesmos 8 pares, mesmo 25/55, mesma curva.

**Conferências que rodaram:** `dbt parse` verde · as duas análises compilam · o universo de 3.930 linhas reconcilia por `outcome` contra uma contagem independente do funil, à linha · zero linhas com nota nula, medido sobre um superconjunto da população.

---

## O que este PR NÃO faz

- Não muda o board, o gate, o `score` nem nenhuma RPC.
- Não propõe corte de publicação, em ramo nenhum.
- Não mexe no seed do denominador.
- Não exige rebuild de imagem nem deploy: `analyses/` é compile-only e não está em `--select` de workflow nenhum.

O `accepted_values` de `faixa` e as duas RPCs recebem estes valores **na virada (#109)**.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTnLDMmnTqwZZwycqB3DT9
