### PR TITLE
fix(futebol): porta_conjunto_completo vira porta_cobertura_pinnacle (#118)

### DIFF
--- a/dbt_futebol/analyses/taskA_a4_fronteiras.sql
+++ b/dbt_futebol/analyses/taskA_a4_fronteiras.sql
@@ -137,7 +137,7 @@ WITH universo AS (
         f.pen_odd_outlier,
         f.prob_justa_fechamento,
         f.porta_saida_catalogada,
-        f.porta_conjunto_completo,
+        f.porta_cobertura_pinnacle,
         {{ futebol_lado('f.market', 'f.outcome', 'f.line_value') }} AS lado
     FROM {{ ref('fact_value_funnel') }} f
     WHERE f.janela_e_corrente
@@ -245,7 +245,7 @@ publicavel AS (
     FROM normalizado n
     JOIN jogos j ON j.fixture_id = n.fixture_id
     WHERE COALESCE(n.porta_saida_catalogada, FALSE)
-      AND COALESCE(n.porta_conjunto_completo, FALSE)
+      AND COALESCE(n.porta_cobertura_pinnacle, FALSE)
       AND n.prob_justa_fechamento IS NOT NULL
       AND COALESCE(n.n_casas >= {{ var('liquidez_min_casas', 4) }}, FALSE)
       AND NOT COALESCE(n.pen_odd_outlier, TRUE)

--- a/dbt_futebol/analyses/taskA_linha_de_base_funil.sql
+++ b/dbt_futebol/analyses/taskA_linha_de_base_funil.sql
@@ -100,13 +100,12 @@
     a quatro cópias (#101/#114). Os prefixos `c1..c7` existem porque são o produto da análise — a
     conjunção inteira já existe e se lê.
 
-    ⚠️ AS DUAS PORTAS DE "COMPLETUDE" SÃO COISAS DIFERENTES, e por isso saem com nomes diferentes.
-    A `porta_conjunto_completo` é `pin_n_outcomes >= N` — a versão anterior à #22, que pergunta
-    "a Pinnacle cobriu?". A regra da ADR 0002 (`n_outcomes_valor = conjunto_esperado`) mora no
-    de-vig e aparece como `porta_valor_estimavel`. Medido (números no documento de resultados),
-    o aninhamento existe no sentido CONTRÁRIO ao que o cabeçalho do mart declara: reprovar em
-    valor implica reprovar em cobertura, e nunca o inverso. Aqui é só rótulo; o predicado é
-    assunto da #118. Nada em produção muda nesta entrega.
+    ⚠️ RESOLVIDO NA #118 (31/08): a porta que perguntava "a Pinnacle cobriu?" chamava-se
+    `porta_conjunto_completo` e o nome escondia dois predicados diferentes por trás de um só.
+    Ela virou `porta_cobertura_pinnacle` no mart — `pin_n_outcomes >= N`, exatamente a versão
+    anterior à #22. A regra da ADR 0002 (`n_outcomes_valor = conjunto_esperado`) mora no de-vig
+    e aparece aqui como `porta_valor_estimavel`; as duas nunca foram aninhadas. Este bloco só lê
+    o mart — nada em produção muda nesta entrega.
 
     ⚠️ O EMPATE DO 1X2 SAI DA FILA (seção 2, com os números inteiros). Ele é um terço do universo
     do 1X2 POR CONSTRUÇÃO — nunca teve lado apostado, nenhuma premissa se aplica (ADR 0005/0006).
@@ -188,16 +187,16 @@ portas AS (
         origem,
         gravado_em,
         sem_lado_apostado,
-        porta_saida_catalogada  AS p1,
-        porta_conjunto_completo AS p2,
-        porta_valor_estimavel   AS p3,
-        porta_linha_meia        AS p4,
-        porta_liquidez          AS p5,
-        porta_odd_dc            AS p6,
-        porta_edge              AS p7,
-        porta_nota              AS p8,
+        porta_saida_catalogada   AS p1,
+        porta_cobertura_pinnacle AS p2,
+        porta_valor_estimavel    AS p3,
+        porta_linha_meia         AS p4,
+        porta_liquidez           AS p5,
+        porta_odd_dc             AS p6,
+        porta_edge               AS p7,
+        porta_nota               AS p8,
         {# a conjunção das oito, DERIVADA NO MART. Ver o ⚠️ do cabeçalho. #}
-        passou_no_gate          AS c8
+        passou_no_gate           AS c8
     FROM funil
 ),
 

--- a/dbt_futebol/models/marts/_fact_value_funnel.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel.yml
@@ -128,25 +128,29 @@ models:
       - name: porta_saida_catalogada
         description: "TRUE = a saída é pontuada pelo Motor. FALSE só na \"12\" da Dupla Chance, hoje. É a porta que existe para que uma saída precificada e não modelada seja um DESCARTE registrado, e não um sumiço."
         tests: [not_null]
-      - name: porta_conjunto_completo
+      - name: porta_cobertura_pinnacle
         description: >
-          TRUE = o conjunto de saídas do de-vig tem o tamanho declarado (ADR 0002): 1X2
-          exige 3 saídas da Pinnacle, Handicap e Gols exigem o par, BTTS exige o par no
-          consenso, Dupla Chance exige o conjunto 1X2 DE ORIGEM completo. É a maior
-          rejeição do sistema (~49% do universo) e até esta entrega ela não existia em
-          lugar nenhum — saía num `WHERE` dentro do join, antes de qualquer nota.
+          TRUE = a Pinnacle precifica o conjunto de saídas inteiro deste mercado
+          (`pin_n_outcomes >= N`), em 1X2 (3), Handicap e Gols (2 cada) — INDEPENDENTE de
+          qual fonte a linha realmente usou (Pinnacle ou fallback de consenso). A Pinnacle
+          não precifica BTTS nem tem eixo próprio na Dupla Chance, então nesses dois a
+          porta é TRIVIALMENTE TRUE (mesmo padrão de `porta_odd_dc` fora da DC).
+
+          ⚠️ RENOMEADA NA #118 (opção 1, 31/08). Chamava-se `porta_conjunto_completo` e o
+          nome mentia de duas formas: (a) em AH/Gols ela reprovava linha de consenso com
+          preço válido só porque a PINNACLE especificamente não cobriu — 9.102 linhas de
+          Handicap e 10.644 de Gols, todas de consenso, tinham `porta_valor_estimavel =
+          TRUE` e a porta velha `= FALSE`; (b) em BTTS/DC ela usava `n_outcomes_valor >=
+          N`, que é uma cópia disfarçada de `porta_valor_estimavel` (zero divergência
+          medida em 8.525 linhas) e não testava nada próprio. `passou_no_gate` não mudou
+          em nenhuma linha — só o nome e a lógica dos dois ramos redundantes.
         tests: [not_null]
       - name: porta_valor_estimavel
         description: >
           TRUE = há `prob_justa_fechamento` — a regra da ADR 0002
-          (`n_outcomes_valor = conjunto_esperado`).
-
-          ⚠️ CORREÇÃO (#118, medida em 28/08): esta descrição afirmava que a porta é
-          ANINHADA com `porta_conjunto_completo` e avisava contra somá-las. É o oposto do
-          medido — elas são quase DISJUNTAS, e quem seguir o aviso antigo SUBESTIMA a
-          leitura marginal: 9.102 linhas de Handicap e 10.644 de Gols, todas de consenso,
-          têm `porta_valor_estimavel = TRUE` e `porta_conjunto_completo = FALSE`. As duas
-          fazem perguntas diferentes apesar do nome; ver a #118 (`ready-for-human`).
+          (`n_outcomes_valor = conjunto_esperado`). Independente de `porta_cobertura_pinnacle`
+          — as duas fazem perguntas diferentes (ver a #118 para o porquê do nome antigo
+          confundir isso) e não são aninhadas.
         tests: [not_null]
       - name: porta_liquidez
         description: >
@@ -231,7 +235,7 @@ models:
         tests:
           - accepted_values:
               arguments:
-                values: ['saida_nao_catalogada', 'conjunto_incompleto', 'valor_nao_estimavel',
+                values: ['saida_nao_catalogada', 'sem_cobertura_pinnacle', 'valor_nao_estimavel',
                          'sem_liquidez', 'sem_edge', 'nota_abaixo_da_regua', 'sem_lado_apostado',
                          'linha_nao_meia', 'odd_dc_abaixo_do_minimo']
       - name: sem_lado_apostado

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -7,7 +7,7 @@ version: 2
 # portas — quantas linhas cada uma remove sozinha, e quantas ela ainda remove depois
 # das anteriores. Numa contagem sobre produção essa distinção é indistinguível de
 # muitas outras coisas: um funil em que toda linha reprovada tem
-# `porta_conjunto_completo = FALSE` é compatível tanto com "a coluna está certa e o
+# `porta_cobertura_pinnacle = FALSE` é compatível tanto com "a coluna está certa e o
 # conjunto incompleto é mesmo 49% do universo" quanto com "todas as portas estão
 # copiando a mesma expressão". Só linha construída separa as duas.
 #
@@ -75,7 +75,7 @@ unit_tests:
           # `funil_duas_portas_o_empate_e_o_insumo_nulo`.
           - {fixture_id: 2, competition: 'brasileirao', season: 2026, market_id: 12, outcome_side: '12', line_value: , janela_usada: 't15m', edge: 0.10, pts_valor: 30, best_odd: 1.50, best_book: 'Bet365', avg_odd: 1.45, n_casas: 5, prob_justa_fechamento: 0.60, pin_n_outcomes: , n_outcomes_valor: 3, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
 
-          # -- 3: porta_conjunto_completo. O 1X2 exige as três saídas da Pinnacle; vieram
+          # -- 3: porta_cobertura_pinnacle. O 1X2 exige as três saídas da Pinnacle; vieram
           # duas. É a MAIOR rejeição do sistema (~49% do universo) e até esta entrega ela
           # não existia em lugar nenhum — saía num `WHERE` dentro do join. ⚠️ O de-vig
           # real anularia prob_justa junto (ADR 0002); aqui ela fica para isolar a porta.
@@ -149,15 +149,15 @@ unit_tests:
 
     expect:
       rows:
-        - {fixture_id: 1, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: true,  motivo_primario: , sem_lado_apostado: false}
-        - {fixture_id: 2, market: 'double_chance',    outcome: '12',   score: 45, porta_saida_catalogada: false, porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'saida_nao_catalogada', sem_lado_apostado: false}
-        - {fixture_id: 3, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: false, porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'conjunto_incompleto', sem_lado_apostado: false}
-        - {fixture_id: 4, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: false, porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'valor_nao_estimavel', sem_lado_apostado: false}
-        - {fixture_id: 5, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: false, porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'sem_liquidez', sem_lado_apostado: false}
-        - {fixture_id: 6, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: false, porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'sem_edge', sem_lado_apostado: false}
-        - {fixture_id: 7, market: 'match_winner',     outcome: 'Home', score: 30, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'nota_abaixo_da_regua', sem_lado_apostado: false}
-        - {fixture_id: 8, market: 'goals_over_under', outcome: 'Over', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: false, porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'linha_nao_meia', sem_lado_apostado: false}
-        - {fixture_id: 9, market: 'double_chance',    outcome: '1X',   score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: false, passou_no_gate: false, motivo_primario: 'odd_dc_abaixo_do_minimo', sem_lado_apostado: false}
+        - {fixture_id: 1, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: true,  motivo_primario: , sem_lado_apostado: false}
+        - {fixture_id: 2, market: 'double_chance',    outcome: '12',   score: 45, porta_saida_catalogada: false, porta_cobertura_pinnacle: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'saida_nao_catalogada', sem_lado_apostado: false}
+        - {fixture_id: 3, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: false, porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'sem_cobertura_pinnacle', sem_lado_apostado: false}
+        - {fixture_id: 4, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true,  porta_valor_estimavel: false, porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'valor_nao_estimavel', sem_lado_apostado: false}
+        - {fixture_id: 5, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true,  porta_valor_estimavel: true,  porta_liquidez: false, porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'sem_liquidez', sem_lado_apostado: false}
+        - {fixture_id: 6, market: 'match_winner',     outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: false, porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'sem_edge', sem_lado_apostado: false}
+        - {fixture_id: 7, market: 'match_winner',     outcome: 'Home', score: 30, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_linha_meia: true,  porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'nota_abaixo_da_regua', sem_lado_apostado: false}
+        - {fixture_id: 8, market: 'goals_over_under', outcome: 'Over', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: false, porta_odd_dc: true,  passou_no_gate: false, motivo_primario: 'linha_nao_meia', sem_lado_apostado: false}
+        - {fixture_id: 9, market: 'double_chance',    outcome: '1X',   score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true,  porta_valor_estimavel: true,  porta_liquidez: true,  porta_edge: true,  porta_nota: true,  porta_linha_meia: true,  porta_odd_dc: false, passou_no_gate: false, motivo_primario: 'odd_dc_abaixo_do_minimo', sem_lado_apostado: false}
 
   # ---------------------------------------------------------------------------
   # 2. OS CASOS QUE A TABELA EXISTE PARA REGISTRAR.
@@ -237,13 +237,13 @@ unit_tests:
     expect:
       rows:
         # duas portas FALSE na mesma linha, e o motivo elege só a primeira.
-        - {fixture_id: 10, market: 'match_winner',  outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: false, porta_edge: false, porta_nota: true,  porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_liquidez',         sem_lado_apostado: false, pts_premissas: 15}
+        - {fixture_id: 10, market: 'match_winner',  outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true, porta_valor_estimavel: true, porta_liquidez: false, porta_edge: false, porta_nota: true,  porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_liquidez',         sem_lado_apostado: false, pts_premissas: 15}
         # a "12" real: sem premissa -> nota NULL -> porta_nota FALSE, e a saída não catalogada.
-        - {fixture_id: 11, market: 'double_chance', outcome: '12',   score: ,   porta_saida_catalogada: false, porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'saida_nao_catalogada', sem_lado_apostado: false, pts_premissas: }
+        - {fixture_id: 11, market: 'double_chance', outcome: '12',   score: ,   porta_saida_catalogada: false, porta_cobertura_pinnacle: true, porta_valor_estimavel: true, porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'saida_nao_catalogada', sem_lado_apostado: false, pts_premissas: }
         # o empate: nota 20 (um número), marca própria e motivo próprio.
-        - {fixture_id: 12, market: 'match_winner',  outcome: 'Draw', score: 20, porta_saida_catalogada: true,  porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_lado_apostado',   sem_lado_apostado: true,  pts_premissas: 0}
+        - {fixture_id: 12, market: 'match_winner',  outcome: 'Draw', score: 20, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true, porta_valor_estimavel: true, porta_liquidez: true,  porta_edge: true,  porta_nota: false, porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_lado_apostado',   sem_lado_apostado: true,  pts_premissas: 0}
         # insumo NULL: porta FALSE, gate FALSE — nunca NULL.
-        - {fixture_id: 13, market: 'match_winner',  outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_conjunto_completo: true, porta_valor_estimavel: true, porta_liquidez: false, porta_edge: true,  porta_nota: true,  porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_liquidez',         sem_lado_apostado: false, pts_premissas: 15}
+        - {fixture_id: 13, market: 'match_winner',  outcome: 'Home', score: 45, porta_saida_catalogada: true,  porta_cobertura_pinnacle: true, porta_valor_estimavel: true, porta_liquidez: false, porta_edge: true,  porta_nota: true,  porta_odd_dc: true, passou_no_gate: false, motivo_primario: 'sem_liquidez',         sem_lado_apostado: false, pts_premissas: 15}
 
   # ---------------------------------------------------------------------------
   # 3. AS QUATRO JANELAS.

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -5,7 +5,7 @@
     on_schema_change='append_new_columns',
     full_refresh=false,
     cluster_by=['competition', 'fixture_id'],
-    description='O FUNIL DE AVALIAÇÃO (#95/#96, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_conjunto_completo, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011): materialização INCREMENTAL por merge no grão (fixture_id, market, outcome, line_key, janela). A linha é escrita e atualizada enquanto o kickoff do fixture está no FUTURO e nenhuma escrita acontece depois dele — o funil deixa de ser uma foto do que o código de hoje diria e passa a ser registro do que o Motor disse. `full_refresh=false` no config porque a fase de RECOVERY do workflow_futebol_odds roda o mesmo --select com --full-refresh: sem isso, a primeira recuperação de deriva apagaria o histórico inteiro. Toda linha carrega `gravado_em` e `origem`: `backfill` no build que cria a tabela (recalculado com o código de hoje, e é a única parte que NÃO é registro de época) e `corrente` em toda escrita incremental. Jogo adiado (PST/SUSP) cujo kickoff volta para o futuro VOLTA a ser gravável — o filtro lê o kickoff corrente, não o da escrita anterior. Fixture ausente em fact_fixtures (kickoff NULL) é FAIL-OPEN: continua gravável para sempre, porque perdê-lo quebraria a reconciliação (ADR 0003). NÃO HÁ EXPURGO DO FUNIL (~45 mil linhas/mês; a política se revisita se a tabela passar de 10 milhões de linhas). NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil). A NOTA DE CONTEXTO (#103, ADR 0012): a coluna `nota_contexto` é a nota depois que o preço sai dela — pts_premissas menos as penalidades de CONTEXTO (pick_empate −10, desfalque_proprio −15, linha_extrema −10, handicap_alto −12), com GREATEST(..., 0) —, e nada mais: sem pts_valor, sem corroboração e sem as quatro penalidades de odd. Ela nasce AO LADO do `score`, que continua sendo o do board: nesta entrega o produto não muda de gate nem de número, e existe UMA virada só, no fim da [A]. A composição mora em macros/futebol_nota_contexto.sql (num lugar só, consumida pelo funil e pela guarda de reconstrução, nunca copiada); duas guardas a protegem — assert_nota_contexto_sem_preco (sentinela da decisão: falha se qualquer componente de preço aparecer no texto da composição) e assert_funil_nota_contexto_reconstroi (a coluna gravada bate com a recomposta). NULL onde não houve premissa a avaliar (a "12" da DC), pelo mesmo motivo que o score (ADR 0003). ⚠️ A coluna chega por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar: as linhas de jogo já apitado antes do deploy da A1 ficam com nota_contexto NULL para sempre, e isso é o append-only funcionando (ADR 0011), não defeito — a guarda de reconstrução é escopada a elas de propósito. A NOTA NORMALIZADA (#105, ADR 0005): as colunas `lado` e `score_normalizado`. `lado` é o eixo do denominador — os ONZE pares de (mercado, lado) que `futebol_lado()` enumera, e no Handicap ele NÃO é o outcome (é o sinal do handicap na ótica do lado apostado: Favorito/Azarao/Pick), enquanto na Dupla Chance 1X e X2 colapsam em `unico` porque as quatro premissas se aplicam às duas saídas. `score_normalizado` é a nota de contexto dividida pelo p95 OBSERVADO daquele lado, congelado no seed versionado `futebol_p95_nota_contexto` (medido uma vez, sobre janela declarada — recalcular em runtime faria a régua significar coisa diferente a cada dia). A nota é ABSOLUTA — quanta evidência acendeu —, nunca percentil dentro do lado: o preço declarado é que os mercados publicam em taxas diferentes, e isso é consequência, não defeito. Clamp em 100 EXPLÍCITO, porque com o p95 no denominador ~5% das linhas de cada lado ficam acima de 100 por construção. Denominador zero (o empate do 1X2 e o Pick do Handicap, que não têm lado apostado) resolve para ZERO explícito e nunca por SAFE_DIVIDE: o NULL faria a comparação com a régua virar NULL e a linha sairia sem passar e sem ser marcada. Denominador AUSENTE (lado fora do seed) cai no mesmo ramo — o join é LEFT para que a linha nunca suma — e quem acende é assert_p95_nota_contexto_nao_derivou, que cobra tanto a COBERTURA dos onze lados quanto a DERIVA do p95 vivo contra o congelado. A aritmética mora em macros/futebol_score_normalizado.sql, sem argumento, pela mesma razão do macro da nota de contexto. O BOARD NÃO MUDA: ele segue no `score` e no gate de 40, e a virada é uma só, no fim da [A]. ⚠️ As duas colunas chegam por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar — linha de jogo já apitado antes do deploy fica com elas NULL para sempre, e isso é o append-only funcionando. AS TRÊS BARREIRAS DE PREÇO (#104, A3+A5): as colunas `porta_liquidez_estrita` (n_casas >= 4), `porta_outlier` (NOT pen_odd_outlier) e `porta_faixa_odd` (best_odd dentro de [1,50; 4,00], e [1,25; 2,00] na Dupla Chance, fronteiras INCLUSIVAS nas duas pontas). Elas são MEDIDAS e ficam FORA de `passou_no_gate` — dizem quem passaria sem remover ninguém; quem as põe em vigor é a virada (#109), que no mesmo ato tira a `porta_liquidez` (>= 3) e põe a `porta_liquidez_estrita` no lugar. ⚠️ A de liquidez tem NOME PRÓPRIO em vez de a `porta_liquidez` ser redefinida para 4, e isso é decisão: o funil é append-only, então redefinir o predicado no lugar faria um nome de coluna valer >= 3 nas linhas congeladas e >= 4 nas novas, para sempre, dentro do registro de época — e as outras duas saídas (mínimo 4 dentro da conjunção, ou a porta de liquidez fora dela) mudariam o board, contra o aceite. As duas convivem e a virada troca qual está na conjunção, sem renomear nada. `porta_outlier` inverte a polaridade da penalidade (penalidade TRUE = suspeita; porta TRUE = passa) com o COALESCE POR FORA do NOT, para que penalidade ausente reprove em vez de aprovar por acidente de negação. Os quatro limites são `var` com default no modelo (liquidez_min_casas=4, faixa_odd_min=1.50, faixa_odd_max=4.00, faixa_odd_dc_min=1.25, faixa_odd_dc_max=2.00), e o piso da DC é lido TAMBÉM pela `porta_odd_dc` já em vigor — o 1,25 existe num lugar só. ⚠️ As três chegam por append_new_columns, como as anteriores, e ficam NULL para sempre na linha de jogo já apitado antes deste deploy. `motivo_primario` NÃO as conhece: linha que só reprovaria nelas continua passando hoje, e dar-lhe um motivo seria descrever uma rejeição que não aconteceu.'
+    description='O FUNIL DE AVALIAÇÃO (#95/#96, ADR 0011 + ADR 0006). 1 linha por (fixture_id, market, outcome, line_value, janela) que TEVE PREÇO naquela janela, nos CINCO mercados pontuados (1X2, Handicap asiático, Gols O/U, Ambos Marcam, Dupla Chance) — e NADA filtrado. Cada porta do Motor é uma COLUNA BOOLEANA (TRUE = passou), nunca um WHERE: porta_saida_catalogada, porta_cobertura_pinnacle, porta_valor_estimavel, porta_liquidez, porta_edge, porta_nota, porta_linha_meia, porta_odd_dc. `passou_no_gate` é a CONJUNÇÃO derivada das oito, jamais escrita à mão; `motivo_primario` é derivado por cima dos booleanos e é conveniência de leitura, não fonte (uma linha reprova em várias portas ao mesmo tempo, e é a leitura marginal — quantas linhas a porta ainda remove DEPOIS das anteriores — que dá valor à tabela). Cada porta é NULL-safe INDIVIDUALMENTE (COALESCE(..., FALSE)): insumo ausente reprova a porta em vez de propagar NULL para dentro da conjunção. UNIVERSO: os candidatos do int_futebol_odds_devig nos cinco mercados, quatro janelas (daily<t24h<t1h<t15m). Gols do 1º tempo (mercado 6) fica FORA — não existe modelo de premissa para ele e a sua ausência não é decisão nossa (ADR 0011). A saída "12" da Dupla Chance fica DENTRO, com porta_saida_catalogada=FALSE: ela é precificada e a decisão de não pontuá-la é nossa. As duas rejeições que hoje são SUMIÇO no fact_value_opportunities — conjunto de saídas incompleto (a maior do sistema) e a "12" da DC — passam a ser linha com carimbo: os WHERE de completude de cada ramo viram coluna e o INNER JOIN com as premissas vira LEFT JOIN. `janela_e_corrente` é COLUNA e fica FORA da conjunção: é redução (qual janela publica), não veredito de qualidade (ADR 0011, D8). O EXPURGO NÃO É PORTA (ADR 0011): o funil guarda jogo encerrado de propósito — é ele que responde quanto rendeu a faixa descartada — e o expurgo continua no board, sobre o status vindo de fact_fixtures. Por isso `kickoff_utc` sai daqui e o STATUS não: status muda depois do apito e uma coluna congelada com o status de antes mentiria (ADR 0011, D10). Sem evidencias[]/avisos[]: são derivados e reconstruíveis. O EMPATE DO 1X2 carrega marca própria (`sem_lado_apostado`): sem lado apostado nenhuma premissa dispara, e um terço do universo do 1X2 está em zero POR CONSTRUÇÃO — sob o motivo genérico ele seria lido como severidade da régua (ADR 0005/0006). APPEND-ONLY, CONGELADO NO APITO (#96, ADR 0011): materialização INCREMENTAL por merge no grão (fixture_id, market, outcome, line_key, janela). A linha é escrita e atualizada enquanto o kickoff do fixture está no FUTURO e nenhuma escrita acontece depois dele — o funil deixa de ser uma foto do que o código de hoje diria e passa a ser registro do que o Motor disse. `full_refresh=false` no config porque a fase de RECOVERY do workflow_futebol_odds roda o mesmo --select com --full-refresh: sem isso, a primeira recuperação de deriva apagaria o histórico inteiro. Toda linha carrega `gravado_em` e `origem`: `backfill` no build que cria a tabela (recalculado com o código de hoje, e é a única parte que NÃO é registro de época) e `corrente` em toda escrita incremental. Jogo adiado (PST/SUSP) cujo kickoff volta para o futuro VOLTA a ser gravável — o filtro lê o kickoff corrente, não o da escrita anterior. Fixture ausente em fact_fixtures (kickoff NULL) é FAIL-OPEN: continua gravável para sempre, porque perdê-lo quebraria a reconciliação (ADR 0003). NÃO HÁ EXPURGO DO FUNIL (~45 mil linhas/mês; a política se revisita se a tabela passar de 10 milhões de linhas). NÃO VAI PARA O SUPABASE: o app não lê funil — sem migração no Postgres, sem RPC, sem tocar check_schema_parity. O board NÃO muda nesta entrega; quem prova que o funil o descreve de verdade é a guarda assert_funil_paridade_com_board, e quem prova que o universo está inteiro é assert_funil_reconcilia_com_devig (que lê a FONTE, nunca o próprio funil). A NOTA DE CONTEXTO (#103, ADR 0012): a coluna `nota_contexto` é a nota depois que o preço sai dela — pts_premissas menos as penalidades de CONTEXTO (pick_empate −10, desfalque_proprio −15, linha_extrema −10, handicap_alto −12), com GREATEST(..., 0) —, e nada mais: sem pts_valor, sem corroboração e sem as quatro penalidades de odd. Ela nasce AO LADO do `score`, que continua sendo o do board: nesta entrega o produto não muda de gate nem de número, e existe UMA virada só, no fim da [A]. A composição mora em macros/futebol_nota_contexto.sql (num lugar só, consumida pelo funil e pela guarda de reconstrução, nunca copiada); duas guardas a protegem — assert_nota_contexto_sem_preco (sentinela da decisão: falha se qualquer componente de preço aparecer no texto da composição) e assert_funil_nota_contexto_reconstroi (a coluna gravada bate com a recomposta). NULL onde não houve premissa a avaliar (a "12" da DC), pelo mesmo motivo que o score (ADR 0003). ⚠️ A coluna chega por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar: as linhas de jogo já apitado antes do deploy da A1 ficam com nota_contexto NULL para sempre, e isso é o append-only funcionando (ADR 0011), não defeito — a guarda de reconstrução é escopada a elas de propósito. A NOTA NORMALIZADA (#105, ADR 0005): as colunas `lado` e `score_normalizado`. `lado` é o eixo do denominador — os ONZE pares de (mercado, lado) que `futebol_lado()` enumera, e no Handicap ele NÃO é o outcome (é o sinal do handicap na ótica do lado apostado: Favorito/Azarao/Pick), enquanto na Dupla Chance 1X e X2 colapsam em `unico` porque as quatro premissas se aplicam às duas saídas. `score_normalizado` é a nota de contexto dividida pelo p95 OBSERVADO daquele lado, congelado no seed versionado `futebol_p95_nota_contexto` (medido uma vez, sobre janela declarada — recalcular em runtime faria a régua significar coisa diferente a cada dia). A nota é ABSOLUTA — quanta evidência acendeu —, nunca percentil dentro do lado: o preço declarado é que os mercados publicam em taxas diferentes, e isso é consequência, não defeito. Clamp em 100 EXPLÍCITO, porque com o p95 no denominador ~5% das linhas de cada lado ficam acima de 100 por construção. Denominador zero (o empate do 1X2 e o Pick do Handicap, que não têm lado apostado) resolve para ZERO explícito e nunca por SAFE_DIVIDE: o NULL faria a comparação com a régua virar NULL e a linha sairia sem passar e sem ser marcada. Denominador AUSENTE (lado fora do seed) cai no mesmo ramo — o join é LEFT para que a linha nunca suma — e quem acende é assert_p95_nota_contexto_nao_derivou, que cobra tanto a COBERTURA dos onze lados quanto a DERIVA do p95 vivo contra o congelado. A aritmética mora em macros/futebol_score_normalizado.sql, sem argumento, pela mesma razão do macro da nota de contexto. O BOARD NÃO MUDA: ele segue no `score` e no gate de 40, e a virada é uma só, no fim da [A]. ⚠️ As duas colunas chegam por append_new_columns e SÓ nas linhas que o congelamento ainda deixa gravar — linha de jogo já apitado antes do deploy fica com elas NULL para sempre, e isso é o append-only funcionando. AS TRÊS BARREIRAS DE PREÇO (#104, A3+A5): as colunas `porta_liquidez_estrita` (n_casas >= 4), `porta_outlier` (NOT pen_odd_outlier) e `porta_faixa_odd` (best_odd dentro de [1,50; 4,00], e [1,25; 2,00] na Dupla Chance, fronteiras INCLUSIVAS nas duas pontas). Elas são MEDIDAS e ficam FORA de `passou_no_gate` — dizem quem passaria sem remover ninguém; quem as põe em vigor é a virada (#109), que no mesmo ato tira a `porta_liquidez` (>= 3) e põe a `porta_liquidez_estrita` no lugar. ⚠️ A de liquidez tem NOME PRÓPRIO em vez de a `porta_liquidez` ser redefinida para 4, e isso é decisão: o funil é append-only, então redefinir o predicado no lugar faria um nome de coluna valer >= 3 nas linhas congeladas e >= 4 nas novas, para sempre, dentro do registro de época — e as outras duas saídas (mínimo 4 dentro da conjunção, ou a porta de liquidez fora dela) mudariam o board, contra o aceite. As duas convivem e a virada troca qual está na conjunção, sem renomear nada. `porta_outlier` inverte a polaridade da penalidade (penalidade TRUE = suspeita; porta TRUE = passa) com o COALESCE POR FORA do NOT, para que penalidade ausente reprove em vez de aprovar por acidente de negação. Os quatro limites são `var` com default no modelo (liquidez_min_casas=4, faixa_odd_min=1.50, faixa_odd_max=4.00, faixa_odd_dc_min=1.25, faixa_odd_dc_max=2.00), e o piso da DC é lido TAMBÉM pela `porta_odd_dc` já em vigor — o 1,25 existe num lugar só. ⚠️ As três chegam por append_new_columns, como as anteriores, e ficam NULL para sempre na linha de jogo já apitado antes deste deploy. `motivo_primario` NÃO as conhece: linha que só reprovaria nelas continua passando hoje, e dar-lhe um motivo seria descrever uma rejeição que não aconteceu.'
 ) }}
 
 -- ============================================================================
@@ -83,8 +83,11 @@ fixtures AS (
 
 -- ============================================================================
 -- Ramo 1X2 (market_id=1). Saídas catalogadas: Home / Draw / Away.
--- Completude do conjunto = 1X2 inteiro na Pinnacle (pin_n_outcomes >= 3) — o MESMO
--- predicado que hoje é `WHERE d.pin_n_outcomes >= 3` no ramo do board, virado coluna.
+-- Cobertura da Pinnacle = 1X2 inteiro precificado por ela (pin_n_outcomes >= 3),
+-- INDEPENDENTE de qual fonte a linha realmente usou (Pinnacle ou fallback de
+-- consenso) — o MESMO predicado que hoje é `WHERE d.pin_n_outcomes >= 3` no ramo do
+-- board, virado coluna. Nome corrigido na #118: ver bloco de comentário antes de
+-- `com_portas` para o porquê.
 -- ============================================================================
 cand_1x2 AS (
     SELECT
@@ -123,7 +126,7 @@ cand_1x2 AS (
         COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
 
         COALESCE(d.outcome_side IN ('Home', 'Draw', 'Away'), FALSE) AS porta_saida_catalogada,
-        COALESCE(d.pin_n_outcomes >= 3, FALSE)          AS porta_conjunto_completo,
+        COALESCE(d.pin_n_outcomes >= 3, FALSE)          AS porta_cobertura_pinnacle,
         -- O EMPATE (ADR 0005/0006). Não tem lado apostado: nenhuma premissa do 1X2 se
         -- aplica, o teto de premissa é zero e — quando a A6 introduzir o denominador —
         -- ele também será zero, explicitamente antes da divisão. A marca é ESTRUTURAL
@@ -144,7 +147,8 @@ cand_1x2 AS (
 
 -- ============================================================================
 -- Ramo Gols O/U (market_id=5). Saídas catalogadas: Over / Under.
--- Completude = par Over+Under da Pinnacle na linha (pin_n_outcomes >= 2).
+-- Cobertura da Pinnacle = par Over+Under precificado por ela na linha
+-- (pin_n_outcomes >= 2), independente da fonte real da linha (#118).
 -- ============================================================================
 cand_ou AS (
     SELECT
@@ -183,7 +187,7 @@ cand_ou AS (
         COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
 
         COALESCE(d.outcome_side IN ('Over', 'Under'), FALSE) AS porta_saida_catalogada,
-        COALESCE(d.pin_n_outcomes >= 2, FALSE)          AS porta_conjunto_completo,
+        COALESCE(d.pin_n_outcomes >= 2, FALSE)          AS porta_cobertura_pinnacle,
         FALSE                                           AS sem_lado_apostado
     FROM devig d
     LEFT JOIN prem_ou p
@@ -201,7 +205,8 @@ cand_ou AS (
 -- ============================================================================
 -- Ramo Handicap asiático (market_id=4). Saídas catalogadas: Home / Away.
 -- `line_value` é o handicap na ótica do MANDANTE e é o MESMO para Home e Away (par
--- complementar). Completude = par da Pinnacle (pin_n_outcomes >= 2).
+-- complementar). Cobertura da Pinnacle = par precificado por ela (pin_n_outcomes
+-- >= 2), independente da fonte real da linha (#118).
 -- ============================================================================
 cand_ah AS (
     SELECT
@@ -240,7 +245,7 @@ cand_ah AS (
         COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
 
         COALESCE(d.outcome_side IN ('Home', 'Away'), FALSE) AS porta_saida_catalogada,
-        COALESCE(d.pin_n_outcomes >= 2, FALSE)          AS porta_conjunto_completo,
+        COALESCE(d.pin_n_outcomes >= 2, FALSE)          AS porta_cobertura_pinnacle,
         FALSE                                           AS sem_lado_apostado
     FROM devig d
     LEFT JOIN prem_ah p
@@ -257,9 +262,19 @@ cand_ah AS (
 
 -- ============================================================================
 -- Ramo Ambos Marcam / BTTS (market_id=8). Saídas catalogadas: Yes / No.
--- A Pinnacle NÃO precifica BTTS -> o valor vem do CONSENSO, e a completude é medida
--- por `n_outcomes_valor >= 2` (o par Yes+No da mediana), não por pin_n_outcomes —
--- que fica NULL aqui, honestamente.
+-- A Pinnacle NÃO precifica BTTS -> `pin_n_outcomes` fica NULL aqui, honestamente, e
+-- a pergunta "a Pinnacle cobriu?" não se aplica: `porta_cobertura_pinnacle` é
+-- TRIVIALMENTE TRUE, mesmo padrão de `porta_odd_dc`/`porta_linha_meia` num mercado
+-- onde a porta não se aplica.
+--
+-- ⚠️ #118: até 28/08 esta porta usava `n_outcomes_valor >= 2` sob o nome de
+-- "conjunto completo" — mas isso é o MESMO que `porta_valor_estimavel` já garante
+-- (ADR 0002 exige n_outcomes_valor = conjunto_esperado, e 2 é o teto do BTTS, então
+-- `>= 2` e `= 2` coincidem sempre). Medido em produção antes da troca: as duas
+-- colunas concordam em 100% das 3.410 linhas de BTTS — zero divergência. A porta era
+-- uma cópia disfarçada, não uma checagem própria; o valor real já vem de
+-- `porta_valor_estimavel`, e trivializar aqui não muda `passou_no_gate` em nenhuma
+-- linha, passada ou futura.
 -- ============================================================================
 cand_btts AS (
     SELECT
@@ -298,7 +313,7 @@ cand_btts AS (
         COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
 
         COALESCE(d.outcome_side IN ('Yes', 'No'), FALSE) AS porta_saida_catalogada,
-        COALESCE(d.n_outcomes_valor >= 2, FALSE)        AS porta_conjunto_completo,
+        TRUE                                             AS porta_cobertura_pinnacle,
         FALSE                                           AS sem_lado_apostado
     FROM devig d
     LEFT JOIN prem_btts p
@@ -320,10 +335,13 @@ cand_btts AS (
 -- JOIN ela entra com `porta_saida_catalogada = FALSE`, que é o que ela é: uma decisão
 -- nossa de não pontuar, não uma ausência de mercado.
 --
--- Completude = conjunto 1X2 DE ORIGEM completo (n_outcomes_valor >= 3): a prob justa da
--- DC é derivada do de-vig 1X2 da Pinnacle. E a DC tem GATE DE ODD PRÓPRIO
--- (best_odd >= 1,25), que hoje mora no `WHERE` do ramo do board e aqui é a
--- `porta_odd_dc`.
+-- A prob justa da DC é derivada do de-vig do 1X2 subjacente, e `pin_n_outcomes` não
+-- existe nesse eixo — a pergunta "a Pinnacle cobriu?" não se aplica aqui do mesmo
+-- jeito que no 1X2 direto: `porta_cobertura_pinnacle` é TRIVIALMENTE TRUE (#118, ver
+-- o comentário equivalente no ramo BTTS — mesma redundância medida e confirmada
+-- aqui: 5.034 linhas concordam em TRUE e 81 em FALSE com `porta_valor_estimavel`,
+-- zero divergência). E a DC tem GATE DE ODD PRÓPRIO (best_odd >= 1,25), que hoje
+-- mora no `WHERE` do ramo do board e aqui é a `porta_odd_dc`.
 -- ============================================================================
 cand_dc AS (
     SELECT
@@ -370,7 +388,7 @@ cand_dc AS (
         COALESCE(c.linha_sharp_confirma, FALSE)         AS linha_sharp_confirma,
 
         COALESCE(d.outcome_side IN ('1X', 'X2'), FALSE) AS porta_saida_catalogada,
-        COALESCE(d.n_outcomes_valor >= 3, FALSE)        AS porta_conjunto_completo,
+        TRUE                                             AS porta_cobertura_pinnacle,
         FALSE                                           AS sem_lado_apostado
     FROM devig d
     LEFT JOIN prem_dc p
@@ -495,22 +513,26 @@ com_nota_normalizada AS (
 -- reprova a porta em vez de propagar NULL para dentro da conjunção. É a degradação
 -- graciosa do Motor, e é o que impede o descarte silencioso que a ADR 0006 proíbe.
 --
--- ⚠️ CORREÇÃO (#118, medida em 28/08): este parágrafo dizia que `porta_conjunto_completo`
--- e `porta_valor_estimavel` são ANINHADAS ("pela ADR 0002, conjunto incompleto implica
--- prob justa ausente") e avisava contra somá-las. Os dados dizem o contrário: elas são
--- quase DISJUNTAS, e quem seguir o aviso antigo SUBESTIMA a leitura marginal.
+-- ⚠️ RESOLVIDO (#118, opção 1 aplicada em 31/08): este parágrafo dizia que
+-- `porta_conjunto_completo` e `porta_valor_estimavel` são ANINHADAS ("pela ADR 0002,
+-- conjunto incompleto implica prob justa ausente") e avisava contra somá-las. Os dados
+-- diziam o contrário — elas eram quase DISJUNTAS em AH/Gols — porque o nome escondia
+-- DOIS predicados diferentes por trás de UM só:
 --
 --   | mercado          | valor_fonte | completo | estimavel | linhas |
 --   |------------------|-------------|----------|-----------|--------|
 --   | asian_handicap   | consenso    | false    | TRUE      |  9.102 |
 --   | goals_over_under | consenso    | false    | TRUE      | 10.644 |
 --
--- O motivo é que as duas fazem perguntas diferentes, apesar do nome: a
--- `porta_valor_estimavel` é a regra da ADR 0002 (`n_outcomes_valor = conjunto_esperado`),
--- enquanto a `porta_conjunto_completo` é `pin_n_outcomes >= N` em 1X2/Gols/Handicap — ou
--- seja, "a PINNACLE cobriu?" — e `n_outcomes_valor >= N` em BTTS/DC. Um nome, dois
--- predicados. A decisão sobre o que fazer com isso é a #118 (`ready-for-human`); aqui só
--- o parágrafo que afirmava o oposto do medido sai do caminho.
+-- A porta virou `porta_cobertura_pinnacle`, que é o que ela sempre testou em
+-- 1X2/Gols/Handicap: `pin_n_outcomes >= N`, "a PINNACLE cobriu?" — independente da
+-- fonte real da linha. A Pinnacle não precifica BTTS nem tem eixo próprio na Dupla
+-- Chance, então nesses dois mercados a pergunta não se aplica e a porta é
+-- TRIVIALMENTE TRUE (mesmo padrão de `porta_odd_dc` fora da DC): o predicado antigo
+-- daqueles dois ramos (`n_outcomes_valor >= N`) provou ser uma cópia disfarçada de
+-- `porta_valor_estimavel` — zero divergência medida em 8.525 linhas de BTTS+DC — e
+-- não precisava de porta própria. `passou_no_gate` não muda em NENHUMA linha, passada
+-- ou futura: só o nome deixou de mentir sobre o que a coluna testa.
 -- ============================================================================
 com_portas AS (
     SELECT
@@ -617,7 +639,7 @@ com_gate AS (
     SELECT
         *,
         (   porta_saida_catalogada
-        AND porta_conjunto_completo
+        AND porta_cobertura_pinnacle
         AND porta_valor_estimavel
         AND porta_liquidez
         AND porta_edge
@@ -659,7 +681,7 @@ SELECT
 
     -- ------------------------------------------------- as oito portas EM VIGOR
     porta_saida_catalogada,
-    porta_conjunto_completo,
+    porta_cobertura_pinnacle,
     porta_valor_estimavel,
     porta_liquidez,
     porta_edge,
@@ -687,15 +709,15 @@ SELECT
     -- dentro da porta de nota: sem ele, um terço do universo do 1X2 apareceria como
     -- "nota abaixo da régua" e a régua pareceria mais severa no 1X2 do que é.
     CASE
-        WHEN NOT porta_saida_catalogada  THEN 'saida_nao_catalogada'
-        WHEN NOT porta_conjunto_completo THEN 'conjunto_incompleto'
-        WHEN NOT porta_valor_estimavel   THEN 'valor_nao_estimavel'
-        WHEN NOT porta_liquidez          THEN 'sem_liquidez'
-        WHEN NOT porta_edge              THEN 'sem_edge'
+        WHEN NOT porta_saida_catalogada   THEN 'saida_nao_catalogada'
+        WHEN NOT porta_cobertura_pinnacle THEN 'sem_cobertura_pinnacle'
+        WHEN NOT porta_valor_estimavel    THEN 'valor_nao_estimavel'
+        WHEN NOT porta_liquidez           THEN 'sem_liquidez'
+        WHEN NOT porta_edge               THEN 'sem_edge'
         WHEN NOT porta_nota
             THEN IF(sem_lado_apostado, 'sem_lado_apostado', 'nota_abaixo_da_regua')
-        WHEN NOT porta_linha_meia        THEN 'linha_nao_meia'
-        WHEN NOT porta_odd_dc            THEN 'odd_dc_abaixo_do_minimo'
+        WHEN NOT porta_linha_meia         THEN 'linha_nao_meia'
+        WHEN NOT porta_odd_dc             THEN 'odd_dc_abaixo_do_minimo'
         ELSE NULL
     END AS motivo_primario,
 


### PR DESCRIPTION
## Resumo

`porta_conjunto_completo` escondia dois predicados diferentes atrás do mesmo nome:

- **1X2, Gols O/U, Handicap**: sempre testou `pin_n_outcomes >= N` — "a Pinnacle cobriu?" — independente da fonte real da linha. Consequência medida na #118: 19.412 linhas de Handicap e Gols com preço de consenso válido barradas sob o rótulo "conjunto incompleto".
- **BTTS, Dupla Chance**: testava `n_outcomes_valor >= N`, que é redundante com `porta_valor_estimavel` — medi 100% de concordância em 8.525 linhas (3.410 BTTS + 5.115 DC), zero divergência.

## O que mudou

- Renomeada para `porta_cobertura_pinnacle` nos três ramos que de fato testam Pinnacle (1X2/O-U/AH), lógica idêntica.
- Trivializada para `TRUE` em BTTS/DC (mesmo padrão de `porta_odd_dc` fora da Dupla Chance) — a redundância com `porta_valor_estimavel` já cobre esses dois mercados.
- `motivo_primario`: `'conjunto_incompleto'` → `'sem_cobertura_pinnacle'`.
- Atualizados `_fact_value_funnel.yml`, `_fact_value_funnel__unit_tests.yml` e as duas analyses vivas (`taskA_a4_fronteiras.sql`, `taskA_linha_de_base_funil.sql`) que liam a coluna diretamente do mart.

**Zero mudança de comportamento**: `passou_no_gate` é idêntico em toda linha, passada e futura — só o nome e a lógica dos dois ramos redundantes.

## Testes

- `dbt parse` / `dbt compile` do modelo e das duas analyses: OK
- `dbt test --select fact_value_funnel,test_type:unit`: 7/7 PASS
- `dbt test --select fact_value_funnel,test_type:data`: os dois testes que dependem do nome novo (`not_null_porta_cobertura_pinnacle`, `accepted_values_motivo_primario`) falham contra a tabela viva **porque ainda não foi deployado** — a tabela do BigQuery segue com o schema antigo até o build+push da imagem. Os outros 28 passam.

## Deploy necessário após o merge

Este mart não vai para o Supabase, mas a tabela é **incremental append-only** (`on_schema_change=append_new_columns`). Um `dbt run` normal NÃO renomeia a coluna — cria `porta_cobertura_pinnacle` como coluna nova e deixa `porta_conjunto_completo` órfã, congelada para sempre (o mesmo footgun que o comentário do `porta_liquidez_estrita` já documenta no modelo). O deploy correto é:

1. `./build-and-push.sh dbt_futebol`
2. `ALTER TABLE smartbetting-dados.futebol.fact_value_funnel RENAME COLUMN porta_conjunto_completo TO porta_cobertura_pinnacle` direto no BigQuery, ANTES do próximo `dbt run` incremental — preserva o histórico sem duplicar a coluna.

Closes #118.