### PR TITLE
fix(futebol): stg_futebol_fixtures não é 1 linha por fixture, é 1 por extração

### DIFF
--- a/dbt_futebol/models/marts/fact_fixtures.sql
+++ b/dbt_futebol/models/marts/fact_fixtures.sql
@@ -67,8 +67,10 @@ SELECT
     loaded_at           AS extracted_at,
     CURRENT_TIMESTAMP() AS dbt_loaded_at
 FROM {{ ref('stg_futebol_fixtures') }}
--- Defensivo: fixture_id já é único (backfill/current não sobrepõem liga-temporada).
--- Mantém o idioma de dedup de dim_players/dim_teams.
+-- NÃO é defensivo: fixture_id NÃO é único em stg_futebol_fixtures (o extractor
+-- re-busca jogo recente e a mesma fixture entra de novo com loaded_at maior — corrigido
+-- na description do modelo em 02/09/2026). Este QUALIFY é o dedup de verdade, latest-wins
+-- por loaded_at. Mantém o idioma de dedup de dim_players/dim_teams.
 QUALIFY ROW_NUMBER() OVER (
     PARTITION BY fixture_id
     ORDER BY loaded_at DESC

--- a/dbt_futebol/models/staging/models.yml
+++ b/dbt_futebol/models/staging/models.yml
@@ -334,13 +334,23 @@ models:
         description: "Timestamp ISO UTC do extractor"
 
   - name: stg_futebol_fixtures
-    description: "Flatten do raw_futebol_fixtures (espinha /fixtures). 1 linha por fixture (jogo). fact_fixtures deriva competition/date_utc (de timestamp_unix) e dedup por fixture_id. ⚠️ date_iso (ISO com offset) e league_season foram removidos por serem passthrough mortos (0 consumidores) — para data use timestamp_unix; para season use requested_season."
+    description: "Flatten do raw_futebol_fixtures (espinha /fixtures). ⚠️ NÃO é 1 linha por fixture — é 1 linha por EXTRAÇÃO: raw_futebol_fixtures é append-only e o extractor re-busca jogo recente pra pegar status/placar atualizado, então o mesmo fixture_id aparece de novo com loaded_at maior. fact_fixtures deriva competition/date_utc (de timestamp_unix) e faz o dedup de verdade (latest-wins por loaded_at) — é lá que mora o teste de unicidade por fixture_id. ⚠️ date_iso (ISO com offset) e league_season foram removidos por serem passthrough mortos (0 consumidores) — para data use timestamp_unix; para season use requested_season."
+    tests:
+      # A unicidade de VERDADE (1 linha por fixture) é testada em fact_fixtures, que já
+      # dedupa por loaded_at. Aqui a invariante mais fina que vale é "a mesma extração não
+      # se repete" — teve `unique` isolado em fixture_id até 02/09/2026, e vivia vermelho:
+      # 11 fixtures re-extraídos (dado idêntico, loaded_at diferente) reprovavam um teste
+      # que testava uma garantia que este modelo nunca teve.
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - fixture_id
+              - loaded_at
     columns:
       - name: fixture_id
-        description: "ID do jogo na API-Football (PK; 1 linha por fixture)"
+        description: "ID do jogo na API-Football (FK p/ fact_fixtures; PODE repetir aqui — cada extração é uma linha nova, ver description do modelo)"
         tests:
           - not_null
-          - unique
       - name: requested_league_id
         description: "ID da liga requisitada (parâmetro `league` da chamada /fixtures)"
         tests:

--- a/dbt_futebol/models/staging/stg_futebol_fixtures.sql
+++ b/dbt_futebol/models/staging/stg_futebol_fixtures.sql
@@ -1,5 +1,5 @@
 {{ config(
-    description='Flatten do raw_futebol_fixtures. 1 linha por fixture (jogo). Apenas a espinha (/fixtures): fixture, league, teams, goals, score. Stats/events/lineups vêm de endpoints separados (subtasks 5-8). fact_fixtures deriva competition/date_utc e dedup por fixture_id.'
+    description='Flatten do raw_futebol_fixtures. NÃO é 1 linha por fixture — é 1 linha por EXTRAÇÃO: raw_futebol_fixtures é append-only e o extractor re-busca jogo recente pra pegar status/placar atualizado, então o mesmo fixture_id repete com loaded_at maior (ver models.yml, corrigido 02/09/2026). Apenas a espinha (/fixtures): fixture, league, teams, goals, score. Stats/events/lineups vêm de endpoints separados (subtasks 5-8). fact_fixtures deriva competition/date_utc e faz o dedup de verdade (latest-wins por loaded_at).'
 ) }}
 
 WITH src AS (


### PR DESCRIPTION
## Resumo

O job `dbt-futebol` falhou hoje (execução `dbt-futebol-jb9sq`, 12:19-12:24 UTC) num teste `unique_stg_futebol_fixtures_fixture_id` com 11 resultados. Investiguei: não é bug de dado, é teste testando a invariante errada.

## Causa

`stg_futebol_fixtures` é `SELECT * FROM raw_futebol_fixtures`, sem dedup. `raw_futebol_fixtures` é append-only e o extractor re-busca jogo recente pra pegar status/placar atualizado — então o mesmo `fixture_id` aparece de novo com `loaded_at` maior. Conferi 3 das 11 duplicatas: dado idêntico, só `loaded_at` diferente (ex. fixture 1550098: extraído em 31/08 20:45 e de novo em 02/09 12:06, mesmo status FT, mesmo placar).

`fact_fixtures` já faz o dedup de verdade (`QUALIFY ROW_NUMBER() OVER (... ORDER BY loaded_at DESC)`) e já tem seu próprio teste `unique` em `fixture_id` — no lugar certo. O `unique` isolado em staging testava uma garantia que o modelo nunca teve.

## O que mudei

- `models/staging/models.yml`: troca o `unique` isolado por `dbt_utils.unique_combination_of_columns([fixture_id, loaded_at])` — mesmo padrão que `stg_futebol_injuries_queried` (mesmo arquivo) já usa pro mesmo motivo. Corrige a description do modelo, que dizia "1 linha por fixture" (falso).
- `models/staging/stg_futebol_fixtures.sql`: corrige a description no `config()`, que tinha a mesma afirmação falsa.
- `models/marts/fact_fixtures.sql`: corrige o comentário do `QUALIFY` — dizia "defensivo: fixture_id já é único", exatamente o oposto do que sabemos agora. Achado pelo `/code-review`: esse comentário, do jeito que estava, é risco real — alguém lendo "já é único" podia tirar o `QUALIFY` como código morto num refactor futuro, e aí a duplicata reentra em silêncio no `fact_fixtures`.

## Validação

- `dbt parse` limpo
- `dbt test --select stg_futebol_fixtures fact_fixtures`: 27/29 PASS, 2 WARN pré-existentes e não relacionados (`assert_per_fixture_coverage`, relationship de `fact_injuries_snapshot`)
- `/code-review` rodado no diff; os dois achados dele (comentários desatualizados) foram corrigidos antes deste commit

## O que NÃO mudei

Não toquei em `fact_fixtures.sql` além do comentário — o dedup por `loaded_at` já está correto e continua sendo a fonte de verdade da unicidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JypLEgi74wXE38suiaSXWg