### PR TITLE
fix(futebol): linha zero do Handicap decide pela odd, não pelo mando (#138 amend)

### DIFF
--- a/dbt_futebol/macros/futebol_lado.sql
+++ b/dbt_futebol/macros/futebol_lado.sql
@@ -30,14 +30,21 @@
   entrava na enumeração pelo mesmo motivo que o `Draw` do 1X2 — nenhuma premissa disparava,
   `is_favorito`/`is_azarao` eram as duas FALSE em handicap zero, e o seed carrega o lado
   com p95 zero explícito. O achado da B3: ao contrário do empate (que é estrutural — não
-  existe "favorito no empate"), a linha 0 do Handicap TEM lado — ninguém dá pontos por
-  PREÇO, mas o mando ainda diz quem é favorito. Sem essa distinção a linha nunca podia
-  publicar (nota sempre zero) nem contribuir a nada. O mando desempata: `outcome='Home'`
-  vira Favorito, `'Away'` vira Azarao — mesma regra em `int_futebol_premissas_ah`, porque
-  os dois têm de concordar sobre qual lado é qual (é a chave do join com o p95). O `Pick`
-  segue no seed (histórico, p95 zero) mas nenhum candidato vivo volta a produzi-lo — é
-  dormente, não removido, mesmo padrão de valor legado que este projeto já usa em
-  `motivo_primario`.
+  existe "favorito no empate"), a linha 0 do Handicap TEM lado. O `Pick` segue no seed
+  (histórico, p95 zero) mas nenhum candidato vivo volta a produzi-lo — é dormente, não
+  removido, mesmo padrão de valor legado que este projeto já usa em `motivo_primario`.
+
+  ⚠️ QUEM DECIDE O LADO NA LINHA 0 É A ODD, NÃO O MANDO — decisão do Victor na B3
+  (comentário de 25/08/2026, ClickUp `wdx6zev656`): "vamos pela menor odd, com desempate
+  pelo mando quando as odds forem iguais". A primeira entrega (#138, 01/09) implementou só
+  mando — corrigido aqui. O `outcome_e_favorito_por_odd_col` é um BOOLEAN já resolvido pelo
+  CHAMADOR (TRUE quando este `outcome_col` tem a menor odd pra esse fixture+linha, com
+  empate desempatado pelo mando) — o macro não tem acesso a odd sozinho, porque ela não
+  está nos três argumentos de sempre. `NULL`/omitido cai no mando puro: é a degradação
+  graciosa de quando não há odd pra essa linha (mesmo padrão do resto do projeto — dado
+  ausente nunca propaga NULL pro veredito, decide pelo fallback mais simples). MESMA regra
+  em `int_futebol_premissas_ah` (`is_favorito`/`is_azarao`), porque os dois têm de
+  concordar sobre qual lado é qual (é a chave do join com o p95).
 
   ⚠️ FAIL-CLOSED, igual ao `futebol_market_slug`: saída fora do catálogo resolve para NULL
   — a "12" da Dupla Chance, e qualquer `outcome` que o de-vig emita e o Motor não pontue.
@@ -46,10 +53,10 @@
   e já está carimbada na `porta_saida_catalogada`. Um lado inventado por acidente casaria
   com nenhuma linha do seed, e o modelo o trataria como denominador ausente.
 
-  Os três argumentos são expressões já qualificadas pelo chamador (ex.: `f.market`), porque
-  os consumidores juntam as tabelas com aliases diferentes.
+  Os argumentos são expressões já qualificadas pelo chamador (ex.: `f.market`), porque os
+  consumidores juntam as tabelas com aliases diferentes.
 -#}
-{% macro futebol_lado(market_col, outcome_col, line_col) -%}
+{% macro futebol_lado(market_col, outcome_col, line_col, outcome_e_favorito_por_odd_col=none) -%}
     CASE {{ market_col }}
         WHEN '{{ futebol_mercados_pontuados()[1] }}' THEN
             IF({{ outcome_col }} IN ('Home', 'Draw', 'Away'), {{ outcome_col }}, NULL)
@@ -65,12 +72,19 @@
                 -- o handicap na ótica do lado apostado; `line_value` vem na do mandante.
                 WHEN IF({{ outcome_col }} = 'Home', {{ line_col }}, -{{ line_col }}) < 0 THEN 'Favorito'
                 WHEN IF({{ outcome_col }} = 'Home', {{ line_col }}, -{{ line_col }}) > 0 THEN 'Azarao'
-                -- linha 0 (B3, #109): ninguém dá/recebe por PREÇO, mas o mando desempata —
-                -- Home é o favorito estrutural (vantagem de campo). MESMA regra em
-                -- `int_futebol_premissas_ah` (is_favorito/is_azarao); os dois têm de
-                -- concordar, porque é esta coluna que casa a linha com o p95 do lado.
+                -- linha 0 (B3, #109): a odd decide quem é favorito, mando só desempata
+                -- odds iguais (ou ausentes). MESMA regra em `int_futebol_premissas_ah`
+                -- (is_favorito/is_azarao); os dois têm de concordar, porque é esta coluna
+                -- que casa a linha com o p95 do lado.
                 WHEN IF({{ outcome_col }} = 'Home', {{ line_col }}, -{{ line_col }}) = 0
-                    THEN IF({{ outcome_col }} = 'Home', 'Favorito', 'Azarao')
+                    THEN IF(
+                        {% if outcome_e_favorito_por_odd_col is not none -%}
+                        COALESCE({{ outcome_e_favorito_por_odd_col }}, {{ outcome_col }} = 'Home')
+                        {%- else -%}
+                        {{ outcome_col }} = 'Home'
+                        {%- endif %},
+                        'Favorito', 'Azarao'
+                    )
                 -- handicap ausente: não dá para dizer o lado, e inventá-lo é pior.
                 ELSE NULL
             END

--- a/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
+++ b/dbt_futebol/models/intermediate/int_futebol_premissas_ah.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='table',
-    description='S3 do Motor de Score — premissas de contexto do mercado HANDICAP ASIATICO (market_id 4). ⚠️ B3 (#109, 2026-09-01): a linha 0 (side_handicap=0) deixou de ser "pick sem lado" — o mando desempata (Home=favorito, Away=azarão), mesma regra de `futebol_lado()`, para as premissas do lado certo acenderem. ⚠️ Task 0 (look-ahead): supremacia/tende_golear/adversario_fragil_fora/mando_forte/sem_rodizio/defesa_fora_solida leem int_futebol_team_form_pit (point-in-time por fixture) — o lado FAVORITO era 100% contaminado. raramente_perde_por_2 e favorito_irregular já eram limpos (margin_stats com kickoff_utc <) e não mudaram. 2 linhas por (fixture, line_value): outcome_side Home e Away. Convenção dos dados (API-Football, confirmada 2026-06-24): line_value é o handicap na ÓTICA DO MANDANTE e é o MESMO p/ os dois lados — "Home -1.5" e "Away -1.5" são o PAR complementar (de-vig soma ~1.03, pin_n_outcomes=2). Logo o handicap NA ÓTICA DO LADO = IF(side=Home, line_value, -line_value): side_handicap<0 => FAVORITO (dá handicap), >0 => AZARÃO (recebe), =0 => o mando decide (B3). Favorito: 5 premissas (Σ40, §12.3); Azarão: 3 (Σ30). Penalidade específica: handicap_alto (-12, |line_value|>=2.5). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. Gate/edge/Score saem no mart fact_value_opportunities (gate de completude Pinnacle = par >=2, igual O/U).
+    description='S3 do Motor de Score — premissas de contexto do mercado HANDICAP ASIATICO (market_id 4). ⚠️ B3 (#109, 2026-09-01, corrigido 02/09): a linha 0 (side_handicap=0) deixou de ser "pick sem lado" — a ODD decide quem é favorito (menor odd), o mando só desempata odds iguais ou ausentes, mesma regra de `futebol_lado()`, para as premissas do lado certo acenderem. ⚠️ Task 0 (look-ahead): supremacia/tende_golear/adversario_fragil_fora/mando_forte/sem_rodizio/defesa_fora_solida leem int_futebol_team_form_pit (point-in-time por fixture) — o lado FAVORITO era 100% contaminado. raramente_perde_por_2 e favorito_irregular já eram limpos (margin_stats com kickoff_utc <) e não mudaram. 2 linhas por (fixture, line_value): outcome_side Home e Away. Convenção dos dados (API-Football, confirmada 2026-06-24): line_value é o handicap na ÓTICA DO MANDANTE e é o MESMO p/ os dois lados — "Home -1.5" e "Away -1.5" são o PAR complementar (de-vig soma ~1.03, pin_n_outcomes=2). Logo o handicap NA ÓTICA DO LADO = IF(side=Home, line_value, -line_value): side_handicap<0 => FAVORITO (dá handicap), >0 => AZARÃO (recebe), =0 => a odd decide, mando desempata (B3). Favorito: 5 premissas (Σ40, §12.3); Azarão: 3 (Σ30). Penalidade específica: handicap_alto (-12, |line_value|>=2.5). Degradação graciosa: dado ausente -> premissa FALSE. evidencias[]/avisos[] = bullets pro front. Gate/edge/Score saem no mart fact_value_opportunities (gate de completude Pinnacle = par >=2, igual O/U).
     ⚠️ Reconciliação §12.3: o bloco "Azarão" do playbook mistura rótulos S/O (ex.: "favorito_irregular | S venceu por 2+..."); aqui as premissas seguem o NOME/INTENÇÃO: raramente_perde_por_2 e defesa_fora_solida medem o AZARÃO (S); favorito_irregular mede o FAVORITO (O). Ao calibrar, alinhar o .md a esta leitura. ⚠️ MEDIÇÃO (task [F], ADR 0007): o margin_stats aceita as DUAS vars da medição — pit_escopo (da_competicao|todas) e pit_recorte (temporada|ultimos_10). ⚠️ Desde a #91 (ADR 0010) os DEFAULTS são `todas` + `ultimos_10` — a célula `ambos` — e NÃO reproduzem mais o comportamento descrito acima; ele descreve o ramo `da_competicao`/`temporada`, hoje alcançável só passando as vars. Produção USA o default, que é a célula `ambos` da [F]; as vars seguem existindo para as OUTRAS células da medição, materializadas no dataset futebol_taskF. supremacia e sem_rodizio NÃO seguem o eixo (rank/ppg/n_teams vêm do team_form_pit, que os mantém competição-scoped em todas as células, ADR 0008). ⚠️ O margin_stats não tem filtro de season nem no default — ele já atravessa temporada hoje —, então sob `todas` ele passa a contar todas as competições E todo o tempo coletado. Contador de cegueira (#41, ADR 0003): premissas_cegas[] e premissas_sem_dado dizem quais premissas APLICÁVEIS a cada linha não puderam ser avaliadas por falta de insumo — geradas do mapa futebol_insumos_premissa(), nunca escritas à mão. O score NÃO muda: a premissa cega já não acendia e continua não acendendo; o que muda é o board passar a dizer o que não levou em conta. A aplicabilidade aqui é o LADO (is_favorito/is_azarao) — sem ela toda linha contaria 3 ou 5 cegas por desenho. A lista de ligas de pontos corridos do sem_rodizio saiu para futebol_ligas_pontos_corridos(), lida também pelo mapa.'
 ) }}
 {#- EIXOS DE ESCOPO E RECORTE DA MEDIÇÃO DA TASK [F] (issue #49, ADR 0007) — desde a #91 o DEFAULT destas vars é o que produção usa.
@@ -162,18 +162,39 @@ margin_stats AS (
 ),
 {%- endif %}
 
+-- A odd da linha 0 (B3, #109/decisão do Victor 25/08): quem tem a MENOR odd é o
+-- favorito; empate (ou odd ausente) desempata pelo mando. `QUALIFY` já reduz a 1 linha
+-- por fixture — no máximo Home e Away entram aqui (market_id=4, line_value=0), a janela
+-- corrente resolve as duas juntas (mesma janela pros dois lados, ver
+-- `futebol_devig_janela_corrente()`), e a ORDER BY escolhe a de menor odd, com o mando
+-- como critério de desempate.
+odds_linha_zero AS (
+    SELECT
+        fixture_id,
+        outcome_side = 'Home' AS home_e_favorito_por_odd
+    FROM ({{ futebol_devig_janela_corrente() }})
+    WHERE market_id = 4 AND line_value = 0
+    QUALIFY ROW_NUMBER() OVER (
+        PARTITION BY fixture_id
+        ORDER BY best_odd ASC, IF(outcome_side = 'Home', 0, 1) ASC
+    ) = 1
+),
+
 -- Métricas brutas por outcome×linha.
 metrics AS (
     SELECT
         o.fixture_id, o.competition, o.season, o.outcome, o.line_value,
         o.s_is_home, o.side_handicap,
-        -- ⚠️ B3 (#109, 2026-09-01): linha 0 (side_handicap=0) não fica mais sem lado. O
-        -- mando desempata — MESMA regra que `macros/futebol_lado.sql` usa, e os dois têm
-        -- de concordar (é o que casa esta linha com o p95 do lado no funil). Antes desta
-        -- entrega as duas eram FALSE em handicap zero: nenhuma premissa disparava, a
-        -- linha nunca tinha nota, e não tinha lado para casar com denominador nenhum.
-        (o.side_handicap < 0 OR (o.side_handicap = 0 AND o.s_is_home))     AS is_favorito,
-        (o.side_handicap > 0 OR (o.side_handicap = 0 AND NOT o.s_is_home)) AS is_azarao,
+        -- ⚠️ B3 (#109, 2026-09-01): linha 0 (side_handicap=0) não fica mais sem lado. A ODD
+        -- decide quem é favorito (decisão do Victor, 25/08) — MESMA regra que
+        -- `macros/futebol_lado.sql` usa, e os dois têm de concordar (é o que casa esta
+        -- linha com o p95 do lado no funil). Sem odd pra essa linha, cai no mando —
+        -- degradação graciosa, nunca NULL. Antes desta entrega as duas eram FALSE em
+        -- handicap zero: nenhuma premissa disparava, a linha nunca tinha nota.
+        (o.side_handicap < 0
+            OR (o.side_handicap = 0 AND COALESCE(olz.home_e_favorito_por_odd, o.s_is_home)))     AS is_favorito,
+        (o.side_handicap > 0
+            OR (o.side_handicap = 0 AND NOT COALESCE(olz.home_e_favorito_por_odd, o.s_is_home))) AS is_azarao,
 
         -- ataque/defesa de S no campo deste jogo (tende_golear, defesa_fora_solida)
         IF(o.s_is_home, s.goals_for_avg_home,     s.goals_for_avg_away)     AS s_gf_venue,
@@ -199,6 +220,7 @@ metrics AS (
     LEFT JOIN pit od  ON od.fixture_id = o.fixture_id AND od.team_id = o.o_team_id
     LEFT JOIN margin_stats sm ON sm.fixture_id = o.fixture_id AND sm.team_id = o.s_team_id
     LEFT JOIN margin_stats om ON om.fixture_id = o.fixture_id AND om.team_id = o.o_team_id
+    LEFT JOIN odds_linha_zero olz ON olz.fixture_id = o.fixture_id
 ),
 
 -- Premissas (booleanos). Gated por favorito/azarão -> só o lado certo dispara; soma <=40 (fav) ou <=30 (dog).

--- a/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
+++ b/dbt_futebol/models/marts/_fact_value_funnel__unit_tests.yml
@@ -749,3 +749,59 @@ unit_tests:
         - {fixture_id: 8,  lado: ,           nota_contexto: ,   score_normalizado: }
         - {fixture_id: 9,  lado: 'Favorito', nota_contexto: 20, score_normalizado: 50}
         - {fixture_id: 10, lado: 'Azarao',   nota_contexto: 20, score_normalizado: 100}
+
+  - name: funil_linha_zero_do_handicap_decide_pela_odd
+    model: fact_value_funnel
+    overrides:
+      macros:
+        is_incremental: false
+    description: >
+      B3 (#109, corrigido 02/09): na linha 0 do Handicap quem decide o favorito é a
+      MENOR odd, o mando só desempata. Fixture 11 prova o caso que a primeira entrega
+      (mando puro) errava: o Away tem a odd menor, então é ELE o favorito, mesmo sendo
+      visitante. Fixture 12 prova que o mando ainda desempata quando as odds EMPATAM.
+    given:
+      - input: ref('int_futebol_odds_devig')
+        rows:
+          # -- 11: odd DISCORDA do mando. Away (1.75, menor) é favorito; Home (2.20,
+          # maior) é azarão — o oposto do que "mando puro" (Home=Favorito) diria.
+          - {fixture_id: 11, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Home', line_value: 0.0, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 2.20, best_book: 'Bet365', avg_odd: 2.10, n_casas: 5, prob_justa_fechamento: 0.45, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 11, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Away', line_value: 0.0, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 1.75, best_book: 'Bet365', avg_odd: 1.70, n_casas: 5, prob_justa_fechamento: 0.55, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          # -- 12: odds EMPATADAS. Sem preferência de mercado, o mando desempata: Home
+          # vira Favorito.
+          - {fixture_id: 12, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Home', line_value: 0.0, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 1.90, best_book: 'Bet365', avg_odd: 1.88, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+          - {fixture_id: 12, competition: 'brasileirao', season: 2026, market_id: 4, outcome_side: 'Away', line_value: 0.0, janela_usada: 't15m', edge: 0.10, pts_valor: 0, best_odd: 1.90, best_book: 'Bet365', avg_odd: 1.88, n_casas: 5, prob_justa_fechamento: 0.50, pin_n_outcomes: 2, n_outcomes_valor: 2, valor_fonte: 'pinnacle', penalidades_globais_pts: 0, pen_odd_outlier: false, pen_poucas_casas: false, pen_odd_longshot: false, pen_odd_juice: false}
+
+      - input: ref('int_futebol_premissas_1x2')
+        rows: []
+      - input: ref('int_futebol_premissas_ou')
+        rows: []
+      - input: ref('int_futebol_premissas_dc')
+        rows: []
+      - input: ref('int_futebol_premissas_btts')
+        rows: []
+      - input: ref('int_futebol_corroboracao')
+        rows: []
+
+      - input: ref('int_futebol_premissas_ah')
+        format: sql
+        rows: |
+          SELECT 11 AS fixture_id, 'Home' AS outcome, 0.0 AS line_value,
+                 10 AS pts_premissas, 0 AS premissas_sem_dado, 0 AS penalidades_ah_pts
+          UNION ALL SELECT 11, 'Away', 0.0, 10, 0, 0
+          UNION ALL SELECT 12, 'Home', 0.0, 10, 0, 0
+          UNION ALL SELECT 12, 'Away', 0.0, 10, 0, 0
+
+      - input: ref('futebol_p95_nota_contexto')
+        format: csv
+        fixture: p95_nota_contexto_sintetico
+
+      - input: ref('fact_fixtures')
+        rows: []
+
+    expect:
+      rows:
+        - {fixture_id: 11, outcome: 'Home', lado: 'Azarao',   nota_contexto: 10, score_normalizado: 50}
+        - {fixture_id: 11, outcome: 'Away', lado: 'Favorito', nota_contexto: 10, score_normalizado: 25}
+        - {fixture_id: 12, outcome: 'Home', lado: 'Favorito', nota_contexto: 10, score_normalizado: 25}
+        - {fixture_id: 12, outcome: 'Away', lado: 'Azarao',   nota_contexto: 10, score_normalizado: 50}

--- a/dbt_futebol/models/marts/fact_value_funnel.sql
+++ b/dbt_futebol/models/marts/fact_value_funnel.sql
@@ -447,10 +447,18 @@ unioned AS (
 -- handicap na ótica do lado apostado, e os conjuntos de premissa de favorito e azarão são
 -- disjuntos (Σ40 contra Σ30).
 -- ============================================================================
+-- PARTITION BY não aceita FLOAT64 (line_value): CAST p/ STRING, mesma conversão que
+-- `futebol_devig_todas_janelas()._line_key` usa pro mesmo motivo.
 com_lado AS (
     SELECT
         u.*,
-        {{ futebol_lado('u.market', 'u.outcome', 'u.line_value') }} AS lado
+        {{ futebol_lado(
+            'u.market', 'u.outcome', 'u.line_value',
+            "(ROW_NUMBER() OVER ("
+            "  PARTITION BY u.fixture_id, u.market, COALESCE(CAST(u.line_value AS STRING), 'NONE'), u.janela_usada"
+            "  ORDER BY u.best_odd ASC, IF(u.outcome = 'Home', 0, 1) ASC"
+            ") = 1)"
+        ) }} AS lado
     FROM unioned u
 ),
 


### PR DESCRIPTION
## Resumo

O PR #138 implementou "mando desempata" pra linha 0 do Handicap (`side_handicap = 0`), mas essa não foi a decisão aprovada. O Victor aprovou explicitamente, na B3 (ClickUp `wdx6zev656`, comentário de 25/08):

> "vamos pela menor odd, com desempate pelo mando quando as odds forem iguais [...] estou ciente de que o preço passa a decidir a classificação do lado, mas aceito essa exceção"

Esta PR corrige as duas implementações que têm de concordar (per o próprio #138): `macros/futebol_lado.sql` e `models/intermediate/int_futebol_premissas_ah.sql`.

## O que muda

- **`macros/futebol_lado.sql`**: novo parâmetro opcional `outcome_e_favorito_por_odd_col` — um BOOLEAN já resolvido pelo chamador (TRUE quando o outcome desta linha tem a menor odd). `NULL`/omitido cai no mando puro (fallback de degradação graciosa, nunca propaga NULL pro veredito).
- **`models/marts/fact_value_funnel.sql`** (único call site em produção): calcula o desempate por odd via `ROW_NUMBER() OVER (PARTITION BY fixture_id, market, line_value, janela_usada ORDER BY best_odd ASC, mando ASC)` e passa pro macro. (`taskA_a4_fronteiras.sql`, a outra chamadora, é análise congelada — Handicap 0 nunca entra na população dela por causa da porta de linha meia, então não precisou mudar; o default `none` cobre.)
- **`models/intermediate/int_futebol_premissas_ah.sql`**: nova CTE `odds_linha_zero`, que lê `int_futebol_odds_devig` (via `futebol_devig_janela_corrente()`) pra market_id=4/line_value=0 e resolve o mesmo critério. `is_favorito`/`is_azarao` passam a usar essa resolução em vez de `s_is_home` puro.

## Por que isso é uma mudança de dependência, registrada

`int_futebol_premissas_ah` não tinha dependência de odds até agora — é um modelo de "contexto", deliberadamente separado de preço (é literalmente o que a task [A] inteira faz: tirar preço da nota). Essa é a exceção que o Victor aprovou por escrito, e só vale pra linha 0 do Handicap.

## Validação

- `dbt parse` limpo.
- Unit tests do funil e do mart de oportunidades: 11/11 PASS (10 existentes + 1 novo).
- **Novo unit test** `funil_linha_zero_do_handicap_decide_pela_odd`: confirmado **vermelho** com a chamada de macro revertida pra 3 argumentos (mando puro) — pega exatamente o padrão do defeito — e **verde** com a correção.
- `int_futebol_premissas_ah` não tem convenção de unit test direto (só os marts mockam `int_` como input, e por isso o teste acima não cobre essa metade). Validei com `bq query --dry_run` (sintaxe/schema OK) e depois execução real contra produção — só leitura, nada escrito — encontrando jogos reais onde o mando puro erraria: ex. fixture 1489381, visitante com melhor odd (1,14), que "mando decide" rotulava Azarão.

## O que NÃO mudei

Não toquei em `taskA_a4_fronteiras.sql` (a análise da #107/#133) porque handicap 0 nunca entra na população medida ali (falha `futebol_e_linha_meia` independente de lado) — já confirmei isso na validação da PR #139. Não há resultado publicado que essa mudança altere retroativamente.

Refs #109 (B3), ClickUp `wdx6zev656`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JypLEgi74wXE38suiaSXWg