### PR TITLE
ci(futebol): marcar PR que altera modelo de tabela sincronizada

### DIFF
--- a/.github/workflows/marca-pr-tabela-sincronizada.yml
+++ b/.github/workflows/marca-pr-tabela-sincronizada.yml
@@ -1,0 +1,90 @@
+# Marca PR que altera modelo cuja tabela é sincronizada para o Postgres de serving.
+#
+# POR QUE ISTO EXISTE:
+# mudar coluna de um modelo que o sync copia exige o DDL correspondente no Postgres no
+# MESMO deploy. Sem isso o parity check pré-flight do sync aborta TUDO — as 22 tabelas,
+# em PRD e DEV — até alguém aplicar o DDL à mão. Já aconteceu 4 vezes. Na última (PR #122,
+# que removeu `linha_subindo`/`linha_descendo` de `int_futebol_premissas_ou`) o serving
+# ficou 3 dias congelado servindo dado de 26/08, e o que acusou foi um e-mail diário que
+# ninguém leu. Nas quatro vezes o gatilho foi o mesmo: mudou o mart, ninguém olhou o
+# Postgres.
+#
+# POR QUE ISTO SÓ MARCA, e não verifica:
+# não dá para verificar aqui. No momento do PR o modelo ainda não rodou, então o BigQuery
+# ainda tem as colunas VELHAS — um parity check daria verde no PR #122 e só ficaria
+# vermelho depois do deploy. Verificação real exigiria `dbt compile` + dry-run no BQ para
+# extrair as colunas de saída do modelo. Desproporcional hoje; anotado como possível.
+#
+# ⚠️ A allowlist é lida do `data-engineering` em tempo de execução, não copiada para cá.
+# Uma segunda cópia derivaria — que é a doença que este aviso trata. Ver
+# scripts/tabelas_sincronizadas.py.
+
+name: PR toca tabela sincronizada
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'dbt_futebol/models/**/*.sql'
+
+jobs:
+  marca:
+    name: tabela sincronizada?
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Modelos sincronizados alterados
+        id: detecta
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # O script sai != 0 se não conseguir ler a allowlist: marcar a menos é pior que
+          # não marcar, então a falha tem que derrubar o job em vez de virar lista vazia.
+          tabelas=$(git diff --name-only "$BASE" "$HEAD" \
+            | python3 scripts/tabelas_sincronizadas.py)
+          echo "tabelas<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$tabelas" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Marcar e avisar
+        if: steps.detecta.outputs.tabelas != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          TABELAS: ${{ steps.detecta.outputs.tabelas }}
+        run: |
+          set -euo pipefail
+          ja_marcado=$(gh pr view "$PR" --json labels \
+            --jq '.labels[].name' | grep -Fx 'tabela-sincronizada' || true)
+          gh pr edit "$PR" --add-label tabela-sincronizada
+
+          # Comentário só na primeira vez: um aviso repetido a cada push é o mesmo papel de
+          # parede que deixou o sync 3 dias parado.
+          if [ -n "$ja_marcado" ]; then
+            echo "PR já marcado; sem comentário novo."
+            exit 0
+          fi
+
+          lista=$(echo "$TABELAS" | sed 's/^/- `/; s/$/`/')
+          gh pr comment "$PR" --body "$(cat <<EOF
+          ⚠️ **Este PR altera modelo cuja tabela é sincronizada para o Postgres de serving.**
+
+          $lista
+
+          Se a mudança **adiciona, remove ou renomeia coluna**, o DDL correspondente no Postgres (PRD **e** DEV) precisa sair no mesmo deploy. Sem ele o parity check pré-flight aborta o sync inteiro — as 22 tabelas, nos dois ambientes — de hora em hora, até alguém aplicar o DDL à mão. Nada é truncado nem corrompido; o serving simplesmente congela no último dado bom, e o app continua respondendo com ele.
+
+          Antes de mergear, conferir quem lê essas colunas: \`data-engineering/docs/contrato-serving-gerado.md\` (mapa RPC×tabela gerado do \`pg_proc\` do PRD). Função não bloqueia \`DROP COLUMN\` — a RPC só estoura em runtime, depois.
+
+          Se a mudança não mexe em coluna, ignorar este aviso.
+          EOF
+          )"

--- a/.github/workflows/marca-pr-tabela-sincronizada.yml
+++ b/.github/workflows/marca-pr-tabela-sincronizada.yml
@@ -26,6 +26,9 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'dbt_futebol/models/**/*.sql'
+      # A `fact_value_opportunities_hist` e SNAPSHOT, nao modelo: uma das 22 tabelas
+      # sincronizadas mora aqui, e sem esta linha mudar coluna nela nao dispara nada.
+      - 'dbt_futebol/snapshots/**/*.sql'
 
 jobs:
   marca:
@@ -34,6 +37,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    # A guarda de "comenta uma vez so" e um read-then-write nao atomico: dois pushes
+    # seguidos leem a label ausente antes de qualquer um gravar, e os dois comentam.
+    concurrency:
+      group: marca-pr-sincronizada-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout
@@ -50,7 +58,12 @@ jobs:
           set -euo pipefail
           # O script sai != 0 se não conseguir ler a allowlist: marcar a menos é pior que
           # não marcar, então a falha tem que derrubar o job em vez de virar lista vazia.
-          tabelas=$(git diff --name-only "$BASE" "$HEAD" \
+          # Tres pontos (merge-base), nao dois: com dois, tudo que entrou na base depois
+          # do fork aparece como alterado por este PR, e o aviso passa a citar arquivo que
+          # o PR nao tocou -- o papel de parede que este workflow existe para evitar.
+          # --no-renames porque a deteccao de rename imprime SO o destino, e renomear um
+          # modelo sincronizado (que DERRUBA a tabela no BQ, o pior caso) passaria batido.
+          tabelas=$(git diff --no-renames --name-only "$BASE...$HEAD" \
             | python3 scripts/tabelas_sincronizadas.py)
           echo "tabelas<<EOF" >> "$GITHUB_OUTPUT"
           echo "$tabelas" >> "$GITHUB_OUTPUT"
@@ -83,7 +96,7 @@ jobs:
 
           Se a mudança **adiciona, remove ou renomeia coluna**, o DDL correspondente no Postgres (PRD **e** DEV) precisa sair no mesmo deploy. Sem ele o parity check pré-flight aborta o sync inteiro — as 22 tabelas, nos dois ambientes — de hora em hora, até alguém aplicar o DDL à mão. Nada é truncado nem corrompido; o serving simplesmente congela no último dado bom, e o app continua respondendo com ele.
 
-          Antes de mergear, conferir quem lê essas colunas: \`data-engineering/docs/contrato-serving-gerado.md\` (mapa RPC×tabela gerado do \`pg_proc\` do PRD). Função não bloqueia \`DROP COLUMN\` — a RPC só estoura em runtime, depois.
+          Antes de mergear, conferir quem lê essas colunas em \`dbt_futebol/docs/contrato-serving-rpcs.md\`. Função não bloqueia \`DROP COLUMN\` — a RPC só estoura em runtime, depois.
 
           Se a mudança não mexe em coluna, ignorar este aviso.
           EOF

--- a/scripts/tabelas_sincronizadas.py
+++ b/scripts/tabelas_sincronizadas.py
@@ -1,0 +1,73 @@
+"""Diz quais modelos alterados num PR alimentam tabelas sincronizadas para o Postgres.
+
+POR QUE ISTO EXISTE:
+mudar coluna de um modelo que o sync copia exige o DDL correspondente no Postgres no MESMO
+deploy. Sem isso o parity check pré-flight aborta o sync inteiro — as 22 tabelas, nos dois
+ambientes — até alguém aplicar o DDL à mão. Aconteceu 4 vezes; na última (PR #122, colunas
+`linha_subindo`/`linha_descendo`) o serving ficou 3 dias congelado. Nas quatro o gatilho foi
+o mesmo: mudou o mart, ninguém olhou o Postgres.
+
+Isto NÃO valida nada, e não dá para validar aqui: no momento do PR o modelo ainda não rodou,
+então o BigQuery ainda tem as colunas velhas e um parity check daria verde. Isto marca — põe
+o aviso na frente de quem revisa, no momento em que a mudança ainda é barata.
+
+POR QUE A LISTA VEM DO data-engineering EM TEMPO DE EXECUÇÃO:
+a allowlist canônica é `FUTEBOL_SYNC_TABLES_ORDERED` em `src/config.py` do
+`data-engineering`. Uma cópia aqui derivaria — que é exatamente a doença que este aviso
+existe para tratar. Os dois repos são públicos, então basta ler o raw. Falha de rede derruba
+o job de propósito: marcar a menos seria pior que não marcar.
+"""
+import os
+import re
+import sys
+import urllib.request
+
+CONFIG_URL = (
+    "https://raw.githubusercontent.com/tech-lamjav/data-engineering/master/src/config.py"
+)
+LISTA = "FUTEBOL_SYNC_TABLES_ORDERED"
+
+
+def allowlist(url: str = CONFIG_URL) -> set[str]:
+    with urllib.request.urlopen(url, timeout=30) as r:
+        fonte = r.read().decode("utf-8")
+
+    bloco = re.search(rf"^{LISTA}\s*=\s*\[(.*?)^\]", fonte, re.S | re.M)
+    if not bloco:
+        raise RuntimeError(f"{LISTA} não encontrada em {url} — o config mudou de forma?")
+
+    tabelas = set(re.findall(r'"([^"]+)"', bloco.group(1)))
+    if not tabelas:
+        raise RuntimeError(f"{LISTA} veio vazia — parsing quebrado, não allowlist vazia.")
+    return tabelas
+
+
+def afetadas(arquivos, tabelas: set[str]) -> list[str]:
+    """Modelo alterado cujo nome está na allowlist. O nome do arquivo é o nome da tabela."""
+    achadas = set()
+    for caminho in arquivos:
+        caminho = caminho.strip()
+        if not caminho.endswith(".sql"):
+            continue
+        nome = os.path.basename(caminho)[: -len(".sql")]
+        if nome in tabelas:
+            achadas.add(nome)
+    return sorted(achadas)
+
+
+def main():
+    arquivos = sys.stdin.read().splitlines()
+    try:
+        tabelas = allowlist()
+    except Exception as e:
+        print(f"ERRO ao ler a allowlist: {e}", file=sys.stderr)
+        return 2
+
+    encontradas = afetadas(arquivos, tabelas)
+    for t in encontradas:
+        print(t)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tabelas_sincronizadas.py
+++ b/scripts/tabelas_sincronizadas.py
@@ -20,6 +20,7 @@ o job de propósito: marcar a menos seria pior que não marcar.
 import os
 import re
 import sys
+import time
 import urllib.request
 
 CONFIG_URL = (
@@ -27,10 +28,27 @@ CONFIG_URL = (
 )
 LISTA = "FUTEBOL_SYNC_TABLES_ORDERED"
 
+# Só o que o dbt_futebol produz conta. Sem o prefixo, o `dbt_nba/models/marts/dim_teams.sql`
+# — nome homônimo de uma tabela sincronizada do futebol — marcaria o PR por engano.
+PREFIXOS = ("dbt_futebol/models/", "dbt_futebol/snapshots/")
+
+TENTATIVAS = 3
+
 
 def allowlist(url: str = CONFIG_URL) -> set[str]:
-    with urllib.request.urlopen(url, timeout=30) as r:
-        fonte = r.read().decode("utf-8")
+    # Falhar fechado é o desenho (marcar a menos é pior que não marcar), mas sem retry um
+    # blip de rede no raw.githubusercontent pinta de vermelho todo PR de dbt por motivo
+    # que nada tem a ver com o PR.
+    for tentativa in range(1, TENTATIVAS + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=30) as r:
+                fonte = r.read().decode("utf-8")
+            break
+        except Exception as e:
+            if tentativa == TENTATIVAS:
+                raise
+            print(f"tentativa {tentativa} falhou ({e}); repetindo", file=sys.stderr)
+            time.sleep(2**tentativa)
 
     bloco = re.search(rf"^{LISTA}\s*=\s*\[(.*?)^\]", fonte, re.S | re.M)
     if not bloco:
@@ -47,7 +65,7 @@ def afetadas(arquivos, tabelas: set[str]) -> list[str]:
     achadas = set()
     for caminho in arquivos:
         caminho = caminho.strip()
-        if not caminho.endswith(".sql"):
+        if not caminho.endswith(".sql") or not caminho.startswith(PREFIXOS):
             continue
         nome = os.path.basename(caminho)[: -len(".sql")]
         if nome in tabelas:


### PR DESCRIPTION
O outro lado de [tech-lamjav/data-engineering#62](https://github.com/tech-lamjav/data-engineering/issues/62) / [PR #63](https://github.com/tech-lamjav/data-engineering/pull/63): lá entra a **detecção**, aqui entra o **aviso no momento da mudança**.

## O problema

Mudar coluna de um modelo cuja tabela o sync copia exige o DDL correspondente no Postgres no **mesmo deploy**. Sem ele, o parity check pré-flight aborta o sync inteiro — as 22 tabelas, em PRD e DEV — de hora em hora, até alguém aplicar o DDL à mão. Nada é truncado nem corrompido: o serving congela no último dado bom e o app segue respondendo com ele.

Já aconteceu **4 vezes**. Na última, o PR #122 removeu `linha_subindo`/`linha_descendo` de `int_futebol_premissas_ou` e o serving ficou 3 dias congelado. Nas quatro o gatilho foi o mesmo: mudou o mart, ninguém olhou o Postgres.

## O que entra

Um job de PR que detecta modelo alterado cuja tabela está na `FUTEBOL_SYNC_TABLES_ORDERED`, põe a label `tabela-sincronizada` e comenta uma vez com o que conferir.

**Ele só marca, e não dá para verificar aqui.** No momento do PR o modelo ainda não rodou, então o BigQuery ainda tem as colunas **velhas** — um parity check daria verde no próprio #122 e só ficaria vermelho depois do deploy. Verificação real exigiria `dbt compile` + dry-run no BQ para extrair as colunas de saída; desproporcional agora, anotado como possível.

**A allowlist é lida do `data-engineering` em tempo de execução**, não copiada para cá. Uma segunda cópia derivaria — que é exatamente a doença que este aviso trata. Falha ao ler derruba o job de propósito: marcar a menos é pior que não marcar.

## Revisão

O segundo commit fecha 7 achados de code review. Os três com consequência real:

- o diff era de **dois pontos** entre as pontas; com a base andando depois do fork, tudo que entrou nela aparecia como alterado por este PR e o aviso citava arquivo que o PR nunca tocou — o papel de parede que o workflow existe para evitar. Agora é merge-base;
- faltava `--no-renames`. A detecção de rename do git imprime **só o destino**, então renomear um modelo sincronizado — que **derruba a tabela no BigQuery**, o pior caso possível para o sync — não aparecia no diff e o PR não era marcado;
- a `fact_value_opportunities_hist` é **snapshot**, não modelo: vive em `dbt_futebol/snapshots/` e o filtro de paths só cobria `models/`. Mudar coluna numa das 22 tabelas sincronizadas não disparava nada.

Mais quatro: casamento por basename sem escopo de path (o `dbt_nba` tem um `dim_teams.sql` homônimo, e um PR de NBA seria marcado como futebol), comentário apontando para doc inexistente, ausência de `concurrency` (dois pushes seguidos comentavam duas vezes) e `urlopen` sem retry.

## Verificação

O YAML foi parseado e o shell extraído foi **executado com um `gh` stubado**: heredoc, dedent e a lista renderizam corretos. O script foi rodado contra o `config.py` real (parseia as 22 tabelas), a colisão com o `dbt_nba` foi reproduzida e corrigida, e a `fact_value_opportunities_hist` foi confirmada em `snapshots/`. A label `tabela-sincronizada` já existe no repo.

Nenhum modelo dbt é tocado, então **não há imagem para rebuildar**.

## Ordem sugerida

Mergear o [DE #63](https://github.com/tech-lamjav/data-engineering/pull/63) primeiro. O comentário deste workflow aponta hoje para `dbt_futebol/docs/contrato-serving-rpcs.md`, que existe; o mapa gerado do `pg_proc` (mais completo, e que corrige a subcontagem de RPCs daquele doc) só passa a existir no master do DE depois daquele merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiZat1DdbMjaPXvLHhszhn
