### PR TITLE
futebol: fronteiras de faixa passam de 25/55 para 30/60 (#109)

### DIFF
--- a/dbt_futebol/models/marts/_fact_value_opportunities.yml
+++ b/dbt_futebol/models/marts/_fact_value_opportunities.yml
@@ -72,7 +72,7 @@ models:
                 min_value: 0
                 max_value: 100
       - name: faixa
-        description: "Faixa de CONFIABILIDADE derivada do score, fronteiras da #107 (PR #133): 'Alta' (>=55) | 'Média' (25-54) | 'Baixa' (<25), fronteira pertencendo à faixa de cima nas duas. ⚠️ #109: 'Baixa' passa a materializar — a régua de nota saiu do gate (decisão do PM de 20/08), então a faixa não é mais sentinela de corte, é rótulo."
+        description: "Faixa de CONFIABILIDADE derivada do score: 'Alta' (>=60) | 'Média' (30-59) | 'Baixa' (<30), fronteira pertencendo à faixa de cima nas duas. Fronteiras trocadas de 25/55 (#107, PR #133) para 30/60 por decisão do PM na #109 (01/09) — decisão de comunicação, não leitura de evidência nova; ambos os pares vêm da mesma grade medida na #107. ⚠️ #109: 'Baixa' passa a materializar — a régua de nota saiu do gate (decisão do PM de 20/08), então a faixa não é mais sentinela de corte, é rótulo."
         tests:
           - accepted_values:
               arguments:

--- a/dbt_futebol/models/marts/fact_value_opportunities.sql
+++ b/dbt_futebol/models/marts/fact_value_opportunities.sql
@@ -147,14 +147,16 @@ SELECT
     -- aritmética, um nome em cada tabela (glossário, CONTEXT.md). Não é uma segunda
     -- fórmula: `score_normalizado` já é 0–100, absoluto, sem preço.
     f.score_normalizado AS score,
-    -- ⚠️ #109: fronteiras da #107 (PR #133), medidas sobre a escala normalizada
-    -- pós-A6 — Baixa < 25 <= Média < 55 <= Alta, fronteira na faixa de cima nas duas.
-    -- 'Baixa' passa a materializar: a régua de nota saiu do gate (decisão do PM de
-    -- 20/08), então a faixa é rótulo, não mais sentinela de corte.
+    -- ⚠️ #109: fronteiras da #107 (PR #133) eram 25/55; trocadas para 30/60 por decisão
+    -- do PM (01/09, comentário na #109) — não é leitura de evidência nova, a #107 já
+    -- tinha medido que nenhum par da grade discrimina Alta de Baixa além de 1 EP. Baixa
+    -- < 30 <= Média < 60 <= Alta, fronteira na faixa de cima nas duas. 'Baixa' passa a
+    -- materializar: a régua de nota saiu do gate (decisão do PM de 20/08), então a faixa
+    -- é rótulo, não mais sentinela de corte.
     CASE
         WHEN f.score_normalizado IS NULL THEN NULL
-        WHEN f.score_normalizado >= 55   THEN 'Alta'
-        WHEN f.score_normalizado >= 25   THEN 'Média'
+        WHEN f.score_normalizado >= 60   THEN 'Alta'
+        WHEN f.score_normalizado >= 30   THEN 'Média'
         ELSE 'Baixa'
     END AS faixa,
     -- técnica, nunca exibida ao usuário (comment da migration 112 do app). 'legacy' é o


### PR DESCRIPTION
## Resumo

PR pequena em cima da #137/#138: troca as fronteiras de faixa no `fact_value_opportunities` de 25/55 para **30/60**, atendendo o pedido do Victor na AE#109 (comentários de 01/09 e 02/09).

## Por quê

**Decisão do PM, não medição nova.** A #107 (PR #133) mediu que nenhum par da grade de oito discrimina `Alta` de `Baixa` além de 1 erro-padrão — a escolha entre 25/55 e 30/60 é sobre quanto rotular como `Alta`, não sobre qual corte tem evidência. O 30/60 está na mesma grade congelada que a #107 mediu.

Comparado ao 25/55 que ficou no aceite original:
- `Alta` deixa de perder para `Baixa` e passa a ser a melhor faixa por ROI.
- O board padrão (`Alta` + `Média`, o filtro inicial do painel) encolhe de 63,5% para 52,8% — coerente com a decisão de segurar volume no lançamento.

**Tem de entrar antes da janela de deploy da virada**: depois dela `faixa` fica carimbada na série nova junto de `score_versao`, e mudar depois criaria duas escalas de rótulo na mesma série — exatamente o que `score_versao` existe para impedir.

## Validação extra (não pedida, mas fiz)

Reroddei a análise congelada `taskA_a4_fronteiras.sql` hoje (código pós-#138) para conferir se a linha zero do Handicap (B3, #138) invalidava a medição da #107. Não invalida, por construção: handicap 0 falha `futebol_e_linha_meia` independente de lado, então essas linhas nunca entram na população da fronteira — confirmado também empiricamente (o `Pick` que aparecia no bloco 4 do #133 sumiu do relatório, porque não é mais "sem lado", só continua invisível pelo mesmo motivo de sempre). A conclusão do 30/60 fica mais forte na medição de hoje (gap Alta−Baixa de 1,5 em vez de 0,5), não mais fraca.

## O que muda

- `models/marts/fact_value_opportunities.sql`: CASE de `faixa` — `>= 55` vira `>= 60`, `>= 25` vira `>= 30`.
- `models/marts/_fact_value_opportunities.yml`: description da coluna `faixa` atualizada com os números novos e o histórico da troca.

Sem mudança em `accepted_values` (o conjunto de labels `['Alta', 'Média', 'Baixa']` não muda, só os limiares).

## Test plan

- [x] `dbt parse` limpo
- [x] `dbt test --select fact_value_opportunities,test_type:unit` — 3/3 PASS (nenhum unit test deste repo cobre a fronteira exata 24/25 ou 54/55, então nada quebrou nem precisou mudar)
- [ ] Front (`prop-play-predictor#327`, já mergeado) já usa 30/60 — depois desta PR os dois lados concordam, mas só valem juntos após a janela de deploy combinada

Refs #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JypLEgi74wXE38suiaSXWg